### PR TITLE
add comments, should sddm user be hardcoded ?

### DIFF
--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -81,6 +81,7 @@ namespace SDDM {
         );
     );
 
+                                                 // is this a default value?
     Config(StateConfig, []()->QString{auto tmp = getpwnam("sddm"); return tmp ? tmp->pw_dir : STATE_DIR;}().append("/state.conf"),
         Section(Last,
             Entry(Session,         QString,     QString(),                                  _S("Name of the session file of the last session selected. This session will be preselected when the login screen shows up."));

--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -134,6 +134,7 @@ namespace SDDM {
 
         if (!daemonApp->testing()) {
             // change the owner and group of the socket to avoid permission denied errors
+            // TODO: sddm user is supposed to be configurable
             struct passwd *pw = getpwnam("sddm");
             if (pw) {
                 if (chown(qPrintable(m_socketServer->socketAddress()), pw->pw_uid, pw->pw_gid) == -1) {

--- a/src/daemon/XorgDisplayServer.cpp
+++ b/src/daemon/XorgDisplayServer.cpp
@@ -266,6 +266,7 @@ namespace SDDM {
 
     void XorgDisplayServer::changeOwner(const QString &fileName) {
         // change the owner and group of the auth file to the sddm user
+        // TODO: sddm user is supposed to be configurable
         struct passwd *pw = getpwnam("sddm");
         if (!pw)
             qWarning() << "Failed to find the sddm user. Owner of the auth file will not be changed.";


### PR DESCRIPTION
Questions in relation with issue #371 

I wonder if those 3 occurrence of *sddm* should be hardcoded like that?
or fetch from config?

also, getpwnam is probably inexpensive but we are doing it 5 times.
should it get encapsulated?

