### PR TITLE
Make test mode parameter consistent and pass it to the greeter

### DIFF
--- a/src/daemon/Greeter.cpp
+++ b/src/daemon/Greeter.cpp
@@ -72,7 +72,12 @@ namespace SDDM {
         m_process->setProcessEnvironment(env);
 
         // start greeter
-        m_process->start(QString("%1/sddm-greeter").arg(BIN_INSTALL_DIR), { "--socket", m_socket, "--theme", m_theme });
+        QStringList args;
+        if (daemonApp->configuration()->testing)
+            args << "--test-mode";
+        args << "--socket" << m_socket
+             << "--theme" << m_theme;
+        m_process->start(QString("%1/sddm-greeter").arg(BIN_INSTALL_DIR), args);
 
         // wait for greeter to start
         if (!m_process->waitForStarted()) {

--- a/src/greeter/GreeterApp.cpp
+++ b/src/greeter/GreeterApp.cpp
@@ -76,7 +76,7 @@ namespace SDDM {
         // Parse arguments
         bool testing = false;
 
-        if (arguments().contains("--test"))
+        if (arguments().contains("--test-mode"))
             testing = true;
 
         // get socket name
@@ -195,7 +195,7 @@ int main(int argc, char **argv) {
                      "Options: \n"
                      "  --theme <theme path>       Set greeter theme\n"
                      "  --socket <socket name>     Set socket name\n"
-                     "  --test                     Testing mode" << std::endl;
+                     "  --test-mode                Start greeter in test mode" << std::endl;
 
         return EXIT_FAILURE;
     }


### PR DESCRIPTION
Greeter now recognize --test-mode instead of --test for consistency,
also daemon pass this argument to the greeter if in test mode.
