### PR TITLE
Change socket owner and group

### DIFF
--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -203,6 +203,17 @@ namespace SDDM {
         // start socket server
         m_socketServer->start(m_display);
 
+        if (!daemonApp->configuration()->testing) {
+            // change the owner and group of the socket to avoid permission denied errors
+            struct passwd *pw = getpwnam("sddm");
+            if (pw) {
+                if (chown(qPrintable(m_socketServer->socketAddress()), pw->pw_uid, pw->pw_gid) == -1) {
+                    qWarning() << "Failed to change owner of the socket";
+                    return;
+                }
+            }
+        }
+
         // set greeter params
         m_greeter->setDisplay(this);
         m_greeter->setAuthPath(m_authPath);

--- a/src/daemon/SocketServer.cpp
+++ b/src/daemon/SocketServer.cpp
@@ -52,7 +52,7 @@ namespace SDDM {
 
 #ifdef USE_QT5
         // set server options
-        m_server->setSocketOptions(QLocalServer::WorldAccessOption);
+        m_server->setSocketOptions(QLocalServer::UserAccessOption);
 #endif
 
         // start listening


### PR DESCRIPTION
Keep the socket open with user access but change owner and group to
sddm to avoid permission denied errors from the greeter.

This is not done in test mode as everything runs with one user.
