### PR TITLE
Start monitoring for X's completion signal before we start X

### DIFF
--- a/src/daemon/XorgDisplayServer.cpp
+++ b/src/daemon/XorgDisplayServer.cpp
@@ -159,9 +159,11 @@ namespace SDDM {
             qDebug() << "Running:"
                      << qPrintable(mainConfig.XDisplay.ServerPath.get())
                      << qPrintable(args.join(" "));
-            process->start(mainConfig.XDisplay.ServerPath.get(), args);
+
             SignalHandler::initializeSigusr1();
             connect(DaemonApp::instance()->signalHandler(), SIGNAL(sigusr1Received()), this, SIGNAL(started()));
+
+            process->start(mainConfig.XDisplay.ServerPath.get(), args);
         }
 
         // wait for display server to start


### PR DESCRIPTION
I saw a logfile which shows we started X but never received the signal
on the first run. There is potential for a race condition here, so this
/might/ fix it.
