### PR TITLE
Don't override pam environment variables

### DIFF
--- a/src/helper/backend/PamBackend.cpp
+++ b/src/helper/backend/PamBackend.cpp
@@ -247,12 +247,13 @@ bool PamBackend::openSession() {
         m_app->error(m_pam->errorString(), Auth::ERROR_AUTHENTICATION);
         return false;
     }
-    QString display = m_app->session()->processEnvironment().value("DISPLAY");
+    QProcessEnvironment sessionEnv = m_app->session()->processEnvironment();
+    QString display = sessionEnv.value("DISPLAY");
     if (!display.isEmpty()) {
         m_pam->setItem(PAM_XDISPLAY, qPrintable(display));
         m_pam->setItem(PAM_TTY, qPrintable(display));
     }
-    if (!m_pam->putEnv(m_app->session()->processEnvironment())) {
+    if (!m_pam->putEnv(sessionEnv)) {
         m_app->error(m_pam->errorString(), Auth::ERROR_INTERNAL);
         return false;
     }
@@ -260,9 +261,8 @@ bool PamBackend::openSession() {
         m_app->error(m_pam->errorString(), Auth::ERROR_INTERNAL);
         return false;
     }
-    QProcessEnvironment env = m_pam->getEnv();
-    env.insert(m_app->session()->processEnvironment());
-    m_app->session()->setProcessEnvironment(env);
+    sessionEnv.insert(m_pam->getEnv());
+    m_app->session()->setProcessEnvironment(sessionEnv);
     return Backend::openSession();
 }
 


### PR DESCRIPTION
When using pam_env users are allowed to provide environment variables
to SDDM.

This is often used to customize PATH like Debian does.
However we overwrite those environment variables with our own.

What happens on Debian is that we overwrite PATH with a less
complete version.

Make sure pam variables are not overridden.

Closes #256

[ChangeLog][Behavioral Change] Don't override pam environment
variables.
