### PR TITLE
Use standard installation paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,9 @@ else()
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2")
 endif()
 
+# Standard installation paths
+include(GNUInstallDirs)
+
 # PKG-CONFIG
 find_package(PkgConfig)
 
@@ -110,15 +113,13 @@ else()
 endif()
 
 # set constants
-set(BIN_INSTALL_DIR             "${CMAKE_INSTALL_PREFIX}/bin"               CACHE PATH      "System binary install directory")
-set(DATA_INSTALL_DIR            "${CMAKE_INSTALL_PREFIX}/share/apps/sddm"   CACHE PATH      "System application data install directory")
-set(SYS_CONFIG_DIR              "/etc"                                      CACHE PATH      "System config directory")
-set(DBUS_CONFIG_DIR             "${SYS_CONFIG_DIR}/dbus-1/system.d"         CACHE PATH      "DBus config files directory")
-set(STATE_DIR                   "/var/lib/sddm"                             CACHE PATH      "State directory")
+set(DATA_INSTALL_DIR            "${CMAKE_INSTALL_FULL_DATADIR}/sddm"                CACHE PATH      "System application data install directory")
+set(DBUS_CONFIG_DIR             "${CMAKE_INSTALL_SYSCONFDIR}/dbus-1/system.d"       CACHE PATH      "DBus config files directory")
+set(STATE_DIR                   "${CMAKE_INSTALL_FULL_LOCALSTATEDIR}/lib/sddm"      CACHE PATH      "State directory")
 
-set(CONFIG_FILE                 "${SYS_CONFIG_DIR}/sddm.conf"               CACHE PATH      "Path of the sddm config file")
-set(LOG_FILE                    "/var/log/sddm.log"                         CACHE PATH      "Path of the sddm log file")
-set(COMPONENTS_TRANSLATION_DIR  "${DATA_INSTALL_DIR}/translations"          CACHE PATH      "Components translations directory")
+set(CONFIG_FILE                 "${CMAKE_INSTALL_SYSCONFDIR}/sddm.conf"             CACHE PATH      "Path of the sddm config file")
+set(LOG_FILE                    "${CMAKE_INSTALL_FULL_LOCALSTATEDIR}/log/sddm.log"  CACHE PATH      "Path of the sddm log file")
+set(COMPONENTS_TRANSLATION_DIR  "${DATA_INSTALL_DIR}/translations"                  CACHE PATH      "Components translations directory")
 
 add_subdirectory(components)
 add_subdirectory(data)

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -3,7 +3,7 @@ configure_file("${CMAKE_SOURCE_DIR}/data/sddm.conf.in"    "${CMAKE_BINARY_DIR}/s
 install(DIRECTORY   "faces"                               DESTINATION "${DATA_INSTALL_DIR}")
 install(DIRECTORY   "flags"                               DESTINATION "${DATA_INSTALL_DIR}")
 
-install(FILES       "${CMAKE_BINARY_DIR}/sddm.conf"     DESTINATION "${SYS_CONFIG_DIR}")
+install(FILES       "${CMAKE_BINARY_DIR}/sddm.conf"     DESTINATION "${CMAKE_INSTALL_SYSCONFDIR}")
 install(FILES       "${CMAKE_BINARY_DIR}/sddm.conf"     DESTINATION "${DATA_INSTALL_DIR}" RENAME "sddm.conf.sample")
 
 install(FILES "org.freedesktop.DisplayManager.conf"       DESTINATION "${DBUS_CONFIG_DIR}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,7 +57,7 @@ if(JOURNALD_FOUND)
     target_link_libraries(sddm ${JOURNALD_LIBRARIES})
 endif()
 
-install(TARGETS sddm DESTINATION ${BIN_INSTALL_DIR})
+install(TARGETS sddm DESTINATION "${CMAKE_INSTALL_BINDIR}")
 
 ## GREETER ##
 
@@ -94,4 +94,4 @@ endif()
 add_dependencies(sddm-greeter components-translation)
 add_dependencies(sddm-greeter themes-translation)
 
-install(TARGETS sddm-greeter DESTINATION "${BIN_INSTALL_DIR}")
+install(TARGETS sddm-greeter DESTINATION "${CMAKE_INSTALL_BINDIR}")

--- a/src/common/Constants.h.in
+++ b/src/common/Constants.h.in
@@ -20,9 +20,9 @@
 #ifndef SDDM_CONSTANTS_H
 #define SDDM_CONSTANTS_H
 
-#define BIN_INSTALL_DIR             "@BIN_INSTALL_DIR@"
+#define BIN_INSTALL_DIR             "@CMAKE_INSTALL_FULL_BINDIR@"
 #define DATA_INSTALL_DIR            "@DATA_INSTALL_DIR@"
-#define SYS_CONFIG_DIR              "@SYS_CONFIG_DIR@"
+#define SYS_CONFIG_DIR              "@CMAKE_INSTALL_FULL_SYSCONFDIR@"
 #define IMPORTS_INSTALL_DIR         "@QT_IMPORTS_DIR@"
 #define COMPONENTS_TRANSLATION_DIR  "@COMPONENTS_TRANSLATION_DIR@"
 #define STATE_DIR                   "@STATE_DIR@"


### PR DESCRIPTION
CMake already has support for standard installation paths
including GNUInstallDirs.  Remove our definitions and use theirs.

While we are here, use a more conventional path for data files.
