### PR TITLE
Fix login with UTF-8 user names

### DIFF
--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -337,11 +337,11 @@ namespace SDDM {
 
     void Display::slotRequestChanged() {
         if (m_auth->request()->prompts().length() == 1) {
-            m_auth->request()->prompts()[0]->setResponse(qPrintable(m_passPhrase));
+            m_auth->request()->prompts()[0]->setResponse(qUtf8Printable(m_passPhrase));
             m_auth->request()->done();
         } else if (m_auth->request()->prompts().length() == 2) {
-            m_auth->request()->prompts()[0]->setResponse(qPrintable(m_auth->user()));
-            m_auth->request()->prompts()[1]->setResponse(qPrintable(m_passPhrase));
+            m_auth->request()->prompts()[0]->setResponse(qUtf8Printable(m_auth->user()));
+            m_auth->request()->prompts()[1]->setResponse(qUtf8Printable(m_passPhrase));
             m_auth->request()->done();
         }
     }

--- a/src/helper/Backend.cpp
+++ b/src/helper/Backend.cpp
@@ -54,7 +54,7 @@ namespace SDDM {
 
     bool Backend::openSession() {
         struct passwd *pw;
-        pw = getpwnam(qPrintable(qobject_cast<HelperApp*>(parent())->user()));
+        pw = getpwnam(qUtf8Printable(qobject_cast<HelperApp*>(parent())->user()));
         if (pw) {
             QProcessEnvironment env = m_app->session()->processEnvironment();
             env.insert("HOME", pw->pw_dir);

--- a/src/helper/UserSession.cpp
+++ b/src/helper/UserSession.cpp
@@ -110,7 +110,7 @@ namespace SDDM {
             }
         }
 
-        const char  *username = qobject_cast<HelperApp*>(parent())->user().toLocal8Bit();
+        const char *username = qUtf8Printable(qobject_cast<HelperApp*>(parent())->user());
         struct passwd *pw = getpwnam(username);
         if (setgid(pw->pw_gid) != 0) {
             qCritical() << "setgid(" << pw->pw_gid << ") failed for user: " << username;

--- a/src/helper/backend/PamHandle.cpp
+++ b/src/helper/backend/PamHandle.cpp
@@ -142,7 +142,7 @@ namespace SDDM {
         if (user.isEmpty())
             m_result = pam_start(qPrintable(service), NULL, &m_conv, &m_handle);
         else
-            m_result = pam_start(qPrintable(service), qPrintable(user), &m_conv, &m_handle);
+            m_result = pam_start(qPrintable(service), qUtf8Printable(user), &m_conv, &m_handle);
         if (m_result != PAM_SUCCESS) {
             qWarning() << "[PAM] start" << pam_strerror(m_handle, m_result);
             return false;

--- a/src/helper/backend/PasswdBackend.cpp
+++ b/src/helper/backend/PasswdBackend.cpp
@@ -66,7 +66,7 @@ namespace SDDM {
             }
         }
 
-        struct passwd *pw = getpwnam(qPrintable(m_user));
+        struct passwd *pw = getpwnam(qUtf8Printable(m_user));
         if (!pw) {
             m_app->error(QString("Wrong user/password combination"), Auth::ERROR_AUTHENTICATION);
             return false;
@@ -81,7 +81,7 @@ namespace SDDM {
         if(!spw->sp_pwdp || !spw->sp_pwdp[0])
             return true;
 
-        char *crypted = crypt(qPrintable(password), spw->sp_pwdp);
+        char *crypted = crypt(qUtf8Printable(password), spw->sp_pwdp);
         if (0 == strcmp(crypted, spw->sp_pwdp)) {
             return true;
         }


### PR DESCRIPTION
Passing user names to C functions using qPrintable() discards UTF-8
characters, better use qUtf8Printable() instead.

Closes #365