### PR TITLE
pbis-open support and manually login

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,7 @@ else()
 endif()
 
 # systemd
-pkg_check_modules(SYSTEMD "libsystemd-daemon")
+pkg_check_modules(SYSTEMD "systemd")
 
 if(SYSTEMD_FOUND)
     execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE} --variable=systemdsystemunitdir systemd OUTPUT_VARIABLE SYSTEMD_SYSTEM_UNIT_DIR)

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -8,6 +8,7 @@ Commit counts have ben removed, since they change pretty frequently.
 Abdurrahman AVCI <abdurrahmanavci@gmail.com>
 Reza Fatahilah Shah <rshah0385@kireihana.com>
 Andrea Scarpino <andrea@archlinux.org>
+Aaron Seigo <aseigo@kde.org>
 Kuzma Shapran <kuzma.shapran@gmail.com>
 Andreas Sturmlechner <andreas.sturmlechner@gmail.com>
 Cochise César <cochisecesar@gmail.com>

--- a/components/1.1/Clock.qml
+++ b/components/1.1/Clock.qml
@@ -29,7 +29,8 @@ Column {
 
     property date dateTime: new Date()
     property color color: "white"
-    property string font: ""
+    property alias timeFont: time.font
+    property alias dateFont: date.font
 
     Timer {
         interval: 100; running: true; repeat: true;
@@ -44,7 +45,7 @@ Column {
 
         text : Qt.formatTime(container.dateTime, "hh:mm")
 
-        font.family: container.font; font.pointSize: 72
+        font.pointSize: 72
     }
 
     Text {
@@ -55,6 +56,6 @@ Column {
 
         text : Qt.formatDate(container.dateTime, "dddd, MMM dd")
 
-        font.family: container.font; font.pointSize: 24
+        font.pointSize: 24
     }
 }

--- a/components/2.0/Clock.qml
+++ b/components/2.0/Clock.qml
@@ -29,7 +29,8 @@ Column {
 
     property date dateTime: new Date()
     property color color: "white"
-    property string font: ""
+    property alias timeFont: time.font
+    property alias dateFont: date.font
 
     Timer {
         interval: 100; running: true; repeat: true;
@@ -44,7 +45,7 @@ Column {
 
         text : Qt.formatTime(container.dateTime, "hh:mm")
 
-        font.family: container.font; font.pointSize: 72
+        font.pointSize: 72
     }
 
     Text {
@@ -55,6 +56,6 @@ Column {
 
         text : Qt.formatDate(container.dateTime, "dddd, MMM dd")
 
-        font.family: container.font; font.pointSize: 24
+        font.pointSize: 24
     }
 }

--- a/data/sddm.conf.in
+++ b/data/sddm.conf.in
@@ -13,7 +13,7 @@ ServerPath=/usr/bin/X
 XauthPath=/usr/bin/xauth
 
 # Path of the directory to create auth files in
-AuthPath=/var/run/xauth
+AuthDir=/var/run/xauth
 
 # Halt and reboot commands
 HaltCommand=@HALT_COMMAND@

--- a/data/themes/maldives/Main.qml
+++ b/data/themes/maldives/Main.qml
@@ -66,7 +66,7 @@ Rectangle {
             anchors.top: parent.top; anchors.right: parent.right
 
             color: "white"
-            font: clockFont.name
+            timeFont.family: clockFont.name
         }
 
         Image {

--- a/data/themes/maui/Main.qml
+++ b/data/themes/maui/Main.qml
@@ -92,7 +92,7 @@ Rectangle {
                     id: clock
                     anchors.centerIn: parent
                     color: "white"
-                    font: clockFont.name
+                    timeFont.family: clockFont.name
                 }
             }
 

--- a/services/CMakeLists.txt
+++ b/services/CMakeLists.txt
@@ -1,5 +1,6 @@
 if(SYSTEMD_FOUND)
-        install(FILES sddm.systemd DESTINATION ${SYSTEMD_SYSTEM_UNIT_DIR} RENAME sddm.service)
+        configure_file(${CMAKE_CURRENT_SOURCE_DIR}/sddm.systemd.in ${CMAKE_CURRENT_BINARY_DIR}/sddm.systemd)
+        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/sddm.systemd DESTINATION ${SYSTEMD_SYSTEM_UNIT_DIR} RENAME sddm.service)
 endif()
 
 install(FILES sddm.pam DESTINATION /etc/pam.d RENAME sddm)

--- a/services/sddm.systemd.in
+++ b/services/sddm.systemd.in
@@ -3,7 +3,7 @@ Description=Simple Desktop Display Manager
 After=systemd-user-sessions.service
 
 [Service]
-ExecStart=/usr/bin/sddm
+ExecStart=@BIN_INSTALL_DIR@/sddm
 
 [Install]
 Alias=display-manager.service

--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -36,7 +36,7 @@ namespace SDDM {
 
         QString xauthPath { "" };
 
-        QString authPath { "" };
+        QString authDir { "" };
 
         QString haltCommand { "" };
         QString rebootCommand { "" };
@@ -80,7 +80,7 @@ namespace SDDM {
         d->defaultPath = settings.value("DefaultPath", "").toString();
         d->serverPath = settings.value("ServerPath", "").toString();
         d->xauthPath = settings.value("XauthPath", "").toString();
-        d->authPath = settings.value("AuthPath", "").toString();
+        d->authDir = settings.value("AuthDir", "").toString();
         d->haltCommand = settings.value("HaltCommand", "").toString();
         d->rebootCommand = settings.value("RebootCommand", "").toString();
         d->sessionsDir = settings.value("SessionsDir", "").toString();
@@ -105,7 +105,7 @@ namespace SDDM {
         settings.setValue("DefaultPath", d->defaultPath);
         settings.setValue("ServerPath", d->serverPath);
         settings.setValue("XauthPath", d->xauthPath);
-        settings.setValue("AuthPath", d->authPath);
+        settings.setValue("AuthDir", d->authDir);
         settings.setValue("HaltCommand", d->haltCommand);
         settings.setValue("RebootCommand", d->rebootCommand);
         settings.setValue("SessionsDir", d->sessionsDir);
@@ -142,8 +142,8 @@ namespace SDDM {
         return d->xauthPath;
     }
 
-    const QString &Configuration::authPath() const {
-        return d->authPath;
+    const QString &Configuration::authDir() const {
+        return d->authDir;
     }
 
     const QString &Configuration::haltCommand() const {

--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -91,7 +91,7 @@ namespace SDDM {
         d->themesDir = settings.value("ThemesDir", "").toString();
         d->currentTheme = settings.value("CurrentTheme", "").toString();
         d->minimumUid = settings.value("MinimumUid", "0").toInt();
-        d->maximumUid = settings.value("MaximumUid", "0").toInt();
+        d->maximumUid = settings.value("MaximumUid", "65000").toInt();
         d->rememberLastUser = settings.value("RememberLastUser", d->rememberLastUser).toBool();
         d->lastUser = settings.value("LastUser", "").toString();
         d->autoUser = settings.value("AutoUser", "").toString();

--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -47,7 +47,7 @@ namespace SDDM {
 
         const QString &xauthPath() const;
 
-        const QString &authPath() const;
+        const QString &authDir() const;
 
         const QString &haltCommand() const;
         const QString &rebootCommand() const;

--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -65,12 +65,12 @@ namespace SDDM {
         connect(this, SIGNAL(loginSucceeded(QLocalSocket*)), m_socketServer, SLOT(loginSucceeded(QLocalSocket*)));
 
 #if !TEST
-        // create auth path if not existing
-        QDir dir;
-        dir.mkpath(Configuration::instance()->authPath());
+        // create auth dir if not existing
+        QDir authDir;
+        authDir.mkpath(Configuration::instance()->authDir());
 
         // set auth path
-        m_authPath = QString("%1/A%2-%3").arg(Configuration::instance()->authPath()).arg(m_display).arg(generateName(6));
+        m_authPath = QString("%1/A%2-%3").arg(Configuration::instance()->authDir()).arg(m_display).arg(generateName(6));
 #else
         // set auth path
         m_authPath = "./sddm.auth";


### PR DESCRIPTION
It would be great if sddm would support pbis-open. Also a field to login manually when pbis-open would be supported. Because if there a hundreds of persons it would be terrible to search a personal name.

And also a gui for plasma to configure all this. Last but not least a scrollbar when there a multiple users infront of sddm. It is not funny when you can see four users and when you don't know that you must scroll to see further user logins.