### PR TITLE
Close the pipe fd passed to X server.

### DIFF
--- a/src/daemon/XorgDisplayServer.cpp
+++ b/src/daemon/XorgDisplayServer.cpp
@@ -175,6 +175,10 @@ namespace SDDM {
                 return false;
             }
 
+            // close the other side of pipe in our process, otherwise reading
+            // from it may stuck even X server exit.
+            close(pipeFds[1]);
+
             QFile readPipe;
 
             if (!readPipe.open(pipeFds[0], QIODevice::ReadOnly)) {


### PR DESCRIPTION
If X server fails to write the display number to the pipe (E.G. crash), sddm may freeze on the next readLine call because it is still possible to read from it, which will freeze sddm.