### PR TITLE
Translate into Finnish

### DIFF
--- a/data/translations/CMakeLists.txt
+++ b/data/translations/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(TRANSLATION_FILES
     cs.ts
+    fi.ts
     it.ts
     ru.ts
     tr.ts

--- a/data/translations/fi.ts
+++ b/data/translations/fi.ts
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.0" language="fi">
+<context>
+    <name>TextConstants</name>
+    <message>
+        <source>Welcome to %1</source>
+        <translation>Tervetuloa koneeseen %1</translation>
+    </message>
+    <message>
+        <source>Warning, Caps Lock is ON!</source>
+        <translation>Varoitus: Caps Lock on PÄÄLLÄ!</translation>
+    </message>
+    <message>
+        <source>Layout</source>
+        <translation>Asettelu</translation>
+    </message>
+    <message>
+        <source>Login</source>
+        <translation>Kirjaudu</translation>
+    </message>
+    <message>
+        <source>Login failed</source>
+        <translation>Kirjautuminen epäonnistui</translation>
+    </message>
+    <message>
+        <source>Login succeeded</source>
+        <translation>Kirjautuminen onnistui</translation>
+    </message>
+    <message>
+        <source>Password</source>
+        <translation>Salasana</translation>
+    </message>
+    <message>
+        <source>Enter your username and password</source>
+        <translation>Kirjoita käyttäjätunnuksesi ja salasanasi</translation>
+    </message>
+    <message>
+        <source>Reboot</source>
+        <translation>Käynnistä uudelleen</translation>
+    </message>
+    <message>
+        <source>Session</source>
+        <translation>Istunto</translation>
+    </message>
+    <message>
+        <source>Shutdown</source>
+        <translation>Sammuta</translation>
+    </message>
+    <message>
+        <source>User name</source>
+        <translation>Käyttäjätunnus</translation>
+    </message>
+    <message>
+        <source>Select your user and enter password</source>
+        <translation>Valitse käyttäjä ja kirjoita salasana</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
Tested the translation and it looked a bit bad on the circles and maldives themes because "Käynnistä uudelleen" (translation for reboot) makes the two adjacent buttons (login and shutdown) too wide. Otherwise it looked good. I could have used an abbreviation ("Käynnistä uud." or similar) there, but it wouldn't have looked good either and isn't typically used if possible.
