### PR TITLE
Fix running SDDM under a Plasma 5.0 desktop.

### DIFF
--- a/src/greeter/GreeterApp.cpp
+++ b/src/greeter/GreeterApp.cpp
@@ -63,7 +63,7 @@ namespace SDDM {
 
     GreeterApp *GreeterApp::self = nullptr;
 
-    GreeterApp::GreeterApp(int argc, char **argv) :
+    GreeterApp::GreeterApp(int &argc, char **argv) :
 #ifdef USE_QT5
     QGuiApplication(argc, argv)
 #else

--- a/src/greeter/GreeterApp.h
+++ b/src/greeter/GreeterApp.h
@@ -52,7 +52,7 @@ namespace SDDM {
         Q_OBJECT
         Q_DISABLE_COPY(GreeterApp)
     public:
-        explicit GreeterApp(int argc, char **argv);
+        explicit GreeterApp(int &argc, char **argv);
 
         static GreeterApp *instance() { return self; }
 


### PR DESCRIPTION
When running SDDM under a full Plasma 5.0 desktop, the integration plugin tries
to access the arguments to figure out a configuration file name.  However, as
argc in SDDM::GreeterApp was passed as a temporary into a QGuiApplication, which
takes argc as a reference, the reference to argc is no longer valid and the
application segfaults.  Fix by having GreeterApp take argc as a reference.
