### PR TITLE
enable QT_NO_CAST_FROM_ASCII

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ option(BUILD_MAN_PAGES "Build man pages" OFF)
 option(ENABLE_JOURNALD "Enable logging to journald" ON)
 
 # Definitions
-add_definitions(-Wall -std=c++11)
+add_definitions(-Wall -std=c++11 -DQT_NO_CAST_FROM_ASCII)
 
 # Default build type
 if(NOT CMAKE_BUILD_TYPE)

--- a/src/auth/Auth.cpp
+++ b/src/auth/Auth.cpp
@@ -100,7 +100,7 @@ namespace SDDM {
     Auth::SocketServer* Auth::SocketServer::instance() {
         if (!self) {
             self = new SocketServer();
-            self->listen(QString("sddm-auth%1").arg(QUuid::createUuid().toString().replace(QRegExp("[{}]"),"")));
+            self->listen(QStringLiteral("sddm-auth%1").arg(QUuid::createUuid().toString().replace(QRegExp(QStringLiteral("[{}]")), QString())));
         }
         return self;
     }
@@ -114,11 +114,11 @@ namespace SDDM {
         SocketServer::instance()->helpers[id] = this;
         QProcessEnvironment env = child->processEnvironment();
         bool langEmpty = true;
-        QFile localeFile("/etc/locale.conf");
+        QFile localeFile(QStringLiteral("/etc/locale.conf"));
         if (localeFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
             QTextStream in(&localeFile);
             while (!in.atEnd()) {
-                QStringList parts = in.readLine().split('=');
+                QStringList parts = in.readLine().split(QLatin1Char('='));
                 if (parts.size() >= 2) {
                     env.insert(parts[0], parts[1]);
                     if (parts[0] == QStringLiteral("LANG"))
@@ -128,7 +128,7 @@ namespace SDDM {
             localeFile.close();
         }
         if (langEmpty)
-            env.insert("LANG", "C");
+            env.insert(QStringLiteral("LANG"), QStringLiteral("C"));
         child->setProcessEnvironment(env);
         connect(child, SIGNAL(finished(int,QProcess::ExitStatus)), this, SLOT(childExited(int,QProcess::ExitStatus)));
         connect(child, SIGNAL(error(QProcess::ProcessError)), this, SLOT(childError(QProcess::ProcessError)));
@@ -193,7 +193,7 @@ namespace SDDM {
                 break;
             }
             default: {
-                Q_EMIT auth->error(QString("Auth: Unexpected value received: %1").arg(m), ERROR_INTERNAL);
+                Q_EMIT auth->error(QStringLiteral("Auth: Unexpected value received: %1").arg(m), ERROR_INTERNAL);
             }
         }
     }
@@ -335,17 +335,17 @@ namespace SDDM {
 
     void Auth::start() {
         QStringList args;
-        args << "--socket" << SocketServer::instance()->fullServerName();
-        args << "--id" << QString("%1").arg(d->id);
+        args << QStringLiteral("--socket") << SocketServer::instance()->fullServerName();
+        args << QStringLiteral("--id") << QStringLiteral("%1").arg(d->id);
         if (!d->sessionPath.isEmpty())
-            args << "--start" << d->sessionPath;
+            args << QStringLiteral("--start") << d->sessionPath;
         if (!d->user.isEmpty())
-            args << "--user" << d->user;
+            args << QStringLiteral("--user") << d->user;
         if (d->autologin)
-            args << "--autologin";
+            args << QStringLiteral("--autologin");
         if (d->greeter)
-            args << "--greeter";
-        d->child->start(QString("%1/sddm-helper").arg(LIBEXEC_INSTALL_DIR), args);
+            args << QStringLiteral("--greeter");
+        d->child->start(QStringLiteral("%1/sddm-helper").arg(QStringLiteral(LIBEXEC_INSTALL_DIR)), args);
     }
 }
 

--- a/src/auth/AuthMessages.h
+++ b/src/auth/AuthMessages.h
@@ -160,7 +160,7 @@ namespace SDDM {
         QStringList l;
         s >> l;
         for (QString s : l) {
-            int pos = s.indexOf('=');
+            int pos = s.indexOf(QLatin1Char('='));
             m.insert(s.left(pos), s.mid(pos + 1));
         }
         return s;

--- a/src/common/ConfigReader.h
+++ b/src/common/ConfigReader.h
@@ -40,7 +40,7 @@
 #define Config(name, file, ...) \
     class name : public SDDM::ConfigBase, public SDDM::ConfigSection { \
     public: \
-        name() : SDDM::ConfigBase(file), SDDM::ConfigSection(this, IMPLICIT_SECTION) { \
+        name() : SDDM::ConfigBase(file), SDDM::ConfigSection(this, QStringLiteral(IMPLICIT_SECTION)) { \
             load(); \
         } \
         void save() { SDDM::ConfigBase::save(nullptr, nullptr); } \
@@ -52,14 +52,14 @@
     }
 // entry wrapper
 #define Entry(name, type, default, description) \
-    SDDM::ConfigEntry<type> name { this, #name, (default), (description) }
+    SDDM::ConfigEntry<type> name { this, QStringLiteral(#name), (default), (description) }
 // section wrapper
 #define Section(name, ...) \
     class name : public SDDM::ConfigSection { \
     public: \
         name (SDDM::ConfigBase *_parent, const QString &_name) : SDDM::ConfigSection(_parent, _name) { } \
         __VA_ARGS__ \
-    } name { this, #name };
+    } name { this, QStringLiteral(#name) };
 
 QTextStream &operator>>(QTextStream &str, QStringList &list);
 QTextStream &operator<<(QTextStream &str, const QStringList &list);
@@ -153,14 +153,14 @@ namespace SDDM {
         }
 
         QString toConfigShort() const {
-            return QString("%1=%2").arg(m_name).arg(value());
+            return QStringLiteral("%1=%2").arg(m_name).arg(value());
         }
 
         QString toConfigFull() const {
             QString str;
-            for (const QString &line : m_description.split('\n'))
-                str.append(QString("# %1\n").arg(line));
-            str.append(QString("%1=%2\n\n").arg(m_name).arg(value()));
+            for (const QString &line : m_description.split(QLatin1Char('\n')))
+                str.append(QStringLiteral("# %1\n").arg(line));
+            str.append(QStringLiteral("%1=%2\n\n").arg(m_name).arg(value()));
             return str;
         }
     private:

--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -34,7 +34,7 @@
 
 namespace SDDM {
     //     Name        File         Sections and/or Entries (but anything else too, it's a class) - Entries in a Config are assumed to be in the General section
-    Config(MainConfig, CONFIG_FILE,
+    Config(MainConfig, QStringLiteral(CONFIG_FILE),
         enum NumState { NUM_NONE, NUM_SET_ON, NUM_SET_OFF };
 
         //    Name                 Type         Default value                               Description
@@ -89,7 +89,7 @@ namespace SDDM {
         );
     );
 
-    Config(StateConfig, []()->QString{auto tmp = getpwnam("sddm"); return tmp ? tmp->pw_dir : STATE_DIR;}().append("/state.conf"),
+    Config(StateConfig, []()->QString{auto tmp = getpwnam("sddm"); return tmp ? QString::fromLocal8Bit(tmp->pw_dir) : QStringLiteral(STATE_DIR);}().append(QStringLiteral("/state.conf")),
         Section(Last,
             Entry(Session,         QString,     QString(),                                  _S("Name of the session file of the last session selected. This session will be preselected when the login screen shows up."));
             Entry(User,            QString,     QString(),                                  _S("Name of the last logged-in user. This username will be preselected/shown when the login screen shows up"));
@@ -101,9 +101,9 @@ namespace SDDM {
 
     inline QTextStream& operator>>(QTextStream &str, MainConfig::NumState &state) {
         QString text = str.readLine().trimmed();
-        if (text.compare("on", Qt::CaseInsensitive) == 0)
+        if (text.compare(QLatin1String("on"), Qt::CaseInsensitive) == 0)
             state = MainConfig::NUM_SET_ON;
-        else if (text.compare("off", Qt::CaseInsensitive) == 0)
+        else if (text.compare(QLatin1String("off"), Qt::CaseInsensitive) == 0)
             state = MainConfig::NUM_SET_OFF;
         else
             state = MainConfig::NUM_NONE;

--- a/src/common/MessageHandler.h
+++ b/src/common/MessageHandler.h
@@ -67,7 +67,7 @@ namespace SDDM {
 #endif
 
     static void standardLogger(QtMsgType type, const QString &msg) {
-        static QFile file(LOG_FILE);
+        static QFile file(QStringLiteral(LOG_FILE));
 
         // try to open file only if it's not already open
         if (!file.isOpen()) {
@@ -76,26 +76,26 @@ namespace SDDM {
         }
 
         // create timestamp
-        QString timestamp = QDateTime::currentDateTime().toString("hh:mm:ss.zzz");
+        QString timestamp = QDateTime::currentDateTime().toString(QStringLiteral("hh:mm:ss.zzz"));
 
         // set log priority
-	QString logPriority = QString("(II)");
+	QString logPriority = QStringLiteral("(II)");
         switch (type) {
             case QtDebugMsg:
             break;
             case QtWarningMsg:
-                logPriority = QString("(WW)");
+                logPriority = QStringLiteral("(WW)");
             break;
             case QtCriticalMsg:
             case QtFatalMsg:
-                logPriority = QString("(EE)");
+                logPriority = QStringLiteral("(EE)");
             break;
 	    default:
 	    break;
         }
 
         // prepare log message
-        QString logMessage = QString("[%1] %2 %3\n").arg(timestamp).arg(logPriority).arg(msg);
+        QString logMessage = QStringLiteral("[%1] %2 %3\n").arg(timestamp).arg(logPriority).arg(msg);
 
         // log message
         if (file.isOpen()) {
@@ -135,15 +135,15 @@ namespace SDDM {
     }
 
     void DaemonMessageHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg) {
-        messageHandler(type, context, "DAEMON: ", msg);
+        messageHandler(type, context, QStringLiteral("DAEMON: "), msg);
     }
 
     void HelperMessageHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg) {
-        messageHandler(type, context, "HELPER: ", msg);
+        messageHandler(type, context, QStringLiteral("HELPER: "), msg);
     }
 
     void GreeterMessageHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg) {
-        messageHandler(type, context, "GREETER: ", msg);
+        messageHandler(type, context, QStringLiteral("GREETER: "), msg);
     }
 }
 

--- a/src/common/Session.cpp
+++ b/src/common/Session.cpp
@@ -86,7 +86,7 @@ namespace SDDM {
 
     QString Session::desktopSession() const
     {
-        return fileName().replace(s_entryExtention, QStringLiteral(""));
+        return fileName().replace(s_entryExtention, QString());
     }
 
     QString Session::desktopNames() const
@@ -132,20 +132,20 @@ namespace SDDM {
         while (!in.atEnd()) {
             QString line = in.readLine();
 
-            if (line.startsWith("Name=")) {
+            if (line.startsWith(QStringLiteral("Name="))) {
                 if (type == WaylandSession)
                     m_displayName = QObject::tr("%1 (Wayland)").arg(line.mid(5));
                 else
                     m_displayName = line.mid(5);
             }
-            if (line.startsWith("Comment="))
+            if (line.startsWith(QStringLiteral("Comment=")))
                 m_comment = line.mid(8);
-            if (line.startsWith("Exec="))
+            if (line.startsWith(QStringLiteral("Exec=")))
                 m_exec = line.mid(5);
-            if (line.startsWith("TryExec="))
+            if (line.startsWith(QStringLiteral("TryExec=")))
                 m_tryExec = line.mid(8);
-            if (line.startsWith("DesktopNames="))
-                m_desktopNames = line.mid(13).replace(';', ':');
+            if (line.startsWith(QStringLiteral("DesktopNames=")))
+                m_desktopNames = line.mid(13).replace(QLatin1Char(';'), QLatin1Char(':'));
         }
 
         file.close();

--- a/src/daemon/DaemonApp.cpp
+++ b/src/daemon/DaemonApp.cpp
@@ -47,7 +47,7 @@ namespace SDDM {
         qDebug() << "Initializing...";
 
         // set testing parameter
-        m_testing = (arguments().indexOf("--test-mode") != -1);
+        m_testing = (arguments().indexOf(QStringLiteral("--test-mode")) != -1);
 
         // create display manager
         m_displayManager = new DisplayManager(this);
@@ -77,7 +77,7 @@ namespace SDDM {
         qDebug() << "Starting...";
 
         // add a seat
-        m_seatManager->createSeat("seat0");
+        m_seatManager->createSeat(QStringLiteral("seat0"));
     }
 
     bool DaemonApp::testing() const {
@@ -114,7 +114,7 @@ int main(int argc, char **argv) {
     QStringList arguments;
 
     for (int i = 0; i < argc; i++)
-        arguments << argv[i];
+        arguments << QString::fromLocal8Bit(argv[i]);
 
     if (arguments.contains(QStringLiteral("--help")) || arguments.contains(QStringLiteral("-h"))) {
         std::cout << "Usage: sddm [options]\n"
@@ -126,7 +126,7 @@ int main(int argc, char **argv) {
     }
 
     // spit a complete config file on stdout and quit on demand
-    if (arguments.contains("--example-config")) {
+    if (arguments.contains(QStringLiteral("--example-config"))) {
         QTextStream(stdout) << SDDM::mainConfig.toConfigFull();
         return EXIT_SUCCESS;
     }

--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -203,7 +203,7 @@ namespace SDDM {
 
         //the SDDM user has special priveledges that skip password checking so that we can load the greeter
         //block ever trying to log in as the SDDM user
-        if (user == "sddm") {
+        if (user == QStringLiteral("sddm")) {
             return;
         }
 
@@ -231,7 +231,7 @@ namespace SDDM {
         QString fileName = name;
 
         // append extension
-        if (!fileName.endsWith(".desktop"))
+        if (!fileName.endsWith(QStringLiteral(".desktop")))
             fileName += QStringLiteral(".desktop");
 
         return dir.exists(fileName);
@@ -269,18 +269,18 @@ namespace SDDM {
         }
 
         QProcessEnvironment env;
-        env.insert("PATH", mainConfig.Users.DefaultPath.get());
+        env.insert(QStringLiteral("PATH"), mainConfig.Users.DefaultPath.get());
         if (session.xdgSessionType() == QStringLiteral("x11"))
-            env.insert("DISPLAY", name());
-        env.insert("XDG_SEAT", seat()->name());
-        env.insert("XDG_SEAT_PATH", daemonApp->displayManager()->seatPath(seat()->name()));
-        env.insert("XDG_SESSION_PATH", daemonApp->displayManager()->sessionPath(QString("Session%1").arg(daemonApp->newSessionId())));
-        env.insert("XDG_VTNR", QString::number(vt));
-        env.insert("DESKTOP_SESSION", session.desktopSession());
-        env.insert("XDG_CURRENT_DESKTOP", session.desktopNames());
-        env.insert("XDG_SESSION_CLASS", "user");
-        env.insert("XDG_SESSION_TYPE", session.xdgSessionType());
-        env.insert("XDG_SESSION_DESKTOP", session.desktopNames());
+            env.insert(QStringLiteral("DISPLAY"), name());
+        env.insert(QStringLiteral("XDG_SEAT"), seat()->name());
+        env.insert(QStringLiteral("XDG_SEAT_PATH"), daemonApp->displayManager()->seatPath(seat()->name()));
+        env.insert(QStringLiteral("XDG_SESSION_PATH"), daemonApp->displayManager()->sessionPath(QStringLiteral("Session%1").arg(daemonApp->newSessionId())));
+        env.insert(QStringLiteral("XDG_VTNR"), QString::number(vt));
+        env.insert(QStringLiteral("DESKTOP_SESSION"), session.desktopSession());
+        env.insert(QStringLiteral("XDG_CURRENT_DESKTOP"), session.desktopNames());
+        env.insert(QStringLiteral("XDG_SESSION_CLASS"), QStringLiteral("user"));
+        env.insert(QStringLiteral("XDG_SESSION_TYPE"), session.xdgSessionType());
+        env.insert(QStringLiteral("XDG_SESSION_DESKTOP"), session.desktopNames());
         m_auth->insertEnvironment(env);
 
         m_auth->setUser(user);

--- a/src/daemon/DisplayManager.h
+++ b/src/daemon/DisplayManager.h
@@ -91,8 +91,8 @@ namespace SDDM {
         ObjectPathList Sessions();
 
     private:
-        QString m_name { "" };
-        QString m_path { "" };
+        QString m_name;
+        QString m_path;
     };
 
     /***************************************************************************
@@ -116,10 +116,10 @@ namespace SDDM {
         ObjectPath SeatPath() const;
 
     private:
-        QString m_name { "" };
-        QString m_path { "" };
-        QString m_seat { "" };
-        QString m_user { "" };
+        QString m_name;
+        QString m_path;
+        QString m_seat;
+        QString m_user;
     };
 }
 

--- a/src/daemon/DisplayServer.h
+++ b/src/daemon/DisplayServer.h
@@ -53,7 +53,7 @@ namespace SDDM {
     protected:
         bool m_started { false };
 
-        QString m_display { "" };
+        QString m_display;
 
     private:
         Display *m_displayPtr { nullptr };

--- a/src/daemon/Greeter.cpp
+++ b/src/daemon/Greeter.cpp
@@ -73,18 +73,18 @@ namespace SDDM {
 
             // set process environment
             QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
-            env.insert("DISPLAY", m_display->name());
-            env.insert("XAUTHORITY", m_authPath);
-            env.insert("XCURSOR_THEME", mainConfig.Theme.CursorTheme.get());
+            env.insert(QStringLiteral("DISPLAY"), m_display->name());
+            env.insert(QStringLiteral("XAUTHORITY"), m_authPath);
+            env.insert(QStringLiteral("XCURSOR_THEME"), mainConfig.Theme.CursorTheme.get());
             m_process->setProcessEnvironment(env);
 
             // start greeter
             QStringList args;
             if (daemonApp->testing())
-                args << "--test-mode";
-            args << "--socket" << m_socket
-                 << "--theme" << m_theme;
-            m_process->start(QString("%1/sddm-greeter").arg(BIN_INSTALL_DIR), args);
+                args << QStringLiteral("--test-mode");
+            args << QStringLiteral("--socket") << m_socket
+                 << QStringLiteral("--theme") << m_theme;
+            m_process->start(QStringLiteral("%1/sddm-greeter").arg(QStringLiteral(BIN_INSTALL_DIR)), args);
 
             //if we fail to start bail immediately, and don't block in waitForStarted
             if (m_process->state() == QProcess::NotRunning) {
@@ -117,38 +117,39 @@ namespace SDDM {
 
             // greeter command
             QStringList args;
-            args << QString("%1/sddm-greeter").arg(BIN_INSTALL_DIR);
-            args << "--socket" << m_socket
-                 << "--theme" << m_theme;
+            args << QStringLiteral("%1/sddm-greeter").arg(QStringLiteral(BIN_INSTALL_DIR));
+            args << QStringLiteral("--socket") << m_socket
+                 << QStringLiteral("--theme") << m_theme;
 
             // greeter environment
             QProcessEnvironment env;
             QProcessEnvironment sysenv = QProcessEnvironment::systemEnvironment();
 
-            insertEnvironmentList({"LANG", "LANGUAGE",
-                                   "LC_CTYPE", "LC_NUMERIC", "LC_TIME", "LC_COLLATE", "LC_MONETARY", "LC_MESSAGES",
-                                   "LC_PAPER", "LC_NAME", "LC_ADDRESS", "LC_TELEPHONE", "LC_MEASUREMENT", "LC_IDENTIFICATION"
+            insertEnvironmentList({QStringLiteral("LANG"), QStringLiteral("LANGUAGE"),
+                                   QStringLiteral("LC_CTYPE"), QStringLiteral("LC_NUMERIC"), QStringLiteral("LC_TIME"), QStringLiteral("LC_COLLATE"),
+                                   QStringLiteral("LC_MONETARY"), QStringLiteral("LC_MESSAGES"), QStringLiteral("LC_PAPER"), QStringLiteral("LC_NAME"),
+                                   QStringLiteral("LC_ADDRESS"), QStringLiteral("LC_TELEPHONE"), QStringLiteral("LC_MEASUREMENT"), QStringLiteral("LC_IDENTIFICATION")
             }, sysenv, env);
 
-            env.insert("PATH", mainConfig.Users.DefaultPath.get());
-            env.insert("DISPLAY", m_display->name());
-            env.insert("XAUTHORITY", m_authPath);
-            env.insert("XCURSOR_THEME", mainConfig.Theme.CursorTheme.get());
-            env.insert("XDG_SEAT", m_display->seat()->name());
-            env.insert("XDG_SEAT_PATH", daemonApp->displayManager()->seatPath(m_display->seat()->name()));
-            env.insert("XDG_SESSION_PATH", daemonApp->displayManager()->sessionPath(QString("Session%1").arg(daemonApp->newSessionId())));
-            env.insert("XDG_VTNR", QString::number(m_display->terminalId()));
-            env.insert("XDG_SESSION_CLASS", "greeter");
-            env.insert("XDG_SESSION_TYPE", m_display->sessionType());
+            env.insert(QStringLiteral("PATH"), mainConfig.Users.DefaultPath.get());
+            env.insert(QStringLiteral("DISPLAY"), m_display->name());
+            env.insert(QStringLiteral("XAUTHORITY"), m_authPath);
+            env.insert(QStringLiteral("XCURSOR_THEME"), mainConfig.Theme.CursorTheme.get());
+            env.insert(QStringLiteral("XDG_SEAT"), m_display->seat()->name());
+            env.insert(QStringLiteral("XDG_SEAT_PATH"), daemonApp->displayManager()->seatPath(m_display->seat()->name()));
+            env.insert(QStringLiteral("XDG_SESSION_PATH"), daemonApp->displayManager()->sessionPath(QStringLiteral("Session%1").arg(daemonApp->newSessionId())));
+            env.insert(QStringLiteral("XDG_VTNR"), QString::number(m_display->terminalId()));
+            env.insert(QStringLiteral("XDG_SESSION_CLASS"), QStringLiteral("greeter"));
+            env.insert(QStringLiteral("XDG_SESSION_TYPE"), m_display->sessionType());
             m_auth->insertEnvironment(env);
 
             // log message
             qDebug() << "Greeter starting...";
 
             // start greeter
-            m_auth->setUser("sddm");
+            m_auth->setUser(QStringLiteral("sddm"));
             m_auth->setGreeter(true);
-            m_auth->setSession(args.join(" "));
+            m_auth->setSession(args.join(QLatin1Char(' ')));
             m_auth->start();
         }
 
@@ -226,14 +227,14 @@ namespace SDDM {
     void Greeter::onReadyReadStandardError()
     {
         if (m_process) {
-            qDebug() << "Greeter errors:" << qPrintable(m_process->readAllStandardError());
+            qDebug() << "Greeter errors:" << qPrintable(QString::fromLocal8Bit(m_process->readAllStandardError()));
         }
     }
 
     void Greeter::onReadyReadStandardOutput()
     {
         if (m_process) {
-            qDebug() << "Greeter output:" << qPrintable(m_process->readAllStandardOutput());
+            qDebug() << "Greeter output:" << qPrintable(QString::fromLocal8Bit(m_process->readAllStandardOutput()));
         }
     }
 

--- a/src/daemon/Greeter.h
+++ b/src/daemon/Greeter.h
@@ -59,9 +59,9 @@ namespace SDDM {
         bool m_started { false };
 
         Display *m_display { nullptr };
-        QString m_authPath { "" };
-        QString m_socket { "" };
-        QString m_theme { "" };
+        QString m_authPath;
+        QString m_socket;
+        QString m_theme;
 
         Auth *m_auth { nullptr };
         QProcess *m_process { nullptr };

--- a/src/daemon/PowerManager.cpp
+++ b/src/daemon/PowerManager.cpp
@@ -73,12 +73,12 @@ namespace SDDM {
             QDBusReply<bool> reply;
 
             // suspend
-            reply = m_interface->call("SuspendAllowed");
+            reply = m_interface->call(QStringLiteral("SuspendAllowed"));
             if (reply.isValid() && reply.value())
                 caps |= Capability::Suspend;
 
             // hibernate
-            reply = m_interface->call("HibernateAllowed");
+            reply = m_interface->call(QStringLiteral("HibernateAllowed"));
             if (reply.isValid() && reply.value())
                 caps |= Capability::Hibernate;
 
@@ -95,11 +95,11 @@ namespace SDDM {
         }
 
         void suspend() const {
-            m_interface->call("Suspend");
+            m_interface->call(QStringLiteral("Suspend"));
         }
 
         void hibernate() const {
-            m_interface->call("Hibernate");
+            m_interface->call(QStringLiteral("Hibernate"));
         }
 
         void hybridSleep() const {
@@ -137,28 +137,28 @@ namespace SDDM {
             QDBusReply<QString> reply;
 
             // power off
-            reply = m_interface->call("CanPowerOff");
-            if (reply.isValid() && (reply.value() == "yes"))
+            reply = m_interface->call(QStringLiteral("CanPowerOff"));
+            if (reply.isValid() && (reply.value() == QStringLiteral("yes")))
                 caps |= Capability::PowerOff;
 
             // reboot
-            reply = m_interface->call("CanReboot");
-            if (reply.isValid() && (reply.value() == "yes"))
+            reply = m_interface->call(QStringLiteral("CanReboot"));
+            if (reply.isValid() && (reply.value() == QStringLiteral("yes")))
                 caps |= Capability::Reboot;
 
             // suspend
-            reply = m_interface->call("CanSuspend");
-            if (reply.isValid() && (reply.value() == "yes"))
+            reply = m_interface->call(QStringLiteral("CanSuspend"));
+            if (reply.isValid() && (reply.value() == QStringLiteral("yes")))
                 caps |= Capability::Suspend;
 
             // hibernate
-            reply = m_interface->call("CanHibernate");
-            if (reply.isValid() && (reply.value() == "yes"))
+            reply = m_interface->call(QStringLiteral("CanHibernate"));
+            if (reply.isValid() && (reply.value() == QStringLiteral("yes")))
                 caps |= Capability::Hibernate;
 
             // hybrid sleep
-            reply = m_interface->call("CanHybridSleep");
-            if (reply.isValid() && (reply.value() == "yes"))
+            reply = m_interface->call(QStringLiteral("CanHybridSleep"));
+            if (reply.isValid() && (reply.value() == QStringLiteral("yes")))
                 caps |= Capability::HybridSleep;
 
             // return capabilities
@@ -166,24 +166,24 @@ namespace SDDM {
         }
 
         void powerOff() const {
-            m_interface->call("PowerOff", true);
+            m_interface->call(QStringLiteral("PowerOff"), true);
         }
 
         void reboot() const {
             if (!daemonApp->testing())
-                m_interface->call("Reboot", true);
+                m_interface->call(QStringLiteral("Reboot"), true);
         }
 
         void suspend() const {
-            m_interface->call("Suspend", true);
+            m_interface->call(QStringLiteral("Suspend"), true);
         }
 
         void hibernate() const {
-            m_interface->call("Hibernate", true);
+            m_interface->call(QStringLiteral("Hibernate"), true);
         }
 
         void hybridSleep() const {
-            m_interface->call("HybridSleep", true);
+            m_interface->call(QStringLiteral("HybridSleep"), true);
         }
 
     private:

--- a/src/daemon/Seat.h
+++ b/src/daemon/Seat.h
@@ -41,7 +41,7 @@ namespace SDDM {
         void displayStopped();
 
     private:
-        QString m_name { "" };
+        QString m_name;
 
         QList<Display *> m_displays;
         QList<int> m_terminalIds;

--- a/src/daemon/SocketServer.cpp
+++ b/src/daemon/SocketServer.cpp
@@ -43,7 +43,7 @@ namespace SDDM {
         if (m_server)
             return false;
 
-        QString socketName = QString("sddm-%1-%2").arg(displayName).arg(generateName(6));
+        QString socketName = QStringLiteral("sddm-%1-%2").arg(displayName).arg(generateName(6));
 
         // log message
         qDebug() << "Socket server starting...";

--- a/src/daemon/Utils.h
+++ b/src/daemon/Utils.h
@@ -26,7 +26,7 @@
 namespace SDDM {
 
 inline QString generateName(int length) {
-    QString digits = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    QString digits = QStringLiteral("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ");
 
     // reserve space for name
     QString name;

--- a/src/daemon/VirtualTerminal.cpp
+++ b/src/daemon/VirtualTerminal.cpp
@@ -142,7 +142,7 @@ out:
 
             int activeVtFd = open("/dev/tty0", O_RDWR | O_NOCTTY);
 
-            QString ttyString = QString("/dev/tty%1").arg(vt);
+            QString ttyString = QStringLiteral("/dev/tty%1").arg(vt);
             int vtFd = open(qPrintable(ttyString), O_RDWR | O_NOCTTY);
             if (vtFd != -1) {
                 fd = vtFd;

--- a/src/daemon/XorgDisplayServer.cpp
+++ b/src/daemon/XorgDisplayServer.cpp
@@ -40,7 +40,7 @@
 namespace SDDM {
     XorgDisplayServer::XorgDisplayServer(Display *parent) : DisplayServer(parent) {
         // get auth directory
-        QString authDir = RUNTIME_DIR;
+        QString authDir = QStringLiteral(RUNTIME_DIR);
 
         // use "." as authdir in test mode
         if (daemonApp->testing())
@@ -50,7 +50,7 @@ namespace SDDM {
         QDir().mkpath(authDir);
 
         // set auth path
-        m_authPath = QString("%1/%2").arg(authDir).arg(QUuid::createUuid().toString());
+        m_authPath = QStringLiteral("%1/%2").arg(authDir).arg(QUuid::createUuid().toString());
 
         // generate cookie
         std::random_device rd;
@@ -95,7 +95,7 @@ namespace SDDM {
         file_handler.open(QIODevice::WriteOnly);
         file_handler.close();
 
-        QString cmd = QString("%1 -f %2 -q").arg(mainConfig.XDisplay.XauthPath.get()).arg(file);
+        QString cmd = QStringLiteral("%1 -f %2 -q").arg(mainConfig.XDisplay.XauthPath.get()).arg(file);
 
         // execute xauth
         FILE *fp = popen(qPrintable(cmd), "w");
@@ -127,7 +127,7 @@ namespace SDDM {
 
         if (daemonApp->testing()) {
             QStringList args;
-            args << m_display << "-ac" << "-br" << "-noreset" << "-screen" << "800x600";
+            args << m_display << QStringLiteral("-ac") << QStringLiteral("-br") << QStringLiteral("-noreset") << QStringLiteral("-screen") << QStringLiteral("800x600");
             process->start(mainConfig.XDisplay.XephyrPath.get(), args);
 
 
@@ -143,7 +143,7 @@ namespace SDDM {
         } else {
             // set process environment
             QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
-            env.insert("XCURSOR_THEME", mainConfig.Theme.CursorTheme.get());
+            env.insert(QStringLiteral("XCURSOR_THEME"), mainConfig.Theme.CursorTheme.get());
             process->setProcessEnvironment(env);
 
             //create pipe for communicating with X server
@@ -154,15 +154,15 @@ namespace SDDM {
             }
 
             // start display server
-            QStringList args = mainConfig.XDisplay.ServerArguments.get().split(" ", QString::SkipEmptyParts);
-            args << "-auth" << m_authPath
-                 << "-background" << "none"
-                 << "-noreset"
-                 << "-displayfd" << QString::number(pipeFds[1])
-                 << QString("vt%1").arg(displayPtr()->terminalId());
+            QStringList args = mainConfig.XDisplay.ServerArguments.get().split(QLatin1Char(' '), QString::SkipEmptyParts);
+            args << QStringLiteral("-auth") << m_authPath
+                 << QStringLiteral("-background") << QStringLiteral("none")
+                 << QStringLiteral("-noreset")
+                 << QStringLiteral("-displayfd") << QString::number(pipeFds[1])
+                 << QStringLiteral("vt%1").arg(displayPtr()->terminalId());
             qDebug() << "Running:"
                      << qPrintable(mainConfig.XDisplay.ServerPath.get())
-                     << qPrintable(args.join(" "));
+                     << qPrintable(args.join(QLatin1Char(' ')));
             process->start(mainConfig.XDisplay.ServerPath.get(), args);
 
             // wait for display server to start
@@ -186,7 +186,7 @@ namespace SDDM {
             QByteArray displayNumber = readPipe.readLine();
             displayNumber.prepend(QByteArray(":"));
             displayNumber.remove(displayNumber.size() -1, 1); //trim trailing whitespace
-            m_display= displayNumber;
+            m_display = QString::fromLocal8Bit(displayNumber);
     
             // close our pipe
             close(pipeFds[0]);
@@ -239,10 +239,10 @@ namespace SDDM {
 
         // set process environment
         QProcessEnvironment env;
-        env.insert("DISPLAY", m_display);
-        env.insert("HOME", "/");
-        env.insert("PATH", mainConfig.Users.DefaultPath.get());
-        env.insert("SHELL", "/bin/sh");
+        env.insert(QStringLiteral("DISPLAY"), m_display);
+        env.insert(QStringLiteral("HOME"), QStringLiteral("/"));
+        env.insert(QStringLiteral("PATH"), mainConfig.Users.DefaultPath.get());
+        env.insert(QStringLiteral("SHELL"), QStringLiteral("/bin/sh"));
         displayStopScript->setProcessEnvironment(env);
 
         // start display setup script
@@ -276,11 +276,11 @@ namespace SDDM {
 
         // set process environment
         QProcessEnvironment env;
-        env.insert("DISPLAY", m_display);
-        env.insert("HOME", "/");
-        env.insert("PATH", mainConfig.Users.DefaultPath.get());
-        env.insert("XAUTHORITY", m_authPath);
-        env.insert("SHELL", "/bin/sh");
+        env.insert(QStringLiteral("DISPLAY"), m_display);
+        env.insert(QStringLiteral("HOME"), QStringLiteral("/"));
+        env.insert(QStringLiteral("PATH"), mainConfig.Users.DefaultPath.get());
+        env.insert(QStringLiteral("XAUTHORITY"), m_authPath);
+        env.insert(QStringLiteral("SHELL"), QStringLiteral("/bin/sh"));
         displayScript->setProcessEnvironment(env);
 
         // delete displayScript on finish

--- a/src/daemon/XorgDisplayServer.h
+++ b/src/daemon/XorgDisplayServer.h
@@ -49,8 +49,8 @@ namespace SDDM {
         void setupDisplay();
 
     private:
-        QString m_authPath { "" };
-        QString m_cookie { "" };
+        QString m_authPath;
+        QString m_cookie;
 
         QProcess *process { nullptr };
 

--- a/src/greeter/GreeterApp.cpp
+++ b/src/greeter/GreeterApp.cpp
@@ -49,7 +49,7 @@ namespace SDDM {
 
         QString value = arguments.at(index + 1);
 
-        if (value.startsWith("-") || value.startsWith("--"))
+        if (value.startsWith(QLatin1Char('-')))
             return defaultValue;
 
         return value;
@@ -64,47 +64,47 @@ namespace SDDM {
         // Parse arguments
         bool testing = false;
 
-        if (arguments().contains("--test-mode"))
+        if (arguments().contains(QStringLiteral("--test-mode")))
             testing = true;
 
         // get socket name
-        QString socket = parameter(arguments(), "--socket", "");
+        QString socket = parameter(arguments(), QStringLiteral("--socket"), QString());
 
         // get theme path
-        m_themePath = parameter(arguments(), "--theme", "");
+        m_themePath = parameter(arguments(), QStringLiteral("--theme"), QString());
 
         // read theme metadata
-        m_metadata = new ThemeMetadata(QString("%1/metadata.desktop").arg(m_themePath));
+        m_metadata = new ThemeMetadata(QStringLiteral("%1/metadata.desktop").arg(m_themePath));
 
         // Translations
         // Components translation
         m_components_tranlator = new QTranslator();
-        if (m_components_tranlator->load(QLocale::system(), "", "", COMPONENTS_TRANSLATION_DIR))
+        if (m_components_tranlator->load(QLocale::system(), QString(), QString(), QStringLiteral(COMPONENTS_TRANSLATION_DIR)))
             installTranslator(m_components_tranlator);
 
         // Theme specific translation
         m_theme_translator = new QTranslator();
-        if (m_theme_translator->load(QLocale::system(), "", "",
-                           QString("%1/%2/").arg(m_themePath, m_metadata->translationsDirectory())))
+        if (m_theme_translator->load(QLocale::system(), QString(), QString(),
+                           QStringLiteral("%1/%2/").arg(m_themePath, m_metadata->translationsDirectory())))
             installTranslator(m_theme_translator);
 
         // get theme config file
-        QString configFile = QString("%1/%2").arg(m_themePath).arg(m_metadata->configFile());
+        QString configFile = QStringLiteral("%1/%2").arg(m_themePath).arg(m_metadata->configFile());
 
         // read theme config
         m_themeConfig = new ThemeConfig(configFile);
 
         // set default icon theme from greeter theme
-        if (m_themeConfig->contains("iconTheme"))
-            QIcon::setThemeName(m_themeConfig->value("iconTheme").toString());
+        if (m_themeConfig->contains(QStringLiteral("iconTheme")))
+            QIcon::setThemeName(m_themeConfig->value(QStringLiteral("iconTheme")).toString());
 
         // set cursor theme according to greeter theme
-        if (m_themeConfig->contains("cursorTheme"))
-            qputenv("XCURSOR_THEME", m_themeConfig->value("cursorTheme").toString().toUtf8());
+        if (m_themeConfig->contains(QStringLiteral("cursorTheme")))
+            qputenv("XCURSOR_THEME", m_themeConfig->value(QStringLiteral("cursorTheme")).toString().toUtf8());
 
         // set platform theme
-        if (m_themeConfig->contains("platformTheme"))
-            qputenv("QT_QPA_PLATFORMTHEME", m_themeConfig->value("platformTheme").toString().toUtf8());
+        if (m_themeConfig->contains(QStringLiteral("platformTheme")))
+            qputenv("QT_QPA_PLATFORMTHEME", m_themeConfig->value(QStringLiteral("platformTheme")).toString().toUtf8());
 
         // create models
 
@@ -170,21 +170,21 @@ namespace SDDM {
         });
 #endif
 
-        view->engine()->addImportPath(IMPORTS_INSTALL_DIR);
+        view->engine()->addImportPath(QStringLiteral(IMPORTS_INSTALL_DIR));
 
         // connect proxy signals
         connect(m_proxy, SIGNAL(loginSucceeded()), view, SLOT(close()));
 
         // set context properties
-        view->rootContext()->setContextProperty("sessionModel", m_sessionModel);
-        view->rootContext()->setContextProperty("screenModel", m_screenModel);
-        view->rootContext()->setContextProperty("userModel", m_userModel);
-        view->rootContext()->setContextProperty("config", *m_themeConfig);
-        view->rootContext()->setContextProperty("sddm", m_proxy);
-        view->rootContext()->setContextProperty("keyboard", m_keyboard);
+        view->rootContext()->setContextProperty(QStringLiteral("sessionModel"), m_sessionModel);
+        view->rootContext()->setContextProperty(QStringLiteral("screenModel"), m_screenModel);
+        view->rootContext()->setContextProperty(QStringLiteral("userModel"), m_userModel);
+        view->rootContext()->setContextProperty(QStringLiteral("config"), *m_themeConfig);
+        view->rootContext()->setContextProperty(QStringLiteral("sddm"), m_proxy);
+        view->rootContext()->setContextProperty(QStringLiteral("keyboard"), m_keyboard);
 
         // get theme main script
-        QString mainScript = QString("%1/%2").arg(m_themePath).arg(m_metadata->mainScript());
+        QString mainScript = QStringLiteral("%1/%2").arg(m_themePath).arg(m_metadata->mainScript());
 
         // set main script as source
         view->setSource(QUrl::fromLocalFile(mainScript));
@@ -206,7 +206,7 @@ int main(int argc, char **argv) {
     QStringList arguments;
 
     for (int i = 0; i < argc; i++)
-        arguments << argv[i];
+        arguments << QString::fromLocal8Bit(argv[i]);
 
     if (arguments.contains(QStringLiteral("--help")) || arguments.contains(QStringLiteral("-h"))) {
         std::cout << "Usage: " << argv[0] << " [options] [arguments]\n"

--- a/src/greeter/GreeterProxy.cpp
+++ b/src/greeter/GreeterProxy.cpp
@@ -32,7 +32,7 @@ namespace SDDM {
     public:
         SessionModel *sessionModel { nullptr };
         QLocalSocket *socket { nullptr };
-        QString hostName { "" };
+        QString hostName;
         bool canPowerOff { false };
         bool canReboot { false };
         bool canSuspend { false };

--- a/src/greeter/KeyboardModel.cpp
+++ b/src/greeter/KeyboardModel.cpp
@@ -242,9 +242,9 @@ namespace SDDM {
         for (int i = 0; i < ind_cnt; i++) {
             QString name = atomName(cookies[i]);
 
-            if (name == "Num Lock") {
+            if (name == QStringLiteral("Num Lock")) {
                 d->numlock.mask = getIndicatorMask(i);
-            } else if (name == "Caps Lock") {
+            } else if (name == QStringLiteral("Caps Lock")) {
                 d->capslock.mask = getIndicatorMask(i);
             }
         }
@@ -334,11 +334,12 @@ namespace SDDM {
         // Get atom name
         reply = xcb_get_atom_name_reply(m_conn, cookie, &error);
 
-        QString res = "";
+        QString res;
 
         if (reply) {
-            res = QByteArray(xcb_get_atom_name_name(reply),
-                             xcb_get_atom_name_name_length(reply));
+            QByteArray replyText(xcb_get_atom_name_name(reply),
+                                 xcb_get_atom_name_name_length(reply));
+            res = QString::fromLocal8Bit(replyText);
             free(reply);
         } else {
             // Log error
@@ -375,12 +376,12 @@ namespace SDDM {
     }
 
     QList<QString> XcbKeyboardBackend::parseShortNames(QString text) {
-        QRegExp re(R"(\+([a-z]+))");
+        QRegExp re(QStringLiteral(R"(\+([a-z]+))"));
         re.setCaseSensitivity(Qt::CaseInsensitive);
 
         QList<QString> res;
         QSet<QString> blackList; // blacklist wrong tokens
-        blackList << "inet" << "group";
+        blackList << QStringLiteral("inet") << QStringLiteral("group");
 
         // Loop through matched substrings
         int pos = 0;

--- a/src/greeter/ScreenModel.cpp
+++ b/src/greeter/ScreenModel.cpp
@@ -128,7 +128,7 @@ namespace SDDM {
             if (screen->virtualGeometry() == primaryScreen->geometry() && screen != primaryScreen)
                 continue;
             // add to the screens list
-            d->screens << ScreenPtr { new Screen { QString("Screen %1").arg(i + 1), screen->geometry() } };
+            d->screens << ScreenPtr { new Screen { QStringLiteral("Screen %1").arg(i + 1), screen->geometry() } };
             // extend available geometry
             d->geometry = d->geometry.united(screen->geometry());
             // check if primary

--- a/src/greeter/SessionModel.cpp
+++ b/src/greeter/SessionModel.cpp
@@ -99,7 +99,7 @@ namespace SDDM {
     void SessionModel::populate(Session::Type type, const QString &path) {
         // read session files
         QDir dir(path);
-        dir.setNameFilters(QStringList() << "*.desktop");
+        dir.setNameFilters(QStringList() << QStringLiteral("*.desktop"));
         dir.setFilter(QDir::Files);
         // read session
         foreach(const QString &session, dir.entryList()) {
@@ -115,8 +115,8 @@ namespace SDDM {
             } else {
                 execAllowed = false;
                 QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
-                QString envPath = env.value("PATH");
-                QStringList pathList = envPath.split(':');
+                QString envPath = env.value(QStringLiteral("PATH"));
+                QStringList pathList = envPath.split(QLatin1Char(':'));
                 foreach(const QString &path, pathList) {
                     QDir pathDir(path);
                     fi.setFile(pathDir, si->tryExec());
@@ -132,7 +132,7 @@ namespace SDDM {
         }
         // add failsafe session
         if (type == Session::X11Session) {
-            Session *si = new Session(type, "failsafe");
+            Session *si = new Session(type, QStringLiteral("failsafe"));
             si->m_displayName = QStringLiteral("Failsafe");
             si->m_comment = QStringLiteral("Failsafe Session");
             si->m_exec = QStringLiteral("failsafe");

--- a/src/greeter/ThemeConfig.cpp
+++ b/src/greeter/ThemeConfig.cpp
@@ -26,7 +26,7 @@
 namespace SDDM {
     ThemeConfig::ThemeConfig(const QString &path) {
         QSettings settings(path, QSettings::IniFormat);
-        QSettings userSettings(path + ".user", QSettings::IniFormat);
+        QSettings userSettings(path + QStringLiteral(".user"), QSettings::IniFormat);
 
         // read default keys
         for (const QString &key: settings.allKeys()) {
@@ -41,8 +41,8 @@ namespace SDDM {
 
         //if the main config contains a background, save this to a new config value
         //to themes can use it if the user set config background cannot be loaded
-        if (settings.contains("background")) {
-            insert("defaultBackground", settings.value("background"));
+        if (settings.contains(QStringLiteral("background"))) {
+            insert(QStringLiteral("defaultBackground"), settings.value(QStringLiteral("background")));
         }
     }
 }

--- a/src/greeter/ThemeMetadata.cpp
+++ b/src/greeter/ThemeMetadata.cpp
@@ -24,17 +24,17 @@
 namespace SDDM {
     class ThemeMetadataPrivate {
     public:
-        QString mainScript { "Main.qml" };
-        QString configFile { "" };
-        QString translationsDirectory { "." };
+        QString mainScript { QStringLiteral("Main.qml") };
+        QString configFile;
+        QString translationsDirectory { QStringLiteral(".") };
     };
 
     ThemeMetadata::ThemeMetadata(const QString &path, QObject *parent) : QObject(parent), d(new ThemeMetadataPrivate()) {
         QSettings settings(path, QSettings::IniFormat);
         // read values
-        d->mainScript = settings.value("SddmGreeterTheme/MainScript", d->mainScript).toString();
-        d->configFile = settings.value("SddmGreeterTheme/ConfigFile", d->configFile).toString();
-        d->translationsDirectory = settings.value("SddmGreeterTheme/TranslationsDirectory", d->translationsDirectory).toString();
+        d->mainScript = settings.value(QStringLiteral("SddmGreeterTheme/MainScript"), d->mainScript).toString();
+        d->configFile = settings.value(QStringLiteral("SddmGreeterTheme/ConfigFile"), d->configFile).toString();
+        d->translationsDirectory = settings.value(QStringLiteral("SddmGreeterTheme/TranslationsDirectory"), d->translationsDirectory).toString();
     }
 
     ThemeMetadata::~ThemeMetadata() {

--- a/src/greeter/UserModel.cpp
+++ b/src/greeter/UserModel.cpp
@@ -33,10 +33,10 @@
 namespace SDDM {
     class User {
     public:
-        QString name { "" };
-        QString realName { "" };
-        QString homeDir { "" };
-        QString icon { "" };
+        QString name;
+        QString realName;
+        QString homeDir;
+        QString icon;
         bool needsPassword { false };
         int uid { 0 };
         int gid { 0 };
@@ -62,17 +62,17 @@ namespace SDDM {
             if ( int(current_pw->pw_uid) > mainConfig.Users.MaximumUid.get())
                 continue;
             // skip entries with user names in the hide users list
-            if (mainConfig.Users.HideUsers.get().contains(current_pw->pw_name))
+            if (mainConfig.Users.HideUsers.get().contains(QString::fromLocal8Bit(current_pw->pw_name)))
                 continue;
 
             // skip entries with shells in the hide shells list
-            if (mainConfig.Users.HideShells.get().contains(current_pw->pw_shell))
+            if (mainConfig.Users.HideShells.get().contains(QString::fromLocal8Bit(current_pw->pw_shell)))
                 continue;
 
             // create user
             UserPtr user { new User() };
             user->name = QString::fromLocal8Bit(current_pw->pw_name);
-            user->realName = QString::fromLocal8Bit(current_pw->pw_gecos).split(",").first();
+            user->realName = QString::fromLocal8Bit(current_pw->pw_gecos).split(QLatin1Char(',')).first();
             user->homeDir = QString::fromLocal8Bit(current_pw->pw_dir);
             user->uid = int(current_pw->pw_uid);
             user->gid = int(current_pw->pw_gid);
@@ -81,14 +81,14 @@ namespace SDDM {
             user->needsPassword = strcmp(current_pw->pw_passwd, "") != 0;
 
             // search for face icon
-            QString userFace = QString("%1/.face.icon").arg(user->homeDir);
-            QString systemFace = QString("%1/%2.face.icon").arg(mainConfig.Theme.FacesDir.get()).arg(user->name);
+            QString userFace = QStringLiteral("%1/.face.icon").arg(user->homeDir);
+            QString systemFace = QStringLiteral("%1/%2.face.icon").arg(mainConfig.Theme.FacesDir.get()).arg(user->name);
             if (QFile::exists(userFace))
                 user->icon = userFace;
             else if (QFile::exists(systemFace))
                 user->icon = systemFace;
             else
-                user->icon = QString("%1/default.face.icon").arg(mainConfig.Theme.FacesDir.get());
+                user->icon = QStringLiteral("%1/default.face.icon").arg(mainConfig.Theme.FacesDir.get());
 
             // add user
             d->users << user;

--- a/src/helper/Backend.cpp
+++ b/src/helper/Backend.cpp
@@ -57,13 +57,13 @@ namespace SDDM {
         pw = getpwnam(qPrintable(qobject_cast<HelperApp*>(parent())->user()));
         if (pw) {
             QProcessEnvironment env = m_app->session()->processEnvironment();
-            env.insert("HOME", pw->pw_dir);
-            env.insert("PWD", pw->pw_dir);
-            env.insert("SHELL", pw->pw_shell);
-            env.insert("USER", pw->pw_name);
-            env.insert("LOGNAME", pw->pw_name);
-            if (env.contains("DISPLAY") && !env.contains("XAUTHORITY"))
-                env.insert("XAUTHORITY", QString("%1/.Xauthority").arg(pw->pw_dir));
+            env.insert(QStringLiteral("HOME"), QString::fromLocal8Bit(pw->pw_dir));
+            env.insert(QStringLiteral("PWD"), QString::fromLocal8Bit(pw->pw_dir));
+            env.insert(QStringLiteral("SHELL"), QString::fromLocal8Bit(pw->pw_shell));
+            env.insert(QStringLiteral("USER"), QString::fromLocal8Bit(pw->pw_name));
+            env.insert(QStringLiteral("LOGNAME"), QString::fromLocal8Bit(pw->pw_name));
+            if (env.contains(QStringLiteral("DISPLAY")) && !env.contains(QStringLiteral("XAUTHORITY")))
+                env.insert(QStringLiteral("XAUTHORITY"), QStringLiteral("%1/.Xauthority").arg(QString::fromLocal8Bit(pw->pw_dir)));
             // TODO: I'm fairly sure this shouldn't be done for PAM sessions, investigate!
             m_app->session()->setProcessEnvironment(env);
         }

--- a/src/helper/HelperApp.cpp
+++ b/src/helper/HelperApp.cpp
@@ -50,7 +50,7 @@ namespace SDDM {
         QString server;
         int pos;
 
-        if ((pos = args.indexOf("--socket")) >= 0) {
+        if ((pos = args.indexOf(QStringLiteral("--socket"))) >= 0) {
             if (pos >= args.length() - 1) {
                 qCritical() << "This application is not supposed to be executed manually";
                 exit(Auth::HELPER_OTHER_ERROR);
@@ -59,7 +59,7 @@ namespace SDDM {
             server = args[pos + 1];
         }
 
-        if ((pos = args.indexOf("--id")) >= 0) {
+        if ((pos = args.indexOf(QStringLiteral("--id"))) >= 0) {
             if (pos >= args.length() - 1) {
                 qCritical() << "This application is not supposed to be executed manually";
                 exit(Auth::HELPER_OTHER_ERROR);
@@ -68,7 +68,7 @@ namespace SDDM {
             m_id = QString(args[pos + 1]).toLongLong();
         }
 
-        if ((pos = args.indexOf("--start")) >= 0) {
+        if ((pos = args.indexOf(QStringLiteral("--start"))) >= 0) {
             if (pos >= args.length() - 1) {
                 qCritical() << "This application is not supposed to be executed manually";
                 exit(Auth::HELPER_OTHER_ERROR);
@@ -77,7 +77,7 @@ namespace SDDM {
             m_session->setPath(args[pos + 1]);
         }
 
-        if ((pos = args.indexOf("--user")) >= 0) {
+        if ((pos = args.indexOf(QStringLiteral("--user"))) >= 0) {
             if (pos >= args.length() - 1) {
                 qCritical() << "This application is not supposed to be executed manually";
                 exit(Auth::HELPER_OTHER_ERROR);
@@ -86,11 +86,11 @@ namespace SDDM {
             m_user = args[pos + 1];
         }
 
-        if ((pos = args.indexOf("--autologin")) >= 0) {
+        if ((pos = args.indexOf(QStringLiteral("--autologin"))) >= 0) {
             m_backend->setAutologin(true);
         }
 
-        if ((pos = args.indexOf("--greeter")) >= 0) {
+        if ((pos = args.indexOf(QStringLiteral("--greeter"))) >= 0) {
             m_backend->setGreeter(true);
         }
 
@@ -113,13 +113,13 @@ namespace SDDM {
             qCritical() << "Couldn't write initial message:" << str.status();
 
         if (!m_backend->start(m_user)) {
-            authenticated(QString(""));
+            authenticated(QString());
             exit(Auth::HELPER_AUTH_ERROR);
             return;
         }
 
         if (!m_backend->authenticate()) {
-            authenticated(QString(""));
+            authenticated(QString());
             exit(Auth::HELPER_AUTH_ERROR);
             return;
         }

--- a/src/helper/UserSession.cpp
+++ b/src/helper/UserSession.cpp
@@ -43,14 +43,14 @@ namespace SDDM {
     bool UserSession::start() {
         QProcessEnvironment env = qobject_cast<HelperApp*>(parent())->session()->processEnvironment();
 
-        if (env.value("XDG_SESSION_CLASS") == QStringLiteral("greeter")) {
+        if (env.value(QStringLiteral("XDG_SESSION_CLASS")) == QStringLiteral("greeter")) {
             QProcess::start(m_path);
-        } else if (env.value("XDG_SESSION_TYPE") == QStringLiteral("x11")) {
+        } else if (env.value(QStringLiteral("XDG_SESSION_TYPE")) == QStringLiteral("x11")) {
             qDebug() << "Starting:" << mainConfig.XDisplay.SessionCommand.get()
                      << m_path;
             QProcess::start(mainConfig.XDisplay.SessionCommand.get(),
                             QStringList() << m_path);
-        } else if (env.value("XDG_SESSION_TYPE") == QStringLiteral("wayland")) {
+        } else if (env.value(QStringLiteral("XDG_SESSION_TYPE")) == QStringLiteral("wayland")) {
             qDebug() << "Starting:" << mainConfig.WaylandDisplay.SessionCommand.get()
                      << m_path;
             QProcess::start(mainConfig.WaylandDisplay.SessionCommand.get(),
@@ -72,13 +72,13 @@ namespace SDDM {
 
     void UserSession::setupChildProcess() {
         // Session type
-        QString sessionType = processEnvironment().value("XDG_SESSION_TYPE");
+        QString sessionType = processEnvironment().value(QStringLiteral("XDG_SESSION_TYPE"));
 
         // For Wayland sessions we leak the VT into the session as stdin so
         // that it stays open without races
         if (sessionType == QStringLiteral("wayland")) {
             // open VT and get the fd
-            QString ttyString = QString("/dev/tty%1").arg(processEnvironment().value("XDG_VTNR"));
+            QString ttyString = QStringLiteral("/dev/tty%1").arg(processEnvironment().value(QStringLiteral("XDG_VTNR")));
             int vtFd = ::open(qPrintable(ttyString), O_RDWR | O_NOCTTY);
 
             // when this is true we'll take control of the tty
@@ -162,15 +162,15 @@ namespace SDDM {
             return;
         QString cookie = qobject_cast<HelperApp*>(parent())->cookie();
         if (!cookie.isEmpty()) {
-            QString file = processEnvironment().value("XAUTHORITY");
-            QString display = processEnvironment().value("DISPLAY");
+            QString file = processEnvironment().value(QStringLiteral("XAUTHORITY"));
+            QString display = processEnvironment().value(QStringLiteral("DISPLAY"));
             qDebug() << "Adding cookie to" << file;
 
             QFile file_handler(file);
             file_handler.open(QIODevice::WriteOnly);
             file_handler.close();
 
-            QString cmd = QString("%1 -f %2 -q").arg(mainConfig.XDisplay.XauthPath.get()).arg(file);
+            QString cmd = QStringLiteral("%1 -f %2 -q").arg(mainConfig.XDisplay.XauthPath.get()).arg(file);
 
             // execute xauth
             FILE *fp = popen(qPrintable(cmd), "w");

--- a/src/helper/backend/PamHandle.cpp
+++ b/src/helper/backend/PamHandle.cpp
@@ -45,10 +45,10 @@ namespace SDDM {
 
         // copy it to the env map
         for (int i = 0; envlist[i] != nullptr; ++i) {
-            QString s(envlist[i]);
+            QString s = QString::fromLocal8Bit(envlist[i]);
 
             // find equal sign
-            int index = s.indexOf('=');
+            int index = s.indexOf(QLatin1Char('='));
 
             // add to the hash
             if (index != -1)
@@ -169,7 +169,7 @@ namespace SDDM {
     }
 
     QString PamHandle::errorString() {
-        return pam_strerror(m_handle, m_result);
+        return QString::fromLocal8Bit(pam_strerror(m_handle, m_result));
     }
 
     PamHandle::PamHandle(PamBackend *parent) {

--- a/test/ConfigurationTest.cpp
+++ b/test/ConfigurationTest.cpp
@@ -52,10 +52,10 @@ void ConfigurationTest::Basic() {
     QVERIFY(config->Boolean.get() == TEST_BOOL_1);
     config->save();
     QVERIFY(!QFile::exists(CONF_FILE));
-    config->String.set(config->String.get().append(" Appended"));
+    config->String.set(config->String.get().append(QStringLiteral(" Appended")));
     config->save();
     QVERIFY(QFile::exists(CONF_FILE));
-    config->String.set(config->String.get().append(" Appended Again"));
+    config->String.set(config->String.get().append(QStringLiteral(" Appended Again")));
     config->save();
     QVERIFY(QFile::exists(CONF_FILE));
 }
@@ -67,10 +67,10 @@ void ConfigurationTest::Sections() {
     QVERIFY(config->Section.Boolean.get() == TEST_BOOL_1);
     config->save();
     QVERIFY(!QFile::exists(CONF_FILE));
-    config->Section.String.set(config->Section.String.get().append(" Appended"));
+    config->Section.String.set(config->Section.String.get().append(QStringLiteral(" Appended")));
     config->save();
     QVERIFY(QFile::exists(CONF_FILE));
-    config->Section.String.set(config->Section.String.get().append(" Appended Again"));
+    config->Section.String.set(config->Section.String.get().append(QStringLiteral(" Appended Again")));
     config->save();
     QVERIFY(QFile::exists(CONF_FILE));
 }
@@ -85,8 +85,8 @@ void ConfigurationTest::Unused() {
     confFile.write("BadSectionValue=0\n");
     confFile.close();
     config->load();
-    config->String.set("Changed String");
-    config->Section.String.set("Changed String");
+    config->String.set(QStringLiteral("Changed String"));
+    config->Section.String.set(QStringLiteral("Changed String"));
     config->save();
     QFile::copy(CONF_FILE, CONF_FILE_COPY);
     config->load();
@@ -145,16 +145,16 @@ void ConfigurationTest::RightOnInit() {
     confFile.write("Custom=null\n");
     confFile.close();
     config = new TestConfig;
-    QVERIFY(config->String.get() == "a");
+    QVERIFY(config->String.get() == QStringLiteral("a"));
     QVERIFY(config->Int.get() == 99999);
-    QVERIFY(config->StringList.get() == QStringList({"a", "b", "c", "qwertzuiop"}));
+    QVERIFY(config->StringList.get() == QStringList({QStringLiteral("a"), QStringLiteral("b"), QStringLiteral("c"), QStringLiteral("qwertzuiop")}));
     QVERIFY(config->Boolean.get() == false);
     QVERIFY(config->Custom.get() == TestConfig::BAZ);
 }
 
 void ConfigurationTest::FileChanged()
 {
-    QVERIFY(config->String.get() == "Test Variable Initial String");
+    QVERIFY(config->String.get() == QStringLiteral("Test Variable Initial String"));
 
     //test from no file to a file
     QFile confFile(CONF_FILE);
@@ -163,7 +163,7 @@ void ConfigurationTest::FileChanged()
     confFile.close();
 
     config->load();
-    QVERIFY(config->String.get() == "a");
+    QVERIFY(config->String.get() == QStringLiteral("a"));
 
     //test file changed
     //wait 2 seconds so timestamp is definitely 1 second apart
@@ -174,7 +174,7 @@ void ConfigurationTest::FileChanged()
     confFile.close();
 
     config->load();
-    QVERIFY(config->String.get() == "b");
+    QVERIFY(config->String.get() == QStringLiteral("b"));
 }
 
 

--- a/test/ConfigurationTest.h
+++ b/test/ConfigurationTest.h
@@ -26,12 +26,13 @@
 
 #include "ConfigReader.h"
 
-#define CONF_FILE "test.conf"
-#define CONF_FILE_COPY "test_copy.conf"
+#define CONF_FILE QStringLiteral("test.conf")
+#define CONF_FILE_COPY QStringLiteral("test_copy.conf")
 
-#define TEST_STRING_1 "Test Variable Initial String"
+#define TEST_STRING_1_PLAIN "Test Variable Initial String"
+#define TEST_STRING_1 QStringLiteral(TEST_STRING_1_PLAIN)
 #define TEST_INT_1 12345
-#define TEST_STRINGLIST_1 {"String1", "String2"}
+#define TEST_STRINGLIST_1 {QStringLiteral("String1"), QStringLiteral("String2")}
 #define TEST_BOOL_1 true
 
 Config (TestConfig, CONF_FILE,
@@ -40,13 +41,13 @@ Config (TestConfig, CONF_FILE,
         BAR,
         BAZ
     };
-    Entry(    String,         QString,               _S(TEST_STRING_1), _S("Test String Description"));
+    Entry(    String,         QString,         _S(TEST_STRING_1_PLAIN), _S("Test String Description"));
     Entry(       Int,             int,                      TEST_INT_1, _S("Test Integer Description"));
     Entry(StringList,     QStringList,  QStringList(TEST_STRINGLIST_1), _S("Test StringList Description"));
     Entry(   Boolean,            bool,                     TEST_BOOL_1, _S("Test Boolean Description"));
     Entry(    Custom,      CustomType,                             FOO, _S("Custom type imitating NumState"));
     Section(Section,
-        Entry(    String,         QString,               _S(TEST_STRING_1), _S("Test String Description"));
+        Entry(    String,         QString,         _S(TEST_STRING_1_PLAIN), _S("Test String Description"));
         Entry(       Int,             int,                      TEST_INT_1, _S("Test Integer Description"));
         Entry(StringList,     QStringList,  QStringList(TEST_STRINGLIST_1), _S("Test StringList Description"));
         Entry(   Boolean,            bool,                     TEST_BOOL_1, _S("Test Boolean Description"));
@@ -55,9 +56,9 @@ Config (TestConfig, CONF_FILE,
 
 inline QTextStream& operator>>(QTextStream &str, TestConfig::CustomType &state) {
     QString text = str.readLine().trimmed();
-    if (text.compare("foo", Qt::CaseInsensitive) == 0)
+    if (text.compare(QLatin1String("foo"), Qt::CaseInsensitive) == 0)
         state = TestConfig::FOO;
-    else if (text.compare("bar", Qt::CaseInsensitive) == 0)
+    else if (text.compare(QLatin1String("bar"), Qt::CaseInsensitive) == 0)
         state = TestConfig::BAR;
     else
         state = TestConfig::BAZ;


### PR DESCRIPTION
To facilitate that, sprinkle a bunch of QStringLiteral() around string
literals and QLatin1Char() around char literals. In some places, I used
QLatin1String() instead of QStringLiteral() when the expression is used
as an argument to a function that has a QLatin1String overload (this is
advised by the Qt docs).

I also replaced empty strings like

    QString x = "";
    QString x { "" };
    funcWithQStringArg("");
    funcWithQStringArg(QString(""));

by the QString() default constructor, which yields an empty string more
efficiently:

    QString x;
    funcWithQStringArg(QString());

QString::fromLocal8Bit() was used whenever strings were read from C
libraries (e.g. PAM). For SDDM's own configuration files, I used
QString::fromUtf8(), under the assumption that most text editors today
default to UTF-8.

In some places, I also used the chance to optimize single-char string
literals to char literals, e.g.

    str << list.join(",");              //before
    str << list.join(QLatin1Char(',')); //after

**Testing done: It compiles and the ConfigurationTest passes. I don't have a test setup for actually running a compiled SDDM, so if someone could check that I didn't break anything, that would be highly appreciated.**

Closes: #469