### PR TITLE
Execute /etc/X11/Xsession if available

### DIFF
--- a/src/helper/UserSession.cpp
+++ b/src/helper/UserSession.cpp
@@ -48,6 +48,7 @@ namespace SDDM {
         } else if (env.value(QStringLiteral("XDG_SESSION_TYPE")) == QStringLiteral("x11")) {
             qDebug() << "Starting:" << mainConfig.X11.SessionCommand.get()
                      << m_path;
+            env.insert(QStringLiteral("STARTUP"), m_path);
             QProcess::start(mainConfig.X11.SessionCommand.get(),
                             QStringList() << m_path);
         } else if (env.value(QStringLiteral("XDG_SESSION_TYPE")) == QStringLiteral("wayland")) {


### PR DESCRIPTION
Ubuntu already provides a /etc/X11/Xsession script which executes
the /etc/X11/Xsession.d scripts.

Those scripts already do the Xresource merge and other actions.

The last script from /etc/X11/Xsession.d executes the session
command specified by $STARTUP, if that is empty it will try
to determine it by itself with the risk of executing something
else.

With this patch we let distros shipping /etc/X11/Xsession to
execute the designated session command and handle Xresource
merge and stuff like that by itself.

At least two other major distributions such as Fedora and
ArchLinux do not have /etc/X11/Xsession, in that case we
will keep the Xresource merge code path and run the session
command ourselves.

Fixes #449
