### PR TITLE
Create X authorization after the Xorg server is started

### DIFF
--- a/src/daemon/XorgDisplayServer.cpp
+++ b/src/daemon/XorgDisplayServer.cpp
@@ -116,10 +116,6 @@ namespace SDDM {
         if (m_started)
             return false;
 
-        // generate auth file
-        addCookie(m_authPath);
-        changeOwner(m_authPath);
-
         // create process
         process = new QProcess(this);
 
@@ -198,6 +194,10 @@ namespace SDDM {
 
             emit started();
         }
+
+        // generate auth file
+        addCookie(m_authPath);
+        changeOwner(m_authPath);
 
         // set flag
         m_started = true;


### PR DESCRIPTION
Otherwise m_display is not yet set.

Issue: #390