### PR TITLE
Qt 5.{1,2} flickering fix (updated)

### DIFF
--- a/src/greeter/GreeterApp.cpp
+++ b/src/greeter/GreeterApp.cpp
@@ -184,6 +184,7 @@ int main(int argc, char **argv) {
 #ifdef USE_QT5
     // install message handler
     qInstallMessageHandler(SDDM::MessageHandler);
+    setenv("QSG_RENDER_LOOP", "windows", 1);
 #endif
     QStringList arguments;
 


### PR DESCRIPTION
Since issue is not fixed in Qt 5.2, I am reopening this.
This fix sets environment variable for Qt renderer [Qt bugtracker](https://bugreports.qt-project.org/browse/QTBUG-32415?focusedCommentId=221915&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-226044)

~~This patch is temporary solution for Qt5.1 compatibility issues. It makes SDDM at least usable wit Qt5.1.~~
~~\- Flickering: for some reason it resolves when screen size isn't equal to window size;~~
~~\- No pointer/X pointer: seems like Qt5.1 doesn't set root window cursor anymore (not sure if its is bug or not).~~
~~So there are 2 ugly workarounds, however one can be improved, if we will properly change root cursor via xcb.~~
