### PR TITLE
Honor the screen available geometry

### DIFF
--- a/src/greeter/GreeterApp.cpp
+++ b/src/greeter/GreeterApp.cpp
@@ -166,7 +166,7 @@ namespace SDDM {
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 4, 0))
         // always resize when the screen geometry changes
         connect(screen, &QScreen::availableGeometryChanged, this, [view](const QRect &r) {
-            view->setGeometry(QRect(QPoint(0, 0), r.size()));
+            view->setGeometry(r);
         });
 #endif
 


### PR DESCRIPTION
Using 0,0 coordinates was wrong and caused additional windows to always
cover the first one when a screen was resized.