### PR TITLE
Install scripts/Xstop now that the script is available

### DIFF
--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -3,7 +3,7 @@ install(DIRECTORY   "flags"                             DESTINATION "${DATA_INST
 
 install(FILES "org.freedesktop.DisplayManager.conf"       DESTINATION "${DBUS_CONFIG_DIR}")
 
-install(FILES "scripts/Xsession" "scripts/Xsetup" DESTINATION "${DATA_INSTALL_DIR}/scripts"
+install(FILES "scripts/Xsession" "scripts/Xsetup" "scripts/Xstop" DESTINATION "${DATA_INSTALL_DIR}/scripts"
         PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
         GROUP_READ GROUP_EXECUTE
         WORLD_READ WORLD_EXECUTE)


### PR DESCRIPTION
This actually installs the Xstop script that is now part of sddm as per #395. Sorry I didn't spot it before.