### PR TITLE
Remove the failsafe session entry

### DIFF
--- a/data/scripts/Xsession
+++ b/data/scripts/Xsession
@@ -89,9 +89,6 @@ case $session in
   "")
     exec xmessage -center -buttons OK:0 -default OK "Sorry, $DESKTOP_SESSION is no valid session."
     ;;
-  failsafe)
-    exec xterm -geometry 80x24-0-0
-    ;;
   *)
     eval exec "$session"
     ;;

--- a/src/greeter/SessionModel.cpp
+++ b/src/greeter/SessionModel.cpp
@@ -130,14 +130,6 @@ namespace SDDM {
             if (execAllowed)
                 d->sessions.push_back(si);
         }
-        // add failsafe session
-        if (type == Session::X11Session) {
-            Session *si = new Session(type, QStringLiteral("failsafe"));
-            si->m_displayName = QStringLiteral("Failsafe");
-            si->m_comment = QStringLiteral("Failsafe Session");
-            si->m_exec = QStringLiteral("failsafe");
-            d->sessions << si;
-        }
         // find out index of the last session
         for (int i = 0; i < d->sessions.size(); ++i) {
             if (d->sessions.at(i)->fileName() == stateConfig.Last.Session.get()) {


### PR DESCRIPTION
The failsafe session can indeed fail if xterm is missing.
For this reason it doesn't hold much value and is a source of bugs.

Closes #515