### PR TITLE
Switch ZSH to sh emulation mode after sourcing zlogin/zprofile

### DIFF
--- a/data/scripts/Xsession
+++ b/data/scripts/Xsession
@@ -22,7 +22,6 @@ case $SHELL in
     ;;
   */zsh)
     [ -z "$ZSH_NAME" ] && exec $SHELL $0 "$@"
-    emulate -R sh
     [ -d /etc/zsh ] && zdir=/etc/zsh || zdir=/etc
     zhome=${ZDOTDIR:-$HOME}
     # zshenv is always sourced automatically.
@@ -30,6 +29,7 @@ case $SHELL in
     [ -f $zhome/.zprofile ] && . $zhome/.zprofile
     [ -f $zdir/zlogin ] && . $zdir/zlogin
     [ -f $zhome/.zlogin ] && . $zhome/.zlogin
+    emulate -R sh
     ;;
   */csh|*/tcsh)
     # [t]cshrc is always sourced automatically.


### PR DESCRIPTION
The Xsession helper script used to switch ZSHs sh emultaion mode before
sourcing the zlogin and zprofile. This caused the imports to fail if
either of the files contained ZSH specific syntax. Which in turn lead to
the session failing to start as the environment would not be setup
correctly.

This was observed with on Archlinux with SDDM 0.11.0 and KDE4/Plasma5.
ZSH was the set as login shell and Prezto ZSH configuration was
installed. In this setup the startkde script failed; the PATH was not
setup due to the sourcing failure, and the startkde script couldn't find
the utilities it needed.

Signed-off-by: Kaushal M <kshlmster@gmail.com>