### PR TITLE
Similar to c4cfeb6bbf8d, avoid crashes due to bad references.

### DIFF
--- a/src/daemon/DaemonApp.cpp
+++ b/src/daemon/DaemonApp.cpp
@@ -39,7 +39,7 @@
 namespace SDDM {
     DaemonApp *DaemonApp::self = nullptr;
 
-    DaemonApp::DaemonApp(int argc, char **argv) : QCoreApplication(argc, argv) {
+    DaemonApp::DaemonApp(int &argc, char **argv) : QCoreApplication(argc, argv) {
         // point instance to this
         self = this;
 

--- a/src/daemon/DaemonApp.h
+++ b/src/daemon/DaemonApp.h
@@ -35,7 +35,7 @@ namespace SDDM {
         Q_OBJECT
         Q_DISABLE_COPY(DaemonApp)
     public:
-        explicit DaemonApp(int argc, char **argv);
+        explicit DaemonApp(int &argc, char **argv);
 
         static DaemonApp *instance() { return self; }
 


### PR DESCRIPTION
Make sure argc is always valid when QCoreApplication access it, by keeping
it as a reference to argc from main.

This is similar to PR #242.
