### PR TITLE
clarify syntax of HideUsers & HideShells in man

### DIFF
--- a/data/man/sddm.conf.rst.in
+++ b/data/man/sddm.conf.rst.in
@@ -104,11 +104,13 @@ OPTIONS
 	Default value is 65000.
 
 `HideUsers=`
-	Users that shouldn't show up in the user list.
+	Comma-separated list of users that shouldn't show up in
+	the user list.
 	Default value is empty.
 
 `HideShells=`
-	Shells of users that shouldn't show up in the user list.
+	Comma-separated list of shells of users that shouldn't
+	show up in the user list.
 	Default value is empty.
 
 `RememberLastUser=`


### PR DESCRIPTION
Explain that the lists of users/shells should be comma-separated. When I was editing my sddm.conf, I found this quite unobvious, especially since it appeared directly under the colon-separated DefaultPath. I'd also suggest changing the default sddm.conf to reflect this, but that is added by the Fedora packager, in my case. I'll file there, too.