### PR TITLE
Set PAM_XDISPLAY only if defined

### DIFF
--- a/src/helper/backend/PamBackend.cpp
+++ b/src/helper/backend/PamBackend.cpp
@@ -251,7 +251,9 @@ namespace SDDM {
         QProcessEnvironment sessionEnv = m_app->session()->processEnvironment();
         QString display = sessionEnv.value("DISPLAY");
         if (!display.isEmpty()) {
+#ifdef PAM_XDISPLAY
             m_pam->setItem(PAM_XDISPLAY, qPrintable(display));
+#endif
             m_pam->setItem(PAM_TTY, qPrintable(display));
         }
         if (!m_pam->putEnv(sessionEnv)) {


### PR DESCRIPTION
PAM_XDISPLAY is Linux-PAM specific and cause build failures on *BSD.

Closes: #353