### PR TITLE
Align flag name to CI settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ include(GNUInstallDirs)
 find_package(PkgConfig)
 
 # PAM
-if(NOT NO_PAM)
+if(USE_PAM)
     find_package(PAM)
 
     if(PAM_FOUND)


### PR DESCRIPTION
In Travis CI config, we have a bool flag `USE_PAM` for `cmake`.