### PR TITLE
Use X_PREFIX rather than hardcoded /usr.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,10 +25,6 @@ option(ENABLE_JOURNALD "Enable logging to journald" ON)
 # Definitions
 add_definitions(-Wall -std=c++11)
 
-if (${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
-    include_directories("${CMAKE_INSTALL_PREFIX}/include")
-endif()
-
 # Default build type
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)
@@ -70,6 +66,7 @@ endif()
 
 # XCB
 find_package(XCB REQUIRED)
+include_directories("${LIBXCB_INCLUDE_DIR}")
 
 # XKB
 find_package(XKB REQUIRED)
@@ -134,6 +131,10 @@ else()
     set(HALT_COMMAND "/sbin/shutdown -h -P now")
     set(REBOOT_COMMAND "/sbin/shutdown -r now")
 endif()
+
+# X components (xauth, xsessions, etc.)
+find_path(X_PREFIX "share/xsessions")
+
 
 # Set constants
 set(DATA_INSTALL_DIR            "${CMAKE_INSTALL_FULL_DATADIR}/sddm"                CACHE PATH      "System application data install directory")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,10 @@ option(ENABLE_JOURNALD "Enable logging to journald" ON)
 # Definitions
 add_definitions(-Wall -std=c++11)
 
+if (${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
+    include_directories("${CMAKE_INSTALL_PREFIX}/include")
+endif()
+
 # Default build type
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)

--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -53,10 +53,10 @@ namespace SDDM {
         );
         // TODO: Not absolutely sure if everything belongs here. Xsessions, VT and probably some more seem universal
         Section(XDisplay,
-            Entry(ServerPath,          QString,     _S("/usr/bin/X"),                           _S("X server path"));
-            Entry(XephyrPath,          QString,     _S("/usr/bin/Xephyr"),                      _S("Xephyr path"));
-            Entry(XauthPath,           QString,     _S("/usr/bin/xauth"),                       _S("Xauth path"));
-            Entry(SessionDir,          QString,     _S("/usr/share/xsessions"),                 _S("Session description directory"));
+            Entry(ServerPath,          QString,     _S(PREFIX "/bin/X"),                           _S("X server path"));
+            Entry(XephyrPath,          QString,     _S(PREFIX "/bin/Xephyr"),                      _S("Xephyr path"));
+            Entry(XauthPath,           QString,     _S(PREFIX "/bin/xauth"),                       _S("Xauth path"));
+            Entry(SessionDir,          QString,     _S(PREFIX "/share/xsessions"),                 _S("Session description directory"));
             Entry(SessionCommand,      QString,     _S(SESSION_COMMAND),                        _S("Xsession script path\n"
                                                                                                    "A script to execute when starting the desktop session"));
             Entry(DisplayCommand,      QString,     _S(DATA_INSTALL_DIR "/scripts/Xsetup"),     _S("Xsetup script path\n"

--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -53,10 +53,10 @@ namespace SDDM {
         );
         // TODO: Not absolutely sure if everything belongs here. Xsessions, VT and probably some more seem universal
         Section(XDisplay,
-            Entry(ServerPath,          QString,     _S(PREFIX "/bin/X"),                           _S("X server path"));
-            Entry(XephyrPath,          QString,     _S(PREFIX "/bin/Xephyr"),                      _S("Xephyr path"));
-            Entry(XauthPath,           QString,     _S(PREFIX "/bin/xauth"),                       _S("Xauth path"));
-            Entry(SessionDir,          QString,     _S(PREFIX "/share/xsessions"),                 _S("Session description directory"));
+            Entry(ServerPath,          QString,     _S(X_PREFIX "/bin/X"),                           _S("X server path"));
+            Entry(XephyrPath,          QString,     _S(X_PREFIX "/bin/Xephyr"),                      _S("Xephyr path"));
+            Entry(XauthPath,           QString,     _S(X_PREFIX "/bin/xauth"),                       _S("Xauth path"));
+            Entry(SessionDir,          QString,     _S(X_PREFIX "/share/xsessions"),                 _S("Session description directory"));
             Entry(SessionCommand,      QString,     _S(SESSION_COMMAND),                        _S("Xsession script path\n"
                                                                                                    "A script to execute when starting the desktop session"));
             Entry(DisplayCommand,      QString,     _S(DATA_INSTALL_DIR "/scripts/Xsetup"),     _S("Xsetup script path\n"

--- a/src/common/Constants.h.in
+++ b/src/common/Constants.h.in
@@ -20,7 +20,7 @@
 #ifndef SDDM_CONSTANTS_H
 #define SDDM_CONSTANTS_H
 
-#define PREFIX                      "@CMAKE_INSTALL_PREFIX@"
+#define X_PREFIX                    "@X_PREFIX@"
 
 #define BIN_INSTALL_DIR             "@CMAKE_INSTALL_FULL_BINDIR@"
 #define LIBEXEC_INSTALL_DIR         "@CMAKE_INSTALL_FULL_LIBEXECDIR@"

--- a/src/common/Constants.h.in
+++ b/src/common/Constants.h.in
@@ -20,6 +20,8 @@
 #ifndef SDDM_CONSTANTS_H
 #define SDDM_CONSTANTS_H
 
+#define PREFIX                      "@CMAKE_INSTALL_PREFIX@"
+
 #define BIN_INSTALL_DIR             "@CMAKE_INSTALL_FULL_BINDIR@"
 #define LIBEXEC_INSTALL_DIR         "@CMAKE_INSTALL_FULL_LIBEXECDIR@"
 #define DATA_INSTALL_DIR            "@DATA_INSTALL_DIR@"


### PR DESCRIPTION
On the BSDs, non-base-system binaries are found in `/usr/local/bin`
and most header files are found in `/usr/local/include`. CMake exposes
this platform detail as `${CMAKE_INSTALL_PREFIX}`, so let's use it to make
SDDM a bit more cross-platform.