### PR TITLE
Fixed autologin

### DIFF
--- a/src/daemon/DaemonApp.h
+++ b/src/daemon/DaemonApp.h
@@ -41,7 +41,7 @@ namespace SDDM {
 
         // TODO: move these two away
         bool testing() const;
-        bool first { false };
+        bool first { true };
 
         QString hostName() const;
         DisplayManager *displayManager() const;


### PR DESCRIPTION
The default value of "first" should be true, not false. This fixes autologin.
#240 can be closed.
