### PR TITLE
Support external on screen keyboard

### DIFF
--- a/data/themes/maui/Main.qml
+++ b/data/themes/maui/Main.qml
@@ -256,7 +256,19 @@ Rectangle {
 
                     onClicked: sddm.powerOff()
 
-                    KeyNavigation.backtab: btnReboot; KeyNavigation.tab: prevUser
+                    KeyNavigation.backtab: btnReboot; KeyNavigation.tab: btnOSK
+                }
+				
+				Button {
+                    id: btnOSK
+                    height: parent.height
+                    text: "OSK"
+
+                    visible: true
+
+                    onClicked: sddm.showExtKeyboard()
+
+                    KeyNavigation.backtab: btnShutdown; KeyNavigation.tab: prevUser
                 }
             }
         }

--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -50,6 +50,7 @@ namespace SDDM {
             Entry(FacesDir,            QString,     _S(DATA_INSTALL_DIR "/faces"),              _S("Face icon directory\n"
                                                                                                    "The files should be in username.face.icon format"));
             Entry(CursorTheme,         QString,     QString(),                                  _S("Cursor theme"));
+			Entry(ExtKeyboard,         QString,     QString(),                                  _S("External Keyboard path"));
         );
         // TODO: Not absolutely sure if everything belongs here. Xsessions, VT and probably some more seem universal
         Section(XDisplay,

--- a/src/greeter/GreeterProxy.cpp
+++ b/src/greeter/GreeterProxy.cpp
@@ -244,7 +244,7 @@ namespace SDDM {
 			process_extKeyboard = new QProcess;
 			connect(process_extKeyboard, SIGNAL(finished(int, QProcess::ExitStatus)), this, SLOT(extKeyboard_finished(int, QProcess::ExitStatus)));
 			// extract command and arguments
-			QStringList arg_list = prog.split(" ");
+			QStringList arg_list = prog.split(QChar::Space);
 			QString cmd = arg_list.at(0);
 			arg_list.removeFirst();
 			qDebug() << "ExtKeyboard command: " << cmd << " arg: " << arg_list;

--- a/src/greeter/GreeterProxy.h
+++ b/src/greeter/GreeterProxy.h
@@ -54,6 +54,9 @@ namespace SDDM {
         bool isConnected() const;
 
         void setSessionModel(SessionModel *model);
+		
+	private:
+		void kill_process_extKeyboard();
 
     public slots:
         void powerOff();
@@ -61,6 +64,7 @@ namespace SDDM {
         void suspend();
         void hibernate();
         void hybridSleep();
+		void showExtKeyboard();
 
         void login(const QString &user, const QString &password, const int sessionIndex) const;
 
@@ -69,6 +73,7 @@ namespace SDDM {
         void disconnected();
         void readyRead();
         void error();
+		void extKeyboard_finished(int exitCode, QProcess::ExitStatus existStatus);
 
     signals:
         void hostNameChanged(const QString &hostName);
@@ -83,6 +88,7 @@ namespace SDDM {
 
     private:
         GreeterProxyPrivate *d { nullptr };
+		QProcess            *process_extKeyboard;
     };
 }
 

--- a/src/greeter/GreeterProxy.h
+++ b/src/greeter/GreeterProxy.h
@@ -21,6 +21,7 @@
 #define SDDM_GREETERPROXY_H
 
 #include <QObject>
+#include <QProcess>
 
 class QLocalSocket;
 


### PR DESCRIPTION
Add a feature that allows the greeter to call external keyboard application such as onboard:
- Add a new option in the sddm configuration file to set the on screen keyboard (likes lightdm-gtk-greeter)
- Add a new function for greeter to call external OSK application.