### PR TITLE
Add config parameter to disable avatars

### DIFF
--- a/data/man/sddm.conf.rst.in
+++ b/data/man/sddm.conf.rst.in
@@ -123,6 +123,12 @@ OPTIONS
 	wont be updated.
 	Default value is true.
 
+`ReadHomeFaces=`
+	If this flag is true, home directories of all users are
+	searched for .face.icon files on startup. This can lead to
+	a slowdown in large NFS environments.
+	Default value is true.
+
 [Autologin] section:
 
 `User=`

--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -72,6 +72,7 @@ namespace SDDM {
                                                                                                    "Users with these shells as their default won't be listed"));
             Entry(RememberLastUser,    bool,        true,                                       _S("Remember the last successfully logged in user"));
             Entry(RememberLastSession, bool,        true,                                       _S("Remember the session of the last successfully logged in user"));
+            Entry(ReadHomeFaces,       bool,        true,                                       _S("Read .face.icon files from home directories.\nCan slowdown startup in NFS environments."));
         );
         Section(Autologin,
             Entry(User,                QString,     QString(),                                  _S("Autologin user"));

--- a/src/greeter/UserModel.cpp
+++ b/src/greeter/UserModel.cpp
@@ -79,12 +79,13 @@ namespace SDDM {
             // search for face icon
             QString userFace = QString("%1/.face.icon").arg(user->homeDir);
             QString systemFace = QString("%1/%2.face.icon").arg(mainConfig.Theme.FacesDir.get()).arg(user->name);
-            if (QFile::exists(userFace))
+            QString defaultFace = QString("%1/default.face.icon").arg(mainConfig.Theme.FacesDir.get());
+            if (mainConfig.Users.ReadHomeFaces.get() && QFile::exists(userFace))
                 user->icon = userFace;
             else if (QFile::exists(systemFace))
                 user->icon = systemFace;
             else
-                user->icon = QString("%1/default.face.icon").arg(mainConfig.Theme.FacesDir.get());
+                user->icon = defaultFace;
 
             // add user
             d->users << user;


### PR DESCRIPTION
On startup, the greeter accesses *all* home directories to check for the existence of a `.face.icon` file. If a home directory sits on a remote machine, this can significantly slow down greeter startup; furthermore, if a remote machine is not available, the greeter sits through the default automounter timeout. The behavior is especially undesirable when a theme is used that does not use face files anyway.

1. The current behavior can make SDDM unfit for client systems in larger networks with distributed home directories.
2. As there is no output at all, graphical or in the log, during that period, it is hard to track down the cause of a seemingly "broken" SDDM.

This patch enables the user to change the default behavior of checking for `.face.icon` files in home directory. When opting out via the ReadHomeFaces setting (default: true), SDDM only supports files in the dedicated FacesDir location (which, for example, could be populated via the LDAP jpegPhoto property). Also, the config description mentions this as a possible cause for slow startup.