### PR TITLE
Improve German translations

### DIFF
--- a/data/translations/de.ts
+++ b/data/translations/de.ts
@@ -9,7 +9,7 @@
     </message>
     <message>
         <source>Warning, Caps Lock is ON!</source>
-        <translation>Achtung, dauerhafte Großschreibung ist aktiviert!</translation>
+        <translation>Achtung, Feststelltaste ist aktiviert!</translation>
     </message>
     <message>
         <source>Layout</source>
@@ -53,7 +53,7 @@
     </message>
     <message>
         <source>Select your user and enter password</source>
-        <translation>Benutzername auswählen und Passwort eingeben</translation>
+        <translation>Benutzer auswählen und Passwort eingeben</translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
Just two minor edits to the German translation:
* The German word for the 'Caps Lock' key is 'Feststelltaste'. I think this is better than 'permanent upper case'.
* Very minor; 'User' was translated as 'Benutzername' ('User name') instead of 'Benutzer'. The original English message (with 'user') also makes more sense in this context, especially since not only the name but also a profile picture of the user can be displayed.