### PR TITLE
Rename XDisplay and WaylandDisplay config sections

### DIFF
--- a/data/man/sddm.conf.rst.in
+++ b/data/man/sddm.conf.rst.in
@@ -67,7 +67,7 @@ OPTIONS
 	them altogether.
 	Default value is true.
 
-[XDisplay] section:
+[X11] section:
 
 `ServerPath=`
 	Path of the X server.
@@ -115,7 +115,7 @@ OPTIONS
 	increase as new displays added.
 	Default value is @MINIMUM_VT@.
 
-[WaylandDisplay] section:
+[Wayland] section:
 
 `SessionDir=`
 	Path of the directory containing session files.

--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -56,7 +56,7 @@ namespace SDDM {
         );
 
         // TODO: Not absolutely sure if everything belongs here. Xsessions, VT and probably some more seem universal
-        Section(XDisplay,
+        Section(X11,
             Entry(ServerPath,          QString,     _S("/usr/bin/X"),                           _S("Path to X server binary"));
             Entry(ServerArguments,     QString,     _S("-nolisten tcp"),                        _S("Arguments passed to the X server invocation"));
             Entry(XephyrPath,          QString,     _S("/usr/bin/Xephyr"),                      _S("Path to Xephyr binary"));
@@ -70,7 +70,7 @@ namespace SDDM {
             Entry(MinimumVT,           int,         MINIMUM_VT,                                 _S("The lowest virtual terminal number that will be used."));
         );
 
-        Section(WaylandDisplay,
+        Section(Wayland,
             Entry(SessionDir,          QString,     _S("/usr/share/wayland-sessions"),          _S("Directory containing available Wayland sessions"));
             Entry(SessionCommand,      QString,     _S(WAYLAND_SESSION_COMMAND),                _S("Path to a script to execute when starting the desktop session"));
 	    Entry(SessionLogFile,      QString,     _S(".cache/wayland-errors"),                       _S("Path to the user session log file"));

--- a/src/common/Session.cpp
+++ b/src/common/Session.cpp
@@ -108,11 +108,11 @@ namespace SDDM {
 
         switch (type) {
         case X11Session:
-            m_dir = QDir(mainConfig.XDisplay.SessionDir.get());
+            m_dir = QDir(mainConfig.X11.SessionDir.get());
             m_xdgSessionType = QStringLiteral("x11");
             break;
         case WaylandSession:
-            m_dir = QDir(mainConfig.WaylandDisplay.SessionDir.get());
+            m_dir = QDir(mainConfig.Wayland.SessionDir.get());
             m_xdgSessionType = QStringLiteral("wayland");
             break;
         default:

--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -108,9 +108,9 @@ namespace SDDM {
 
         // determine session type
         const QString &autologinSession = mainConfig.Autologin.Session.get();
-        if (findSessionEntry(mainConfig.XDisplay.SessionDir.get(), autologinSession)) {
+        if (findSessionEntry(mainConfig.X11.SessionDir.get(), autologinSession)) {
             sessionType = Session::X11Session;
-        } else if (findSessionEntry(mainConfig.WaylandDisplay.SessionDir.get(), autologinSession)) {
+        } else if (findSessionEntry(mainConfig.Wayland.SessionDir.get(), autologinSession)) {
             sessionType = Session::WaylandSession;
         } else {
             qCritical() << "Unable to find autologin session entry" << autologinSession;

--- a/src/daemon/Seat.cpp
+++ b/src/daemon/Seat.cpp
@@ -57,7 +57,7 @@ namespace SDDM {
         
         if (terminalId == -1) {
                 // find unused terminal
-            terminalId = findUnused(mainConfig.XDisplay.MinimumVT.get(), [&](const int number) {
+            terminalId = findUnused(mainConfig.X11.MinimumVT.get(), [&](const int number) {
                 return m_terminalIds.contains(number);
             });
         }

--- a/src/daemon/XorgDisplayServer.cpp
+++ b/src/daemon/XorgDisplayServer.cpp
@@ -95,7 +95,7 @@ namespace SDDM {
         file_handler.open(QIODevice::WriteOnly);
         file_handler.close();
 
-        QString cmd = QStringLiteral("%1 -f %2 -q").arg(mainConfig.XDisplay.XauthPath.get()).arg(file);
+        QString cmd = QStringLiteral("%1 -f %2 -q").arg(mainConfig.X11.XauthPath.get()).arg(file);
 
         // execute xauth
         FILE *fp = popen(qPrintable(cmd), "w");
@@ -128,7 +128,7 @@ namespace SDDM {
         if (daemonApp->testing()) {
             QStringList args;
             args << m_display << QStringLiteral("-ac") << QStringLiteral("-br") << QStringLiteral("-noreset") << QStringLiteral("-screen") << QStringLiteral("800x600");
-            process->start(mainConfig.XDisplay.XephyrPath.get(), args);
+            process->start(mainConfig.X11.XephyrPath.get(), args);
 
 
             // wait for display server to start
@@ -154,16 +154,16 @@ namespace SDDM {
             }
 
             // start display server
-            QStringList args = mainConfig.XDisplay.ServerArguments.get().split(QLatin1Char(' '), QString::SkipEmptyParts);
+            QStringList args = mainConfig.X11.ServerArguments.get().split(QLatin1Char(' '), QString::SkipEmptyParts);
             args << QStringLiteral("-auth") << m_authPath
                  << QStringLiteral("-background") << QStringLiteral("none")
                  << QStringLiteral("-noreset")
                  << QStringLiteral("-displayfd") << QString::number(pipeFds[1])
                  << QStringLiteral("vt%1").arg(displayPtr()->terminalId());
             qDebug() << "Running:"
-                     << qPrintable(mainConfig.XDisplay.ServerPath.get())
+                     << qPrintable(mainConfig.X11.ServerPath.get())
                      << qPrintable(args.join(QLatin1Char(' ')));
-            process->start(mainConfig.XDisplay.ServerPath.get(), args);
+            process->start(mainConfig.X11.ServerPath.get(), args);
 
             // wait for display server to start
             if (!process->waitForStarted()) {
@@ -236,7 +236,7 @@ namespace SDDM {
         // log message
         qDebug() << "Display server stopped.";
 
-        QString displayStopCommand = mainConfig.XDisplay.DisplayStopCommand.get();
+        QString displayStopCommand = mainConfig.X11.DisplayStopCommand.get();
 
         // create display setup script process
         QProcess *displayStopScript = new QProcess();
@@ -273,7 +273,7 @@ namespace SDDM {
     }
 
     void XorgDisplayServer::setupDisplay() {
-        QString displayCommand = mainConfig.XDisplay.DisplayCommand.get();
+        QString displayCommand = mainConfig.X11.DisplayCommand.get();
 
         // create display setup script process
         QProcess *displayScript = new QProcess();

--- a/src/greeter/SessionModel.cpp
+++ b/src/greeter/SessionModel.cpp
@@ -38,8 +38,8 @@ namespace SDDM {
     };
 
     SessionModel::SessionModel(QObject *parent) : QAbstractListModel(parent), d(new SessionModelPrivate()) {
-        populate(Session::X11Session, mainConfig.XDisplay.SessionDir.get());
-        populate(Session::WaylandSession, mainConfig.WaylandDisplay.SessionDir.get());
+        populate(Session::X11Session, mainConfig.X11.SessionDir.get());
+        populate(Session::WaylandSession, mainConfig.Wayland.SessionDir.get());
     }
 
     SessionModel::~SessionModel() {

--- a/src/helper/Backend.cpp
+++ b/src/helper/Backend.cpp
@@ -67,7 +67,7 @@ namespace SDDM {
                 // determine Xauthority path
                 QString value = QStringLiteral("%1/%2")
                         .arg(QString::fromLocal8Bit(pw->pw_dir))
-                        .arg(mainConfig.XDisplay.UserAuthFile.get());
+                        .arg(mainConfig.X11.UserAuthFile.get());
                 env.insert(QStringLiteral("XAUTHORITY"), value);
             }
             // TODO: I'm fairly sure this shouldn't be done for PAM sessions, investigate!

--- a/src/helper/UserSession.cpp
+++ b/src/helper/UserSession.cpp
@@ -46,14 +46,14 @@ namespace SDDM {
         if (env.value(QStringLiteral("XDG_SESSION_CLASS")) == QStringLiteral("greeter")) {
             QProcess::start(m_path);
         } else if (env.value(QStringLiteral("XDG_SESSION_TYPE")) == QStringLiteral("x11")) {
-            qDebug() << "Starting:" << mainConfig.XDisplay.SessionCommand.get()
+            qDebug() << "Starting:" << mainConfig.X11.SessionCommand.get()
                      << m_path;
-            QProcess::start(mainConfig.XDisplay.SessionCommand.get(),
+            QProcess::start(mainConfig.X11.SessionCommand.get(),
                             QStringList() << m_path);
         } else if (env.value(QStringLiteral("XDG_SESSION_TYPE")) == QStringLiteral("wayland")) {
-            qDebug() << "Starting:" << mainConfig.WaylandDisplay.SessionCommand.get()
+            qDebug() << "Starting:" << mainConfig.Wayland.SessionCommand.get()
                      << m_path;
-            QProcess::start(mainConfig.WaylandDisplay.SessionCommand.get(),
+            QProcess::start(mainConfig.Wayland.SessionCommand.get(),
                             QStringList() << m_path);
         } else {
             qCritical() << "Unable to run user session: unknown session type";
@@ -137,8 +137,8 @@ namespace SDDM {
         QString sessionLog = QStringLiteral("%1/%2")
                 .arg(QString::fromLocal8Bit(pw->pw_dir))
                 .arg(sessionType == QStringLiteral("x11")
-                     ? mainConfig.XDisplay.SessionLogFile.get()
-                     : mainConfig.WaylandDisplay.SessionLogFile.get());
+                     ? mainConfig.X11.SessionLogFile.get()
+                     : mainConfig.Wayland.SessionLogFile.get());
 
         // create the path
         QFileInfo finfo(sessionLog);
@@ -182,7 +182,7 @@ namespace SDDM {
             file_handler.open(QIODevice::WriteOnly);
             file_handler.close();
 
-            QString cmd = QStringLiteral("%1 -f %2 -q").arg(mainConfig.XDisplay.XauthPath.get()).arg(file);
+            QString cmd = QStringLiteral("%1 -f %2 -q").arg(mainConfig.X11.XauthPath.get()).arg(file);
 
             // execute xauth
             FILE *fp = popen(qPrintable(cmd), "w");


### PR DESCRIPTION
Closes #536

[ChangeLog][Configuration] Rename XDisplay section to X11 and
WaylandDisplay to Wayland because the "Display" part is unnecessary.