### PR TITLE
Don't cast QByteArray to (char *)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ option(BUILD_MAN_PAGES "Build man pages" OFF)
 option(ENABLE_JOURNALD "Enable logging to journald" ON)
 
 # Definitions
-add_definitions(-Wall -std=c++11 -DQT_NO_CAST_FROM_ASCII)
+add_definitions(-Wall -std=c++11 -DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_FROM_BYTEARRAY)
 
 # Default build type
 if(NOT CMAKE_BUILD_TYPE)

--- a/src/helper/UserSession.cpp
+++ b/src/helper/UserSession.cpp
@@ -110,8 +110,8 @@ namespace SDDM {
             }
         }
 
-        const char  *username = qobject_cast<HelperApp*>(parent())->user().toLocal8Bit();
-        struct passwd *pw = getpwnam(username);
+        const QByteArray username = qobject_cast<HelperApp*>(parent())->user().toLocal8Bit();
+        struct passwd *pw = getpwnam(username.constData());
         if (setgid(pw->pw_gid) != 0) {
             qCritical() << "setgid(" << pw->pw_gid << ") failed for user: " << username;
             exit(Auth::HELPER_OTHER_ERROR);


### PR DESCRIPTION
Don't cast `QByteArray` to `char *`, they're [obsolete members](http://doc.qt.io/qt-5/qbytearray-obsolete.html) and caused #489
