### PR TITLE
Fix ZSH integration part of Xsession script

### DIFF
--- a/data/scripts/Xsession
+++ b/data/scripts/Xsession
@@ -22,7 +22,7 @@ case $SHELL in
     ;;
   */zsh)
     [ -z "$ZSH_NAME" ] && exec $SHELL $0 "$@"
-    emulate -R zsh
+    emulate -R sh
     [ -d /etc/zsh ] && zdir=/etc/zsh || zdir=/etc
     zhome=${ZDOTDIR:-$HOME}
     # zshenv is always sourced automatically.


### PR DESCRIPTION
This is a long-time issue for Kubuntu it seems.

See https://bugs.launchpad.net/ubuntu/+source/kdebase/+bug/13965 (KDM
contains the same code, and people also had issues logging in with ZSH
here). The bug report is from 2005 ;)
