### PR TITLE
Load Xsession scripts on startup

### DIFF
--- a/data/scripts/Xsession
+++ b/data/scripts/Xsession
@@ -57,6 +57,25 @@ if [ -d /etc/X11/xinit/xinitrc.d ]; then
   done
 fi
 
+# Load Xsession scripts
+# OPTIONFILE, USERXSESSION, USERXSESSIONRC and ALTUSERXSESSION are required
+# by the scripts to work
+xsessionddir="/etc/X11/Xsession.d"
+OPTIONFILE=/etc/X11/Xsession.options
+USERXSESSION=$HOME/.xsession
+USERXSESSIONRC=$HOME/.xsessionrc
+ALTUSERXSESSION=$HOME/.Xsession
+
+if [ -d "$xsessionddir" ]; then
+    for i in `ls $xsessionddir`; do
+        script="$xsessionddir/$i"
+        echo "Loading X session script $script"
+        if [ -r "$script"  -a -f "$script" ] && expr "$i" : '^[[:alnum:]_-]\+$' > /dev/null; then
+            . "$script"
+        fi
+    done
+fi
+
 if [ -d /etc/X11/Xresources ]; then
   for i in /etc/X11/Xresources/*; do
     [ -f $i ] && xrdb -merge $i


### PR DESCRIPTION
Totally untested and stolen from
http://bazaar.launchpad.net/~lightdm-team/lightdm/trunk/view/head:/debian/lightdm-session.

See this more like a bug report. SDDM doesn't load the Xsession scripts
for me, and I think a patch like this would fix it.
