### PR TITLE
Read session desktop entries with Session and pass it upon login

### DIFF
--- a/src/common/Session.h
+++ b/src/common/Session.h
@@ -1,0 +1,94 @@
+/***************************************************************************
+* Copyright (c) 2015 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 2 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, write to the
+* Free Software Foundation, Inc.,
+* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+***************************************************************************/
+
+#ifndef SDDM_SESSION_H
+#define SDDM_SESSION_H
+
+#include <QDataStream>
+#include <QDir>
+#include <QSharedPointer>
+
+namespace SDDM {
+    class SessionModel;
+
+    class Session {
+    public:
+        enum Type {
+            UnknownSession = 0,
+            X11Session,
+            WaylandSession
+        };
+
+        explicit Session();
+        Session(Type type, const QString &fileName);
+
+        bool isValid() const;
+
+        Type type() const;
+
+        QString xdgSessionType() const;
+
+        QDir directory() const;
+        QString fileName() const;
+
+        QString displayName() const;
+        QString comment() const;
+
+        QString exec() const;
+        QString tryExec() const;
+
+        QString desktopSession() const;
+        QString desktopNames() const;
+
+        void setTo(Type type, const QString &name);
+
+        Session &operator=(const Session &other);
+
+    private:
+        bool m_valid;
+        Type m_type;
+        QDir m_dir;
+        QString m_name;
+        QString m_fileName;
+        QString m_displayName;
+        QString m_comment;
+        QString m_exec;
+        QString m_tryExec;
+        QString m_xdgSessionType;
+        QString m_desktopNames;
+
+        friend class SessionModel;
+    };
+
+    inline QDataStream &operator<<(QDataStream &stream, const Session &session) {
+        const quint32 type = static_cast<quint32>(session.type());
+        stream << type << session.fileName();
+        return stream;
+    }
+
+    inline QDataStream &operator>>(QDataStream &stream, Session &session) {
+        quint32 type;
+        QString fileName;
+        stream >> type >> fileName;
+        session.setTo(static_cast<Session::Type>(type), fileName);
+        return stream;
+    }
+}
+
+#endif // SDDM_SESSION_H

--- a/src/common/SocketWriter.cpp
+++ b/src/common/SocketWriter.cpp
@@ -1,4 +1,5 @@
 /***************************************************************************
+* Copyright (c) 2015 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
 * Copyright (c) 2013 Abdurrahman AVCI <abdurrahmanavci@gmail.com>
 *
 * This program is free software; you can redistribute it and/or modify
@@ -38,6 +39,12 @@ namespace SDDM {
     }
 
     SocketWriter &SocketWriter::operator << (const QString &s) {
+        *output << s;
+
+        return *this;
+    }
+
+    SocketWriter &SocketWriter::operator << (const Session &s) {
         *output << s;
 
         return *this;

--- a/src/common/SocketWriter.h
+++ b/src/common/SocketWriter.h
@@ -1,4 +1,5 @@
 /***************************************************************************
+* Copyright (c) 2015 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
 * Copyright (c) 2013 Abdurrahman AVCI <abdurrahmanavci@gmail.com>
 *
 * This program is free software; you can redistribute it and/or modify
@@ -23,6 +24,8 @@
 #include <QDataStream>
 #include <QLocalSocket>
 
+#include "Session.h"
+
 namespace SDDM {
     class SocketWriter {
         Q_DISABLE_COPY(SocketWriter)
@@ -32,6 +35,7 @@ namespace SDDM {
 
         SocketWriter &operator << (const quint32 &u);
         SocketWriter &operator << (const QString &s);
+        SocketWriter &operator << (const Session &s);
 
     private:
         QByteArray data;

--- a/src/daemon/CMakeLists.txt
+++ b/src/daemon/CMakeLists.txt
@@ -8,6 +8,7 @@ set(DAEMON_SOURCES
     ${CMAKE_SOURCE_DIR}/src/common/Configuration.cpp
     ${CMAKE_SOURCE_DIR}/src/common/SafeDataStream.cpp
     ${CMAKE_SOURCE_DIR}/src/common/ConfigReader.cpp
+    ${CMAKE_SOURCE_DIR}/src/common/Session.cpp
     ${CMAKE_SOURCE_DIR}/src/common/SocketWriter.cpp
     ${CMAKE_SOURCE_DIR}/src/auth/Auth.cpp
     ${CMAKE_SOURCE_DIR}/src/auth/AuthPrompt.cpp

--- a/src/daemon/Display.h
+++ b/src/daemon/Display.h
@@ -1,5 +1,5 @@
 /***************************************************************************
-* Copyright (c) 2014 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+* Copyright (c) 2014-2015 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
 * Copyright (c) 2014 Martin Bříza <mbriza@redhat.com>
 * Copyright (c) 2013 Abdurrahman AVCI <abdurrahmanavci@gmail.com>
 *
@@ -23,8 +23,10 @@
 #define SDDM_DISPLAY_H
 
 #include <QObject>
+#include <QDir>
 
 #include "Auth.h"
+#include "Session.h"
 
 class QLocalSocket;
 
@@ -55,7 +57,9 @@ namespace SDDM {
         void start();
         void stop();
 
-        void login(QLocalSocket *socket, const QString &user, const QString &password, const QString &session);
+        void login(QLocalSocket *socket,
+                   const QString &user, const QString &password,
+                   const Session &session);
         void displayServerStarted();
 
     signals:
@@ -66,7 +70,10 @@ namespace SDDM {
 
     private:
         QString findGreeterTheme() const;
-        void startAuth(const QString &user, const QString &password, const QString &session);
+        bool findSessionEntry(const QDir &dir, const QString &name) const;
+
+        void startAuth(const QString &user, const QString &password,
+                       const Session &session);
 
         bool m_relogin { true };
         bool m_started { false };

--- a/src/daemon/SocketServer.cpp
+++ b/src/daemon/SocketServer.cpp
@@ -1,4 +1,5 @@
 /***************************************************************************
+* Copyright (c) 2015 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
 * Copyright (c) 2013 Abdurrahman AVCI <abdurrahmanavci@gmail.com>
 *
 * This program is free software; you can redistribute it and/or modify
@@ -132,7 +133,8 @@ namespace SDDM {
                 qDebug() << "Message received from greeter: Login";
 
                 // read username, pasword etc.
-                QString user, password, session;
+                QString user, password, filename;
+                Session session;
                 input >> user >> password >> session;
 
                 // emit signal

--- a/src/daemon/SocketServer.h
+++ b/src/daemon/SocketServer.h
@@ -1,4 +1,5 @@
 /***************************************************************************
+* Copyright (c) 2015 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
 * Copyright (c) 2013 Abdurrahman AVCI <abdurrahmanavci@gmail.com>
 *
 * This program is free software; you can redistribute it and/or modify
@@ -23,6 +24,8 @@
 #include <QObject>
 #include <QString>
 
+#include "Session.h"
+
 class QLocalServer;
 class QLocalSocket;
 
@@ -46,7 +49,9 @@ namespace SDDM {
         void loginSucceeded(QLocalSocket *socket);
 
     signals:
-        void login(QLocalSocket *socket, const QString &user, const QString &password, const QString &session);
+        void login(QLocalSocket *socket,
+                   const QString &user, const QString &password,
+                   const Session &session);
         void connected();
 
     private:

--- a/src/greeter/CMakeLists.txt
+++ b/src/greeter/CMakeLists.txt
@@ -4,6 +4,7 @@ include_directories("${CMAKE_BINARY_DIR}/src/common")
 set(GREETER_SOURCES
     ${CMAKE_SOURCE_DIR}/src/common/Configuration.cpp
     ${CMAKE_SOURCE_DIR}/src/common/ConfigReader.cpp
+    ${CMAKE_SOURCE_DIR}/src/common/Session.cpp
     ${CMAKE_SOURCE_DIR}/src/common/SocketWriter.cpp
     GreeterApp.cpp
     GreeterProxy.cpp

--- a/src/greeter/GreeterProxy.cpp
+++ b/src/greeter/GreeterProxy.cpp
@@ -1,4 +1,5 @@
 /***************************************************************************
+* Copyright (c) 2015 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
 * Copyright (c) 2013 Abdurrahman AVCI <abdurrahmanavci@gmail.com>
 *
 * This program is free software; you can redistribute it and/or modify
@@ -120,7 +121,10 @@ namespace SDDM {
         QModelIndex index = d->sessionModel->index(sessionIndex, 0);
 
         // send command to the daemon
-        SocketWriter(d->socket) << quint32(GreeterMessages::Login) << user << password << d->sessionModel->data(index, SessionModel::FileRole).toString();
+        Session::Type type = static_cast<Session::Type>(d->sessionModel->data(index, SessionModel::TypeRole).toInt());
+        QString name = d->sessionModel->data(index, SessionModel::FileRole).toString();
+        Session session(type, name);
+        SocketWriter(d->socket) << quint32(GreeterMessages::Login) << user << password << session;
     }
 
     void GreeterProxy::connected() {

--- a/src/greeter/SessionModel.h
+++ b/src/greeter/SessionModel.h
@@ -21,6 +21,8 @@
 #ifndef SDDM_SESSIONMODEL_H
 #define SDDM_SESSIONMODEL_H
 
+#include "Session.h"
+
 #include <QAbstractListModel>
 
 #include <QHash>
@@ -36,14 +38,10 @@ namespace SDDM {
         enum SessionRole {
             DirectoryRole = Qt::UserRole + 1,
             FileRole,
+            TypeRole,
             NameRole,
             ExecRole,
             CommentRole
-        };
-
-        enum SessionType {
-            X11Session = 0,
-            WaylandSession
         };
 
         SessionModel(QObject *parent = 0);
@@ -59,7 +57,7 @@ namespace SDDM {
     private:
         SessionModelPrivate *d { nullptr };
 
-        void populate(SessionType type, const QString &path);
+        void populate(Session::Type type, const QString &path);
     };
 }
 


### PR DESCRIPTION
The greeter knows where the session entry is located (either under the
X11 or Wayland sessions path) and so it must pass this information
to the daemon.

Add a class to represent a session in order to share this information
between daemon and greater allowing to know the exact location of
the session desktop entry.

Since a relative file name can be specified for autologin session,
we need to search the desktop entry and create a Session object
with the right type.

In the long run we might want to deal with absolute desktop entry
paths and do not allow relative paths or names without extention.

Issue: #419