### PR TITLE
Set policy CMP0043 only if it exists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,9 @@ set(CMAKE_AUTOMOC ON)
 SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 # Silence CMake 3.0 warnings
-cmake_policy(SET CMP0043 OLD)
+if(POLICY CMP0043)
+  cmake_policy(SET CMP0043 OLD)
+endif()
 
 # Set version
 set(SDDM_VERSION_MAJOR 0)


### PR DESCRIPTION
Guard the command to avoid errors with CMake versions older than 3.0.
