### PR TITLE
Install 'sddm.service' in 'graphical.target'.

### DIFF
--- a/services/sddm.service.in
+++ b/services/sddm.service.in
@@ -11,4 +11,4 @@ Restart=always
 
 [Install]
 Alias=display-manager.service
-
+WantedBy=graphical.target


### PR DESCRIPTION
sddm didn't start for me anymore on bootup - the explanation was actually rather straight-forward.
I wonder how we missed this so far ;)