### PR TITLE
Make PasswordBox follow user set height.

### DIFF
--- a/components/2.0/PasswordBox.qml
+++ b/components/2.0/PasswordBox.qml
@@ -52,7 +52,7 @@ FocusScope {
 
     TextBox {
         id: txtMain
-        width: parent.width; height: 30
+        width: parent.width; height: parent.height
         font.pixelSize: 14
 
         echoMode: TextInput.Password


### PR DESCRIPTION
The widgets in PasswordBox have a fixed height in them. This means that if some theme applies a custom height to PasswordBox, it is ignored, and the default 30px is used anyway.

This commit makes it so the widgets inside PasswordBox inherit the container's size, so when a custom height is applied, it is followed.

---

I have tested the default themes included and they are unaffected by this change.