### PR TITLE
Add UsersThresholdToDisableAvatars (and more)

### DIFF
--- a/src/common/ConfigReader.cpp
+++ b/src/common/ConfigReader.cpp
@@ -186,17 +186,17 @@ namespace SDDM {
          * Initialization of the map of nondefault values to be saved
          */
         if (section) {
-            if (entry && !entry->isDefault())
+            if (entry && !entry->matchesDefault())
                 remainingEntries.insert(section, entry);
             else
                 for (const ConfigEntryBase *b : section->entries().values())
-                    if (!b->isDefault())
+                    if (!b->matchesDefault())
                         remainingEntries.insert(section, b);
         }
         else {
             for (const ConfigSection *s : m_sections)
                 for (const ConfigEntryBase *b : s->entries().values())
-                    if (!b->isDefault())
+                    if (!b->matchesDefault())
                         remainingEntries.insert(s, b);
         }
 

--- a/src/common/ConfigReader.h
+++ b/src/common/ConfigReader.h
@@ -77,6 +77,7 @@ namespace SDDM {
         virtual void setValue(const QString &str) = 0;
         virtual QString toConfigShort() const = 0;
         virtual QString toConfigFull() const = 0;
+        virtual bool matchesDefault() const = 0;
         virtual bool isDefault() const = 0;
     };
 
@@ -107,6 +108,7 @@ namespace SDDM {
             m_description(description),
             m_default(value),
             m_value(value),
+            m_isDefault(true),
             m_parent(parent) {
             m_parent->m_entries[name] = this;
         }
@@ -117,13 +119,19 @@ namespace SDDM {
 
         void set(const T val) {
             m_value = val;
+            m_isDefault = false;
         }
 
-        bool isDefault() const {
+        bool matchesDefault() const {
             return m_value == m_default;
         }
 
+        bool isDefault() const {
+            return m_isDefault;
+        }
+
         bool setDefault() {
+            m_isDefault = true;
             if (m_value == m_default)
                 return false;
             m_value = m_default;
@@ -147,6 +155,7 @@ namespace SDDM {
 
         // specialised for QString
         void setValue(const QString &str) {
+            m_isDefault = false;
             QTextStream in(qPrintable(str));
             in >> m_value;
         }
@@ -167,6 +176,7 @@ namespace SDDM {
         const QString m_description;
         T m_default;
         T m_value;
+        bool m_isDefault;
         ConfigSection *m_parent;
     };
 

--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -50,6 +50,9 @@ namespace SDDM {
                                                                                                    "The files should be named <username>.face.icon"));
             Entry(CursorTheme,         QString,     QString(),                                  _S("Cursor theme used in the greeter"));
             Entry(EnableAvatars,       bool,        true,                                       _S("Enable display of custom user avatars"));
+            Entry(DisableAvatarsThreshold,int,      7,                                          _S("Number of users to use as threshold\n"
+                                                                                                   "above which avatars are disabled\n"
+                                                                                                   "unless explicitly enabled with EnableAvatars"));
         );
 
         // TODO: Not absolutely sure if everything belongs here. Xsessions, VT and probably some more seem universal

--- a/src/greeter/UserModel.h
+++ b/src/greeter/UserModel.h
@@ -32,6 +32,7 @@ namespace SDDM {
         Q_DISABLE_COPY(UserModel)
         Q_PROPERTY(int lastIndex READ lastIndex CONSTANT)
         Q_PROPERTY(QString lastUser READ lastUser CONSTANT)
+        Q_PROPERTY(int count READ rowCount CONSTANT)
     public:
         enum UserRoles {
             NameRole = Qt::UserRole + 1,

--- a/src/greeter/UserModel.h
+++ b/src/greeter/UserModel.h
@@ -33,6 +33,7 @@ namespace SDDM {
         Q_PROPERTY(int lastIndex READ lastIndex CONSTANT)
         Q_PROPERTY(QString lastUser READ lastUser CONSTANT)
         Q_PROPERTY(int count READ rowCount CONSTANT)
+        Q_PROPERTY(int disableAvatarsThreshold READ disableAvatarsThreshold CONSTANT)
     public:
         enum UserRoles {
             NameRole = Qt::UserRole + 1,
@@ -53,6 +54,7 @@ namespace SDDM {
         int rowCount(const QModelIndex &parent = QModelIndex()) const override;
         QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
 
+        int disableAvatarsThreshold() const;
     private:
         UserModelPrivate *d { nullptr };
     };


### PR DESCRIPTION
This pull request:
- Adds a count property to UserModel with the number of users in the model.
- Renames ConfigReader::isDefault() to matchesDefault() since that's what it really do.
- Adds a real ConfigReader::isDefault() so we can check if a value was explictly set, or its value is just the default (so we can check if EnableAvatars was explicitly set to true or it's true just because that's the default and so, it can be overriden by usersThresholdToDisableAvatars)
- Adds a new config setting UsersThresholdToDisableAvatars. This is the number of users to use as threshold above which avatars are disabled automatically unless explicitly enabled with EnableAvatars.
- Adds a usersThresholdToDisableAvatars to UserModel

I've also changed plasma's breeze theme to use all this to show either a user list (with avatars) or username/password editlines depending on the number of users in the system, the value of usersThresholdToDisableAvatars.

This fixes the sddm problems in systems with a large number of users and NFS mounted homes as in https://bugzilla.opensuse.org/show_bug.cgi?id=953778