### PR TITLE
handle merge of libsystemd-journal -> libsystemd for systemd >= 209

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,12 @@ if(SYSTEMD_FOUND)
     add_definitions(-DHAVE_SYSTEMD)
     set(CMAKE_AUTOMOC_MOC_OPTIONS -DHAVE_SYSTEMD)
 
-    pkg_check_modules(JOURNALD "libsystemd-journal")
+    # libsystemd-journal was merged into libsystemd in 209
+    if(${SYSTEMD_VERSION} VERSION_LESS 209)
+        pkg_check_modules(JOURNALD "libsystemd-journal")
+    else()
+        pkg_check_modules(JOURNALD "libsystemd")
+    endif()
 
     if(ENABLE_JOURNALD)
         if(JOURNALD_FOUND)


### PR DESCRIPTION
see [1]:

'The APIs "sd-journal.h", "sd-login.h", "sd-id128.h", "sd-daemon.h" are no
longer found in individual libraries libsystemd-journal.so, , libsystemd-login.so,
libsystemd-id128.so, libsystemd-daemon.so. Instead, we have merged them into
a single library, libsystemd.so, which provides all symbols.

[1] http://cgit.freedesktop.org/systemd/systemd/tree/NEWS

Signed-off-by: Andreas Müller <schnitzeltony@googlemail.com>