### PR TITLE
Position-independent code required to compile with Qt5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,8 +26,9 @@ find_package(PAM REQUIRED)
 # X11
 find_package(X11 REQUIRED)
 
-if (USE_QT5)
+if(USE_QT5)
   find_package(Qt5Core REQUIRED)
+  add_definitions(-fPIE)
 
   add_executable(sddm ${SOURCES})
   target_link_libraries(sddm ${PAM_LIBRARIES} ${X11_X11_LIB})


### PR DESCRIPTION
Qt 5.0.1 precompiled by QtProject requires position-independent code to be switched on, i.e. -fPIC or -fPIE to be used when compiling.
