### PR TITLE
Add rounded corner support to TextBox and PasswordBox

### DIFF
--- a/components/2.0/PasswordBox.qml
+++ b/components/2.0/PasswordBox.qml
@@ -32,6 +32,7 @@ FocusScope {
     property alias borderColor: txtMain.borderColor
     property alias focusColor: txtMain.focusColor
     property alias hoverColor: txtMain.hoverColor
+    property alias radius: txtMain.radius
     property alias font: txtMain.font
     property alias textColor: txtMain.color
     property alias echoMode: txtMain.echoMode

--- a/components/2.0/TextBox.qml
+++ b/components/2.0/TextBox.qml
@@ -32,6 +32,7 @@ FocusScope {
     property color borderColor: "#ababab"
     property color focusColor: "#266294"
     property color hoverColor: "#5692c4"
+    property real  radius: 0.0
     property alias font: txtMain.font
     property alias textColor: txtMain.color
     property alias echoMode: txtMain.echoMode
@@ -45,6 +46,7 @@ FocusScope {
         color: container.color
         border.color: container.borderColor
         border.width: 1
+        radius: container.radius
 
         Behavior on border.color { ColorAnimation { duration: 100 } }
 

--- a/components/2.0/TextBox.qml
+++ b/components/2.0/TextBox.qml
@@ -32,7 +32,7 @@ FocusScope {
     property color borderColor: "#ababab"
     property color focusColor: "#266294"
     property color hoverColor: "#5692c4"
-    property real  radius: 0.0
+    property alias radius: main.radius
     property alias font: txtMain.font
     property alias textColor: txtMain.color
     property alias echoMode: txtMain.echoMode
@@ -46,7 +46,6 @@ FocusScope {
         color: container.color
         border.color: container.borderColor
         border.width: 1
-        radius: container.radius
 
         Behavior on border.color { ColorAnimation { duration: 100 } }
 


### PR DESCRIPTION
Although the widgets used inside TextBox and PasswordBox support rounded corners, these widgets themselves do not provide it.

By adding the radius property to the TextBox and PasswordBox, these widgets become capable of supporting rounded corners, which are a simple nice ability to give to themes.