### PR TITLE
Replace signal handling method of detecting X startup with FD method

### DIFF
--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -40,8 +40,8 @@
 #include <unistd.h>
 
 namespace SDDM {
-    Display::Display(const int displayId, const int terminalId, Seat *parent) : QObject(parent),
-        m_displayId(displayId), m_terminalId(terminalId),
+    Display::Display(const int terminalId, Seat *parent) : QObject(parent),
+        m_terminalId(terminalId),
         m_auth(new Auth(this)),
         m_displayServer(new XorgDisplayServer(this)),
         m_seat(parent),
@@ -73,8 +73,8 @@ namespace SDDM {
         stop();
     }
 
-    const int Display::displayId() const {
-        return m_displayId;
+    QString Display::displayId() const {
+        return m_displayServer->display();
     }
 
     const int Display::terminalId() const {

--- a/src/daemon/Display.h
+++ b/src/daemon/Display.h
@@ -39,10 +39,10 @@ namespace SDDM {
         Q_OBJECT
         Q_DISABLE_COPY(Display)
     public:
-        explicit Display(const int displayId, const int terminalId, Seat *parent);
+        explicit Display(int terminalId, Seat *parent);
         ~Display();
 
-        const int displayId() const;
+        QString displayId() const;
         const int terminalId() const;
 
         const QString &name() const;
@@ -71,7 +71,6 @@ namespace SDDM {
         bool m_relogin { true };
         bool m_started { false };
 
-        int m_displayId { 0 };
         int m_terminalId { 7 };
 
         QString m_passPhrase;

--- a/src/daemon/Seat.h
+++ b/src/daemon/Seat.h
@@ -34,8 +34,8 @@ namespace SDDM {
         const QString &name() const;
 
     public slots:
-        void createDisplay(int displayId = -1, int terminalId = -1);
-        void removeDisplay(int displayId);
+        void createDisplay(int terminalId = -1);
+        void removeDisplay(SDDM::Display* display);
 
     private slots:
         void displayStopped();
@@ -45,7 +45,6 @@ namespace SDDM {
 
         QList<Display *> m_displays;
         QList<int> m_terminalIds;
-        QList<int> m_displayIds;
     };
 }
 

--- a/src/daemon/XorgDisplayServer.h
+++ b/src/daemon/XorgDisplayServer.h
@@ -33,8 +33,6 @@ namespace SDDM {
         explicit XorgDisplayServer(Display *parent);
         ~XorgDisplayServer();
 
-        static bool displayExists(int number);
-
         const QString &display() const;
         const QString &authPath() const;
 


### PR DESCRIPTION
Using SIGUSR1 to detect when X has started doesn't work with multi seat
as we end up starting two X servers in such fast succession that one
signal gets lost.

Xorg also supports an approach where we pass a file descriptor as an
argument and X will write the used dislay ID (i.e :0) into this file
when it is ready. Apparently this is the preferred approach for
detecting X startup.
