### PR TITLE
Add ConsoleKit2 as a PowerManager backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ add_custom_target(dist COMMAND ${CMAKE_MAKE_PROGRAM} package_source)
 # Options
 option(BUILD_MAN_PAGES "Build man pages" OFF)
 option(ENABLE_JOURNALD "Enable logging to journald" ON)
+option(ENABLE_CONSOLEKIT2 "Enable ConsoleKit2 support" ON)
 
 # Definitions
 add_definitions(-Wall -std=c++11)
@@ -139,6 +140,11 @@ else()
     set(MINIMUM_VT 7)
     set(HALT_COMMAND "/sbin/shutdown -h -P now")
     set(REBOOT_COMMAND "/sbin/shutdown -r now")
+endif()
+
+if(ENABLE_CONSOLEKIT2)
+    add_definitions(-DHAVE_CONSOLEKIT2)
+    set(CMAKE_AUTOMOC_MOC_OPTIONS -DHAVE_CONSOLEKIT2)
 endif()
 
 # Set constants

--- a/INSTALL
+++ b/INSTALL
@@ -30,8 +30,8 @@ its home set to `/var/lib/sddm` by default.
 SDDM depends on PAM for authorization and XCB to communicate with the X server.
 Apart from other things, it also depends on Qt for the user interface and event
 loop management.
-SDDM can optionally make use of logind (the systemd login manager API) or
-upower to enable support for suspend, hibernate etc.
+SDDM can optionally make use of logind (the systemd login manager API), or
+ConsoleKit2, or upower to enable support for suspend, hibernate etc.
 In order to build the man pages, you will need `rst2man` installed. It is
 provided by the python `docutils` package
 

--- a/src/daemon/PowerManager.cpp
+++ b/src/daemon/PowerManager.cpp
@@ -117,9 +117,11 @@ namespace SDDM {
 #define LOGIN1_PATH     QStringLiteral("/org/freedesktop/login1")
 #define LOGIN1_OBJECT   QStringLiteral("org.freedesktop.login1.Manager")
 
+#ifdef HAVE_CONSOLEKIT2
 #define CK2_SERVICE  QStringLiteral("org.freedesktop.ConsoleKit")
 #define CK2_PATH     QStringLiteral("/org/freedesktop/ConsoleKit/Manager")
 #define CK2_OBJECT   QStringLiteral("org.freedesktop.ConsoleKit.Manager")
+#endif // HAVE_CONSOLEKIT2
 
     class SeatManagerBackend : public PowerManagerBackend {
     public:
@@ -200,9 +202,11 @@ namespace SDDM {
         if (interface->isServiceRegistered(LOGIN1_SERVICE))
             m_backends << new SeatManagerBackend(LOGIN1_SERVICE, LOGIN1_PATH, LOGIN1_OBJECT);
 
+#ifdef HAVE_CONSOLEKIT2
         // check if ConsoleKit2 interface exists
         if (interface->isServiceRegistered(CK2_SERVICE))
             m_backends << new SeatManagerBackend(CK2_SERVICE, CK2_PATH, CK2_OBJECT);
+#endif // HAVE_CONSOLEKIT2
 
         // check if upower interface exists
         if (interface->isServiceRegistered(UPOWER_SERVICE))

--- a/src/daemon/PowerManager.cpp
+++ b/src/daemon/PowerManager.cpp
@@ -59,8 +59,8 @@ namespace SDDM {
 
     class UPowerBackend : public PowerManagerBackend {
     public:
-        UPowerBackend() {
-            m_interface = new QDBusInterface(UPOWER_SERVICE, UPOWER_PATH, UPOWER_OBJECT, QDBusConnection::systemBus());
+        UPowerBackend(const QString & service, const QString & path, const QString & interface) {
+            m_interface = new QDBusInterface(service, path, interface, QDBusConnection::systemBus());
         }
 
         ~UPowerBackend() {
@@ -110,20 +110,24 @@ namespace SDDM {
     };
 
     /**********************************************/
-    /* LOGIN1 BACKEND                             */
+    /* LOGIN1 && ConsoleKit2 BACKEND              */
     /**********************************************/
 
 #define LOGIN1_SERVICE  QStringLiteral("org.freedesktop.login1")
 #define LOGIN1_PATH     QStringLiteral("/org/freedesktop/login1")
 #define LOGIN1_OBJECT   QStringLiteral("org.freedesktop.login1.Manager")
 
-    class Login1Backend : public PowerManagerBackend {
+#define CK2_SERVICE  QStringLiteral("org.freedesktop.ConsoleKit")
+#define CK2_PATH     QStringLiteral("/org/freedesktop/ConsoleKit/Manager")
+#define CK2_OBJECT   QStringLiteral("org.freedesktop.ConsoleKit.Manager")
+
+    class SeatManagerBackend : public PowerManagerBackend {
     public:
-        Login1Backend() {
-            m_interface = new QDBusInterface(LOGIN1_SERVICE, LOGIN1_PATH, LOGIN1_OBJECT, QDBusConnection::systemBus());
+        SeatManagerBackend(const QString & service, const QString & path, const QString & interface) {
+            m_interface = new QDBusInterface(service, path, interface, QDBusConnection::systemBus());
         }
 
-        ~Login1Backend() {
+        ~SeatManagerBackend() {
             delete m_interface;
         }
 
@@ -194,11 +198,15 @@ namespace SDDM {
 
         // check if login1 interface exists
         if (interface->isServiceRegistered(LOGIN1_SERVICE))
-            m_backends << new Login1Backend();
+            m_backends << new SeatManagerBackend(LOGIN1_SERVICE, LOGIN1_PATH, LOGIN1_OBJECT);
+
+        // check if ConsoleKit2 interface exists
+        if (interface->isServiceRegistered(CK2_SERVICE))
+            m_backends << new SeatManagerBackend(CK2_SERVICE, CK2_PATH, CK2_OBJECT);
 
         // check if upower interface exists
         if (interface->isServiceRegistered(UPOWER_SERVICE))
-            m_backends << new UPowerBackend();
+            m_backends << new UPowerBackend(UPOWER_SERVICE, UPOWER_PATH, UPOWER_OBJECT);
     }
 
     PowerManager::~PowerManager() {


### PR DESCRIPTION
This optionally adds ConsoleKit2 as a PowerManager backend (via an ENABLE_CONSOLEKIT2 cmake option). It uses the same DBUS API as logind and turns it into a shared seat manager backend.