### PR TITLE
Add the ConsoleKit2 pam connector to the greeter

### DIFF
--- a/services/sddm-greeter.pam
+++ b/services/sddm-greeter.pam
@@ -15,3 +15,4 @@ password	required pam_deny.so
 # Setup session
 session		required pam_unix.so
 session		optional pam_systemd.so
+session		optional pam_ck_connector.so


### PR DESCRIPTION
This way a ConsoleKit2 session is setup the same way systemd-logind is.
See: https://github.com/sddm/sddm/issues/465