### PR TITLE
Fix memory leak after getting environment from PAM

### DIFF
--- a/src/daemon/Authenticator.cpp
+++ b/src/daemon/Authenticator.cpp
@@ -322,7 +322,10 @@ namespace SDDM {
             // add to the hash
             if (index != -1)
                 env.insert(s.left(index), s.mid(index + 1));
+
+            free(envlist[i]);
         }
+        free(envlist);
 #else
         // we strdup'd the string before in this branch
         free(mapped);


### PR DESCRIPTION
```
   The format of the memory is a malloc()´d array of char pointers, the last element of
   which is set to NULL. Each of the non-NULL entries in this array point to a NUL
   terminated and malloc()´d char string of the form: "name=value".
```
