### PR TITLE
wait for the display script to complete

### DIFF
--- a/src/daemon/XorgDisplayServer.cpp
+++ b/src/daemon/XorgDisplayServer.cpp
@@ -290,6 +290,7 @@ namespace SDDM {
         // start display setup script
         qDebug() << "Running display setup script " << displayCommand;
         displayScript->start(displayCommand);
+        displayScript->waitForFinished(-1);
     }
 
     void XorgDisplayServer::changeOwner(const QString &fileName) {


### PR DESCRIPTION
Received this from OpenMandriva: https://abf.io/openmandriva/sddm/blob/master/sddm-wait-for-display-script.patch

Not super sure about -1, I get it that we can't run the process async but waiting forever is probably not a good idea.

Thoughs @davidedmundson ?