### PR TITLE
Support logging to journald if enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake;${CMAKE_MODULE_PATH}")
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 
+option(ENABLE_JOURNALD "Enable logging to journald" ON)
+
 add_definitions(-Wall -march=native -std=c++11)
 
 if(NOT CMAKE_BUILD_TYPE)
@@ -76,6 +78,17 @@ add_custom_target(uninstall COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_D
 pkg_check_modules(SYSTEMD "systemd")
 
 if(SYSTEMD_FOUND)
+    pkg_check_modules(JOURNALD "libsystemd-journal")
+
+    if(ENABLE_JOURNALD)
+        if(JOURNALD_FOUND)
+            add_definitions(-DHAVE_JOURNALD)
+            set(CMAKE_AUTOMOC_MOC_OPTIONS -DHAVE_JOURNALD)
+        else()
+            message(WARNING "Disable journald support for lack of libsystemd-journal")
+        endif()
+    endif()
+
     execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE} --variable=systemdsystemunitdir systemd OUTPUT_VARIABLE SYSTEMD_SYSTEM_UNIT_DIR)
     string(REGEX REPLACE "[ \t\n]+" \; SYSTEMD_SYSTEM_UNIT_DIR "${SYSTEMD_SYSTEM_UNIT_DIR}")
     set(HALT_COMMAND "/usr/bin/systemctl poweroff")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,6 +53,10 @@ else()
     endif()
 endif()
 
+if(JOURNALD_FOUND)
+    target_link_libraries(sddm ${JOURNALD_LIBRARIES})
+endif()
+
 install(TARGETS sddm DESTINATION ${BIN_INSTALL_DIR})
 
 ## GREETER ##
@@ -80,6 +84,10 @@ else()
 
     add_executable(sddm-greeter ${GREETER_SOURCES})
     target_link_libraries(sddm-greeter ${LIBXCB_LIBRARIES} ${LIBXKB_LIBRARIES} ${QT_LIBRARIES})
+endif()
+
+if(JOURNALD_FOUND)
+    target_link_libraries(sddm-greeter ${JOURNALD_LIBRARIES})
 endif()
 
 # Translations

--- a/src/common/MessageHandler.h
+++ b/src/common/MessageHandler.h
@@ -28,10 +28,43 @@
 
 #include <iostream>
 
-namespace SDDM {
-    void MessageHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg) {
-        Q_UNUSED(context)
+#ifdef HAVE_JOURNALD
+#include <systemd/sd-journal.h>
+#include <unistd.h>
+#endif
 
+namespace SDDM {
+#ifdef HAVE_JOURNALD
+    static void journaldLogger(QtMsgType type, const QMessageLogContext &context, const QString &msg) {
+        int priority = LOG_INFO;
+        switch (type) {
+            case QtDebugMsg:
+                priority = LOG_DEBUG;
+            break;
+            case QtWarningMsg:
+                priority = LOG_WARNING;
+            break;
+            case QtCriticalMsg:
+                priority = LOG_CRIT;
+            break;
+            case QtFatalMsg:
+                priority = LOG_ALERT;
+            break;
+        }
+
+        char fileBuffer[PATH_MAX + sizeof("CODE_FILE=")];
+        snprintf(fileBuffer, sizeof(fileBuffer), "CODE_FILE=%s", context.file ? context.file : "unknown");
+
+        char lineBuffer[32];
+        snprintf(lineBuffer, sizeof(lineBuffer), "CODE_LINE=%d", context.line);
+
+        sd_journal_print_with_location(priority, fileBuffer, lineBuffer,
+                                       context.function ? context.function : "unknown",
+                                       "%s", qPrintable(msg));
+    }
+#endif
+
+    static void standardLogger(QtMsgType type, const QString &msg) {
         static QFile file(LOG_FILE);
 
         // try to open file only if it's not already open
@@ -63,6 +96,44 @@ namespace SDDM {
             file.write(logMessage.toLocal8Bit());
         else
             std::cout << qPrintable(logMessage);
+    }
+
+    static void messageHandler(QtMsgType type, const QMessageLogContext &context, const QString &prefix, const QString &msg) {
+        // copy message to edit it
+        QString logMessage = msg;
+
+#ifdef HAVE_JOURNALD
+        // don't log to journald if running interactively, this is likely
+        // the case when running sddm in test mode
+        static bool isInteractive = isatty(STDIN_FILENO);
+        if (!isInteractive) {
+            // journald doesn't like trailing \n
+            logMessage.chop(1);
+
+            // log to journald
+            journaldLogger(type, context, logMessage);
+        } else {
+            // prepend program name
+            logMessage = prefix + msg;
+
+            // log to file or stdout
+            standardLogger(type, logMessage);
+        }
+#else
+        // prepend program name
+        logMessage = prefix + msg;
+
+        // log to file or stdout
+        standardLogger(type, logMessage);
+#endif
+    }
+
+    void DaemonMessageHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg) {
+        messageHandler(type, context, "DAEMON: ", msg);
+    }
+
+    void GreeterMessageHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg) {
+        messageHandler(type, context, "GREETER: ", msg);
     }
 }
 

--- a/src/daemon/Authenticator.cpp
+++ b/src/daemon/Authenticator.cpp
@@ -202,7 +202,7 @@ namespace SDDM {
 
         if (command.isEmpty()) {
             // log error
-            qCritical() << " DAEMON: Failed to find command for session:" << session;
+            qCritical() << "Failed to find command for session:" << session;
 
             // return fail
             return false;
@@ -262,7 +262,7 @@ namespace SDDM {
             struct passwd *pw;
             if ((pw = getpwnam(qPrintable(user))) == nullptr) {
                 // log error
-                qCritical() << " DAEMON: Failed to get user entry.";
+                qCritical() << "Failed to get user entry.";
 
                 // return fail
                 return false;
@@ -271,7 +271,7 @@ namespace SDDM {
             struct spwd *sp;
             if ((sp = getspnam(pw->pw_name)) == nullptr) {
                 // log error
-                qCritical() << " DAEMON: Failed to get shadow entry.";
+                qCritical() << "Failed to get shadow entry.";
 
                 // return fail
                 return false;
@@ -295,7 +295,7 @@ namespace SDDM {
         struct passwd *pw;
         if ((pw = getpwnam(mapped)) == nullptr) {
             // log error
-            qCritical() << " DAEMON: Failed to get user name.";
+            qCritical() << "Failed to get user name.";
 
             // return fail
             return false;
@@ -368,14 +368,14 @@ namespace SDDM {
         // wait for started
         if (!process->waitForStarted()) {
             // log error
-            qDebug() << " DAEMON: Failed to start user session.";
+            qDebug() << "Failed to start user session.";
 
             // return fail
             return false;
         }
 
         // log message
-        qDebug() << " DAEMON: User session started.";
+        qDebug() << "User session started.";
 
         // register to the display manager
         daemonApp->displayManager()->AddSession(process->name(), seat->name(), pw->pw_name);
@@ -393,7 +393,7 @@ namespace SDDM {
             return;
 
         // log message
-        qDebug() << " DAEMON: User session stopping...";
+        qDebug() << "User session stopping...";
 
         // terminate process
         process->terminate();
@@ -412,7 +412,7 @@ namespace SDDM {
         m_started = false;
 
         // log message
-        qDebug() << " DAEMON: User session ended.";
+        qDebug() << "User session ended.";
 
         // unregister from the display manager
         daemonApp->displayManager()->RemoveSession(process->name());

--- a/src/daemon/DaemonApp.cpp
+++ b/src/daemon/DaemonApp.cpp
@@ -44,11 +44,11 @@ namespace SDDM {
         self = this;
 
 #ifdef USE_QT5
-        qInstallMessageHandler(SDDM::MessageHandler);
+        qInstallMessageHandler(SDDM::DaemonMessageHandler);
 #endif
 
         // log message
-        qDebug() << " DAEMON: Initializing...";
+        qDebug() << "Initializing...";
 
         // create configuration
         m_configuration = new Configuration(CONFIG_FILE, this);
@@ -81,7 +81,7 @@ namespace SDDM {
         connect(signalHandler, SIGNAL(sigtermReceived()), this, SLOT(quit()));
 
         // log message
-        qDebug() << " DAEMON: Starting...";
+        qDebug() << "Starting...";
 
         // add a seat
         m_seatManager->createSeat("seat0");

--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -119,7 +119,7 @@ namespace SDDM {
 
     void Display::addCookie(const QString &file) {
         // log message
-        qDebug() << " DAEMON: Adding cookie to" << file;
+        qDebug() << "Adding cookie to" << file;
 
         // Touch file
         QFile file_handler(file);

--- a/src/daemon/DisplayServer.cpp
+++ b/src/daemon/DisplayServer.cpp
@@ -58,7 +58,7 @@ namespace SDDM {
         connect(process, SIGNAL(finished(int,QProcess::ExitStatus)), this, SLOT(finished()));
 
         // log message
-        qDebug() << " DAEMON: Display server starting...";
+        qDebug() << "Display server starting...";
 
         if (daemonApp->configuration()->testing) {
             process->start("/usr/bin/Xephyr", { m_display, "-ac", "-br", "-noreset", "-screen",  "800x600"});
@@ -77,7 +77,7 @@ namespace SDDM {
         // wait for display server to start
         if (!process->waitForStarted()) {
             // log message
-            qCritical() << " DAEMON: Failed to start display server process.";
+            qCritical() << "Failed to start display server process.";
 
             // return fail
             return false;
@@ -86,14 +86,14 @@ namespace SDDM {
         // wait until we can connect to the display server
         if (!this->waitForStarted()) {
             // log message
-            qCritical() << " DAEMON: Failed to connect to the display server.";
+            qCritical() << "Failed to connect to the display server.";
 
             // return fail
             return false;
         }
 
         // log message
-        qDebug() << " DAEMON: Display server started.";
+        qDebug() << "Display server started.";
 
         // set flag
         m_started = true;
@@ -108,7 +108,7 @@ namespace SDDM {
             return;
 
         // log message
-        qDebug() << " DAEMON: Display server stopping...";
+        qDebug() << "Display server stopping...";
 
         // terminate process
         process->terminate();
@@ -127,7 +127,7 @@ namespace SDDM {
         m_started = false;
 
         // log message
-        qDebug() << " DAEMON: Display server stopped.";
+        qDebug() << "Display server stopped.";
 
         // clean up
         process->deleteLater();

--- a/src/daemon/Greeter.cpp
+++ b/src/daemon/Greeter.cpp
@@ -62,7 +62,7 @@ namespace SDDM {
         connect(m_process, SIGNAL(finished(int,QProcess::ExitStatus)), this, SLOT(finished()));
 
         // log message
-        qDebug() << " DAEMON: Greeter starting...";
+        qDebug() << "Greeter starting...";
 
         // set process environment
         QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
@@ -77,14 +77,14 @@ namespace SDDM {
         // wait for greeter to start
         if (!m_process->waitForStarted()) {
             // log message
-            qCritical() << " DAEMON: Failed to start greeter.";
+            qCritical() << "Failed to start greeter.";
 
             // return fail
             return false;
         }
 
         // log message
-        qDebug() << " DAEMON: Greeter started.";
+        qDebug() << "Greeter started.";
 
         // set flag
         m_started = true;
@@ -99,7 +99,7 @@ namespace SDDM {
             return;
 
         // log message
-        qDebug() << " DAEMON: Greeter stopping...";
+        qDebug() << "Greeter stopping...";
 
         // terminate process
         m_process->terminate();
@@ -118,7 +118,7 @@ namespace SDDM {
         m_started = false;
 
         // log message
-        qDebug() << " DAEMON: Greeter stopped.";
+        qDebug() << "Greeter stopped.";
 
         // clean up
         m_process->deleteLater();

--- a/src/daemon/Seat.cpp
+++ b/src/daemon/Seat.cpp
@@ -69,7 +69,7 @@ namespace SDDM {
         m_terminalIds << terminalId;
 
         // log message
-        qDebug() << " DAEMON: Adding new display :" << displayId << " on vt" << terminalId << "...";
+        qDebug() << "Adding new display :" << displayId << " on vt" << terminalId << "...";
 
         // create a new display
         Display *display = new Display(displayId, terminalId, this);
@@ -85,7 +85,7 @@ namespace SDDM {
     }
 
     void Seat::removeDisplay(int displayId) {
-        qDebug() << " DAEMON: Removing display :" << displayId << "...";
+        qDebug() << "Removing display :" << displayId << "...";
 
         // display object
         Display *display = nullptr;

--- a/src/daemon/Session.cpp
+++ b/src/daemon/Session.cpp
@@ -59,7 +59,7 @@ namespace SDDM {
             return;
 
         if (initgroups(qPrintable(m_user), m_gid)) {
-            qCritical() << " DAEMON: Failed to initialize user groups.";
+            qCritical() << "Failed to initialize user groups.";
 
             // emit signal
             emit finished(EXIT_FAILURE, QProcess::NormalExit);
@@ -69,7 +69,7 @@ namespace SDDM {
         }
 
         if (setgid(m_gid)) {
-            qCritical() << " DAEMON: Failed to set group id.";
+            qCritical() << "Failed to set group id.";
 
             // emit signal
             emit finished(EXIT_FAILURE, QProcess::NormalExit);
@@ -79,7 +79,7 @@ namespace SDDM {
         }
 
         if (setuid(m_uid)) {
-            qCritical() << " DAEMON: Failed to set user id.";
+            qCritical() << "Failed to set user id.";
 
             // emit signal
             emit finished(EXIT_FAILURE, QProcess::NormalExit);
@@ -94,7 +94,7 @@ namespace SDDM {
 
         // change to user home dir
         if (chdir(qPrintable(m_dir))) {
-            qCritical() << " DAEMON: Failed to change dir to user home.";
+            qCritical() << "Failed to change dir to user home.";
 
             // emit signal
             emit finished(EXIT_FAILURE, QProcess::NormalExit);

--- a/src/daemon/SignalHandler.cpp
+++ b/src/daemon/SignalHandler.cpp
@@ -34,19 +34,19 @@ namespace SDDM {
 
     SignalHandler::SignalHandler(QObject *parent) : QObject(parent) {
         if (::socketpair(AF_UNIX, SOCK_STREAM, 0, sighupFd))
-            qCritical() << " DAEMON: Failed to create socket pair for SIGHUP handling.";
+            qCritical() << "Failed to create socket pair for SIGHUP handling.";
 
         snhup = new QSocketNotifier(sighupFd[1], QSocketNotifier::Read, this);
         connect(snhup, SIGNAL(activated(int)), this, SLOT(handleSighup()));
 
         if (::socketpair(AF_UNIX, SOCK_STREAM, 0, sigintFd))
-            qCritical() << " DAEMON: Failed to create socket pair for SIGINT handling.";
+            qCritical() << "Failed to create socket pair for SIGINT handling.";
 
         snint = new QSocketNotifier(sigintFd[1], QSocketNotifier::Read, this);
         connect(snint, SIGNAL(activated(int)), this, SLOT(handleSigint()));
 
         if (::socketpair(AF_UNIX, SOCK_STREAM, 0, sigtermFd))
-            qCritical() << " DAEMON: Failed to create socket pair for SIGTERM handling.";
+            qCritical() << "Failed to create socket pair for SIGTERM handling.";
 
         snterm = new QSocketNotifier(sigtermFd[1], QSocketNotifier::Read, this);
         connect(snterm, SIGNAL(activated(int)), this, SLOT(handleSigterm()));
@@ -60,7 +60,7 @@ namespace SDDM {
         sighup.sa_flags |= SA_RESTART;
 
         if (sigaction(SIGHUP, &sighup, 0) > 0) {
-            qCritical() << " DAEMON: Failed to setup SIGHUP handler.";
+            qCritical() << "Failed to setup SIGHUP handler.";
             return;
         }
 
@@ -70,7 +70,7 @@ namespace SDDM {
         sigint.sa_flags |= SA_RESTART;
 
         if (sigaction(SIGINT, &sigint, 0) > 0) {
-            qCritical() << " DAEMON: Failed to set up SIGINT handler.";
+            qCritical() << "Failed to set up SIGINT handler.";
             return;
         }
 
@@ -80,7 +80,7 @@ namespace SDDM {
         sigterm.sa_flags |= SA_RESTART;
 
         if (sigaction(SIGTERM, &sigterm, 0) > 0) {
-            qCritical() << " DAEMON: Failed to set up SIGTERM handler.";
+            qCritical() << "Failed to set up SIGTERM handler.";
             return;
         }
     }
@@ -88,7 +88,7 @@ namespace SDDM {
     void SignalHandler::hupSignalHandler(int) {
         char a = 1;
         if (::write(sighupFd[0], &a, sizeof(a)) == -1) {
-            qCritical() << " DAEMON: Error writing to the SIGHUP handler";
+            qCritical() << "Error writing to the SIGHUP handler";
             return;
         }
     }
@@ -96,7 +96,7 @@ namespace SDDM {
     void SignalHandler::intSignalHandler(int) {
         char a = 1;
         if (::write(sigintFd[0], &a, sizeof(a)) == -1) {
-            qCritical() << " DAEMON: Error writing to the SIGINT handler";
+            qCritical() << "Error writing to the SIGINT handler";
             return;
         }
     }
@@ -104,7 +104,7 @@ namespace SDDM {
     void SignalHandler::termSignalHandler(int) {
         char a = 1;
         if (::write(sigtermFd[0], &a, sizeof(a)) == -1) {
-            qCritical() << " DAEMON: Error writing to the SIGTERM handler";
+            qCritical() << "Error writing to the SIGTERM handler";
             return;
         }
     }
@@ -117,12 +117,12 @@ namespace SDDM {
         char a;
         if (::read(sighupFd[1], &a, sizeof(a)) == -1) {
             // something went wrong!
-            qCritical() << " DAEMON: Error reading from the socket";
+            qCritical() << "Error reading from the socket";
             return;
         }
 
         // log event
-        qWarning() << " DAEMON: Signal received: SIGHUP";
+        qWarning() << "Signal received: SIGHUP";
 
         // emit signal
         emit sighupReceived();
@@ -139,12 +139,12 @@ namespace SDDM {
         char a;
         if (::read(sigintFd[1], &a, sizeof(a)) == -1) {
             // something went wrong!
-            qCritical() << " DAEMON: Error reading from the socket";
+            qCritical() << "Error reading from the socket";
             return;
         }
 
         // log event
-        qWarning() << " DAEMON: Signal received: SIGINT";
+        qWarning() << "Signal received: SIGINT";
 
         // emit signal
         emit sigintReceived();
@@ -161,12 +161,12 @@ namespace SDDM {
         char a;
         if (::read(sigtermFd[1], &a, sizeof(a)) == -1) {
             // something went wrong!
-            qCritical() << " DAEMON: Error reading from the socket";
+            qCritical() << "Error reading from the socket";
             return;
         }
 
         // log event
-        qWarning() << " DAEMON: Signal received: SIGTERM";
+        qWarning() << "Signal received: SIGTERM";
 
         // emit signal
         emit sigtermReceived();

--- a/src/daemon/SocketServer.cpp
+++ b/src/daemon/SocketServer.cpp
@@ -40,7 +40,7 @@ namespace SDDM {
             return false;
 
         // log message
-        qDebug() << " DAEMON: Socket server starting...";
+        qDebug() << "Socket server starting...";
 
         // create server
         server = new QLocalServer(this);
@@ -56,14 +56,14 @@ namespace SDDM {
         // start listening
         if (!server->listen(m_socket)) {
             // log message
-            qCritical() << " DAEMON: Failed to start socket server.";
+            qCritical() << "Failed to start socket server.";
 
             // return fail
             return false;
         }
 
         // log message
-        qDebug() << " DAEMON: Socket server started.";
+        qDebug() << "Socket server started.";
 
         // connect signals
         connect(server, SIGNAL(newConnection()), this, SLOT(newConnection()));
@@ -84,14 +84,14 @@ namespace SDDM {
         m_started = false;
 
         // log message
-        qDebug() << " DAEMON: Socket server stopping...";
+        qDebug() << "Socket server stopping...";
 
         // delete server
         server->deleteLater();
         server = nullptr;
 
         // log message
-        qDebug() << " DAEMON: Socket server stopped.";
+        qDebug() << "Socket server stopped.";
     }
 
     void SocketServer::newConnection() {
@@ -120,7 +120,7 @@ namespace SDDM {
         switch (GreeterMessages(message)) {
             case GreeterMessages::Connect: {
                 // log message
-                qDebug() << " DAEMON: Message received from greeter: Connect";
+                qDebug() << "Message received from greeter: Connect";
 
                 // send capabilities
                 SocketWriter(socket) << quint32(DaemonMessages::Capabilities) << quint32(daemonApp->powerManager()->capabilities());
@@ -131,7 +131,7 @@ namespace SDDM {
             break;
             case GreeterMessages::Login: {
                 // log message
-                qDebug() << " DAEMON: Message received from greeter: Login";
+                qDebug() << "Message received from greeter: Login";
 
                 // read username, pasword etc.
                 QString user, password, session;
@@ -143,7 +143,7 @@ namespace SDDM {
             break;
             case GreeterMessages::PowerOff: {
                 // log message
-                qDebug() << " DAEMON: Message received from greeter: PowerOff";
+                qDebug() << "Message received from greeter: PowerOff";
 
                 // power off
                 daemonApp->powerManager()->powerOff();
@@ -151,7 +151,7 @@ namespace SDDM {
             break;
             case GreeterMessages::Reboot: {
                 // log message
-                qDebug() << " DAEMON: Message received from greeter: Reboot";
+                qDebug() << "Message received from greeter: Reboot";
 
                 // reboot
                 daemonApp->powerManager()->reboot();
@@ -159,7 +159,7 @@ namespace SDDM {
             break;
             case GreeterMessages::Suspend: {
                 // log message
-                qDebug() << " DAEMON: Message received from greeter: Suspend";
+                qDebug() << "Message received from greeter: Suspend";
 
                 // suspend
                 daemonApp->powerManager()->suspend();
@@ -167,7 +167,7 @@ namespace SDDM {
             break;
             case GreeterMessages::Hibernate: {
                 // log message
-                qDebug() << " DAEMON: Message received from greeter: Hibernate";
+                qDebug() << "Message received from greeter: Hibernate";
 
                 // hibernate
                 daemonApp->powerManager()->hibernate();
@@ -175,7 +175,7 @@ namespace SDDM {
             break;
             case GreeterMessages::HybridSleep: {
                 // log message
-                qDebug() << " DAEMON: Message received from greeter: HybridSleep";
+                qDebug() << "Message received from greeter: HybridSleep";
 
                 // hybrid sleep
                 daemonApp->powerManager()->hybridSleep();
@@ -183,7 +183,7 @@ namespace SDDM {
             break;
             default: {
                 // log message
-                qWarning() << " DAEMON: Unknown message" << message;
+                qWarning() << "Unknown message" << message;
             }
         }
     }

--- a/src/greeter/GreeterApp.cpp
+++ b/src/greeter/GreeterApp.cpp
@@ -183,7 +183,7 @@ namespace SDDM {
 int main(int argc, char **argv) {
 #ifdef USE_QT5
     // install message handler
-    qInstallMessageHandler(SDDM::MessageHandler);
+    qInstallMessageHandler(SDDM::GreeterMessageHandler);
 #endif
     QStringList arguments;
 

--- a/src/greeter/GreeterProxy.cpp
+++ b/src/greeter/GreeterProxy.cpp
@@ -111,7 +111,7 @@ namespace SDDM {
     void GreeterProxy::login(const QString &user, const QString &password, const int sessionIndex) const {
         if (!d->sessionModel) {
             // log error
-            qCritical() << "GREETER: Session model is not set.";
+            qCritical() << "Session model is not set.";
 
             // return
             return;
@@ -126,7 +126,7 @@ namespace SDDM {
 
     void GreeterProxy::connected() {
         // log connection
-        qDebug() << "GREETER: Connected to the daemon.";
+        qDebug() << "Connected to the daemon.";
 
         // send connected message
         SocketWriter(d->socket) << quint32(GreeterMessages::Connect);
@@ -134,11 +134,11 @@ namespace SDDM {
 
     void GreeterProxy::disconnected() {
         // log disconnection
-        qDebug() << "GREETER: Disconnected from the daemon.";
+        qDebug() << "Disconnected from the daemon.";
     }
 
     void GreeterProxy::error() {
-        qCritical() << "GREETER: Socket error: " << d->socket->errorString();
+        qCritical() << "Socket error: " << d->socket->errorString();
     }
 
     void GreeterProxy::readyRead() {
@@ -153,7 +153,7 @@ namespace SDDM {
             switch (DaemonMessages(message)) {
                 case DaemonMessages::Capabilities: {
                     // log message
-                    qDebug() << "GREETER: Message received from daemon: Capabilities";
+                    qDebug() << "Message received from daemon: Capabilities";
 
                     // read capabilities
                     quint32 capabilities;
@@ -176,7 +176,7 @@ namespace SDDM {
                 break;
                 case DaemonMessages::HostName: {
                     // log message
-                    qDebug() << "GREETER: Message received from daemon: HostName";
+                    qDebug() << "Message received from daemon: HostName";
 
                     // read host name
                     input >> d->hostName;
@@ -187,7 +187,7 @@ namespace SDDM {
                 break;
                 case DaemonMessages::LoginSucceeded: {
                     // log message
-                    qDebug() << "GREETER: Message received from daemon: LoginSucceeded";
+                    qDebug() << "Message received from daemon: LoginSucceeded";
 
                     // emit signal
                     emit loginSucceeded();
@@ -195,7 +195,7 @@ namespace SDDM {
                 break;
                 case DaemonMessages::LoginFailed: {
                     // log message
-                    qDebug() << "GREETER: Message received from daemon: LoginFailed";
+                    qDebug() << "Message received from daemon: LoginFailed";
 
                     // emit signal
                     emit loginFailed();
@@ -203,7 +203,7 @@ namespace SDDM {
                 break;
                 default: {
                     // log message
-                    qWarning() << "GREETER: Unknown message received from daemon.";
+                    qWarning() << "Unknown message received from daemon.";
                 }
             }
         }


### PR DESCRIPTION
Add support to journald logging that provides us much more information
such as code line and function, process command line, etc...
Logging works just like before when running interactively.

Since the DAEMON or GREETER prefix are not useful when logging to journald
and there was not even consistency between them, we now have two message
handlers respectively for daemon and greeter.

Those message handlers prepend the correct prefix to the message when
logging to file or stdout.  As a result all log messages don't need to
provide those prefixes anymore.
