### PR TITLE
allow changing the dbus config file name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,6 +141,7 @@ set(SESSION_COMMAND             "${DATA_INSTALL_DIR}/scripts/Xsession"          
 
 set(CONFIG_FILE                 "${CMAKE_INSTALL_FULL_SYSCONFDIR}/sddm.conf"        CACHE PATH      "Path of the sddm config file")
 set(LOG_FILE                    "${CMAKE_INSTALL_FULL_LOCALSTATEDIR}/log/sddm.log"  CACHE PATH      "Path of the sddm log file")
+set(DBUS_CONFIG_FILENAME        "org.freedesktop.DisplayManager.conf"               CACHE STRING    "Name of the sddm config file")
 set(COMPONENTS_TRANSLATION_DIR  "${DATA_INSTALL_DIR}/translations"                  CACHE PATH      "Components translations directory")
 
 # Add subdirectories

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -1,7 +1,7 @@
 install(DIRECTORY   "faces"                             DESTINATION "${DATA_INSTALL_DIR}")
 install(DIRECTORY   "flags"                             DESTINATION "${DATA_INSTALL_DIR}")
 
-install(FILES "org.freedesktop.DisplayManager.conf"       DESTINATION "${DBUS_CONFIG_DIR}")
+install(FILES "org.freedesktop.DisplayManager.conf"     DESTINATION "${DBUS_CONFIG_DIR}" RENAME ${DBUS_CONFIG_FILENAME})
 
 install(FILES "scripts/Xsession" "scripts/Xsetup" "scripts/Xstop" DESTINATION "${DATA_INSTALL_DIR}/scripts"
         PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE


### PR DESCRIPTION
on some distributions the generic name of the dbus config might be provided
by more than one display manager, so always installing with the generic
name would require distributions to hard-patch the cmake code.
allowing to change it through a cmake cache variable enables distributions
to simply parameterize in their cmake call.

this for example affects Ubuntu where the config would be provided by both
SDDM and LightDM.