### PR TITLE
Fix for QT_IMPORTS_DIR in Debian

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,12 @@ if(USE_QT5)
 else()
   find_package(Qt4 REQUIRED)
 
+  # find qt4 imports dir, required if no QML plugins are already installed
+  # for example, see: https://bugs.launchpad.net/ubuntu/+source/cmake/+bug/894805
+  # and many other bug reports
+  _qt4_query_qmake(QT_INSTALL_IMPORTS QT_IMPORTS_DIR)
+  set(QT_IMPORTS_DIR "${QT_IMPORTS_DIR}")
+
   set(COMPONENTS_VERSION 1.1)
 endif()
 


### PR DESCRIPTION
Fix finding QT_IMPORTS_DIR on Debian, if no libqt4-declarative\* package is already installed.
