### PR TITLE
Remove -march=native to fix ARM builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_AUTOMOC ON)
 
 option(ENABLE_JOURNALD "Enable logging to journald" ON)
 
-add_definitions(-Wall -march=native -std=c++11)
+add_definitions(-Wall -std=c++11)
 
 if(NOT CMAKE_BUILD_TYPE)
         set(CMAKE_BUILD_TYPE Release)


### PR DESCRIPTION
This flag breaks ARM builds and doesn't buy us much when building
on other architectures.
