### PR TITLE
Fixed "avaialble" typo in man pages

### DIFF
--- a/data/man/sddm-greeter.rst.in
+++ b/data/man/sddm-greeter.rst.in
@@ -58,4 +58,4 @@ SEE ALSO
 
 **sddm**\(1\), **sddm.conf**\(5\)
 
-The full documentation for sddm is avaialble at https://github.com/sddm/sddm
+The full documentation for sddm is available at https://github.com/sddm/sddm

--- a/data/man/sddm-state.conf.rst.in
+++ b/data/man/sddm-state.conf.rst.in
@@ -41,4 +41,4 @@ SEE ALSO
 
 **sddm**\(1\)
 
-The full documentation for sddm is avaialble at https://github.com/sddm/sddm
+The full documentation for sddm is available at https://github.com/sddm/sddm

--- a/data/man/sddm.conf.rst.in
+++ b/data/man/sddm.conf.rst.in
@@ -146,4 +146,4 @@ SEE ALSO
 
 **sddm**\(1\)
 
-The full documentation for sddm is avaialble at https://github.com/sddm/sddm
+The full documentation for sddm is available at https://github.com/sddm/sddm

--- a/data/man/sddm.rst.in
+++ b/data/man/sddm.rst.in
@@ -57,4 +57,4 @@ SEE ALSO
 
 **sddm.conf**\(5\)
 
-The full documentation for sddm is avaialble at https://github.com/sddm/sddm
+The full documentation for sddm is available at https://github.com/sddm/sddm


### PR DESCRIPTION
Just a minor correction, "avaialble" should be "available" in the man pages.
