### PR TITLE
Add support for the DisplayStopCommand entry

### DIFF
--- a/data/man/sddm.conf.rst.in
+++ b/data/man/sddm.conf.rst.in
@@ -85,6 +85,10 @@ OPTIONS
 	Path of script to execute when starting the display server.
 	Default value is "@DATA_INSTALL_DIR@/scripts/Xsetup".
 
+`DisplayStopCommand=`
+	Path of script to execute when stopping the display server.
+	Default value is "@DATA_INSTALL_DIR@/scripts/Xsetup".
+
 `MinimumVT=`
 	Minimum virtual terminal number that will be used
 	by the first display. Virtual terminal number will

--- a/data/scripts/Xstop
+++ b/data/scripts/Xstop
@@ -1,0 +1,2 @@
+#!/bin/sh
+# Xstop - run as root after stopping X

--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -61,6 +61,8 @@ namespace SDDM {
                                                                                                    "A script to execute when starting the desktop session"));
             Entry(DisplayCommand,      QString,     _S(DATA_INSTALL_DIR "/scripts/Xsetup"),     _S("Xsetup script path\n"
                                                                                                    "A script to execute when starting the display server"));
+            Entry(DisplayStopCommand,  QString,     _S(DATA_INSTALL_DIR "/scripts/Xstop"),      _S("Xstop script path\n"
+                                                                                                   "A script to execute when stopping the display server"));
             Entry(MinimumVT,           int,         MINIMUM_VT,                                 _S("Minimum VT\n"
                                                                                                    "The lowest virtual terminal number that will be used."));
         );

--- a/src/daemon/XorgDisplayServer.cpp
+++ b/src/daemon/XorgDisplayServer.cpp
@@ -250,6 +250,14 @@ namespace SDDM {
         qDebug() << "Running display stop script " << displayStopCommand;
         displayStopScript->start(displayStopCommand);
 
+        // wait for finished
+        if (!displayStopScript->waitForFinished(5000))
+            displayStopScript->kill();
+
+        // clean up the script process
+        displayStopScript->deleteLater();
+        displayStopScript = nullptr;
+
         // clean up
         process->deleteLater();
         process = nullptr;
@@ -275,6 +283,9 @@ namespace SDDM {
         env.insert("XAUTHORITY", m_authPath);
         env.insert("SHELL", "/bin/sh");
         displayScript->setProcessEnvironment(env);
+
+        // delete displayScript on finish
+        connect(displayScript, SIGNAL(finished(int,QProcess::ExitStatus)), displayScript, SLOT(deleteLater()));
 
         // start display setup script
         qDebug() << "Running display setup script " << displayCommand;

--- a/src/daemon/XorgDisplayServer.cpp
+++ b/src/daemon/XorgDisplayServer.cpp
@@ -233,6 +233,23 @@ namespace SDDM {
         // log message
         qDebug() << "Display server stopped.";
 
+        QString displayStopCommand = mainConfig.XDisplay.DisplayStopCommand.get();
+
+        // create display setup script process
+        QProcess *displayStopScript = new QProcess();
+
+        // set process environment
+        QProcessEnvironment env;
+        env.insert("DISPLAY", m_display);
+        env.insert("HOME", "/");
+        env.insert("PATH", mainConfig.Users.DefaultPath.get());
+        env.insert("SHELL", "/bin/sh");
+        displayStopScript->setProcessEnvironment(env);
+
+        // start display setup script
+        qDebug() << "Running display stop script " << displayStopCommand;
+        displayStopScript->start(displayStopCommand);
+
         // clean up
         process->deleteLater();
         process = nullptr;


### PR DESCRIPTION
The DisplayStopCommand entry allows executing a script right after stopping X.

This is relevant to the following feature request:
https://github.com/sddm/sddm/issues/393