### PR TITLE
Expose arrow background color

### DIFF
--- a/components/2.0/ComboBox.qml
+++ b/components/2.0/ComboBox.qml
@@ -36,6 +36,7 @@ FocusScope {
     property font font
     property alias model: listView.model
     property int index: 0
+    property alias arrowColor: arrow.color
     property alias arrowIcon: arrowIcon.source
 
     property Component rowDelegate: defaultRowDelegate


### PR DESCRIPTION
Let themes change the arrow background color.
Closes #542.

[ChangeLog][Components] ComboBox now exposes the arrow background color.