### PR TITLE
Only allocate VTs for seat0. Preparing for multi-seat support (#78).

### DIFF
--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -271,10 +271,12 @@ namespace SDDM {
         qDebug() << "Session" << m_sessionName << "selected, command:" << session.exec();
 
         // create new VT for Wayland sessions otherwise use greeter vt
-        int vt = terminalId();
-        if (session.xdgSessionType() == QLatin1String("wayland")) {
-            vt = VirtualTerminal::setUpNewVt();
-            VirtualTerminal::jumpToVt(vt);
+        if (seat()->name() == "seat0") {
+            int vt = terminalId();
+            if (session.xdgSessionType() == QLatin1String("wayland")) {
+                vt = VirtualTerminal::setUpNewVt();
+                VirtualTerminal::jumpToVt(vt);
+            }
         }
 
         QProcessEnvironment env;
@@ -284,7 +286,8 @@ namespace SDDM {
         env.insert(QStringLiteral("XDG_SEAT"), seat()->name());
         env.insert(QStringLiteral("XDG_SEAT_PATH"), daemonApp->displayManager()->seatPath(seat()->name()));
         env.insert(QStringLiteral("XDG_SESSION_PATH"), daemonApp->displayManager()->sessionPath(QStringLiteral("Session%1").arg(daemonApp->newSessionId())));
-        env.insert(QStringLiteral("XDG_VTNR"), QString::number(vt));
+        if (seat()->name() == "seat0")
+            env.insert(QStringLiteral("XDG_VTNR"), QString::number(vt));
         env.insert(QStringLiteral("DESKTOP_SESSION"), session.desktopSession());
         env.insert(QStringLiteral("XDG_CURRENT_DESKTOP"), session.desktopNames());
         env.insert(QStringLiteral("XDG_SESSION_CLASS"), QStringLiteral("user"));

--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -271,8 +271,8 @@ namespace SDDM {
         qDebug() << "Session" << m_sessionName << "selected, command:" << session.exec();
 
         // create new VT for Wayland sessions otherwise use greeter vt
+        int vt = terminalId();
         if (seat()->name() == QStringLiteral("seat0")) {
-            int vt = terminalId();
             if (session.xdgSessionType() == QLatin1String("wayland")) {
                 vt = VirtualTerminal::setUpNewVt();
                 VirtualTerminal::jumpToVt(vt);

--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -271,7 +271,7 @@ namespace SDDM {
         qDebug() << "Session" << m_sessionName << "selected, command:" << session.exec();
 
         // create new VT for Wayland sessions otherwise use greeter vt
-        if (seat()->name() == "seat0") {
+        if (seat()->name() == QStringLiteral("seat0")) {
             int vt = terminalId();
             if (session.xdgSessionType() == QLatin1String("wayland")) {
                 vt = VirtualTerminal::setUpNewVt();
@@ -286,7 +286,7 @@ namespace SDDM {
         env.insert(QStringLiteral("XDG_SEAT"), seat()->name());
         env.insert(QStringLiteral("XDG_SEAT_PATH"), daemonApp->displayManager()->seatPath(seat()->name()));
         env.insert(QStringLiteral("XDG_SESSION_PATH"), daemonApp->displayManager()->sessionPath(QStringLiteral("Session%1").arg(daemonApp->newSessionId())));
-        if (seat()->name() == "seat0")
+        if (seat()->name() == QStringLiteral("seat0"))
             env.insert(QStringLiteral("XDG_VTNR"), QString::number(vt));
         env.insert(QStringLiteral("DESKTOP_SESSION"), session.desktopSession());
         env.insert(QStringLiteral("XDG_CURRENT_DESKTOP"), session.desktopNames());

--- a/src/daemon/Greeter.cpp
+++ b/src/daemon/Greeter.cpp
@@ -142,7 +142,7 @@ namespace SDDM {
             env.insert(QStringLiteral("XDG_SEAT"), m_display->seat()->name());
             env.insert(QStringLiteral("XDG_SEAT_PATH"), daemonApp->displayManager()->seatPath(m_display->seat()->name()));
             env.insert(QStringLiteral("XDG_SESSION_PATH"), daemonApp->displayManager()->sessionPath(QStringLiteral("Session%1").arg(daemonApp->newSessionId())));
-            if (m_display->seat()->name() == "seat0")
+            if (m_display->seat()->name() == QStringLiteral("seat0"))
                 env.insert(QStringLiteral("XDG_VTNR"), QString::number(m_display->terminalId()));
             env.insert(QStringLiteral("XDG_SESSION_CLASS"), QStringLiteral("greeter"));
             env.insert(QStringLiteral("XDG_SESSION_TYPE"), m_display->sessionType());

--- a/src/daemon/Greeter.cpp
+++ b/src/daemon/Greeter.cpp
@@ -142,7 +142,8 @@ namespace SDDM {
             env.insert(QStringLiteral("XDG_SEAT"), m_display->seat()->name());
             env.insert(QStringLiteral("XDG_SEAT_PATH"), daemonApp->displayManager()->seatPath(m_display->seat()->name()));
             env.insert(QStringLiteral("XDG_SESSION_PATH"), daemonApp->displayManager()->sessionPath(QStringLiteral("Session%1").arg(daemonApp->newSessionId())));
-            env.insert(QStringLiteral("XDG_VTNR"), QString::number(m_display->terminalId()));
+            if (m_display->seat()->name() == "seat0")
+                env.insert(QStringLiteral("XDG_VTNR"), QString::number(m_display->terminalId()));
             env.insert(QStringLiteral("XDG_SESSION_CLASS"), QStringLiteral("greeter"));
             env.insert(QStringLiteral("XDG_SESSION_TYPE"), m_display->sessionType());
 

--- a/src/daemon/Seat.cpp
+++ b/src/daemon/Seat.cpp
@@ -55,7 +55,7 @@ namespace SDDM {
         //reload config if needed
         mainConfig.load();
 
-        if (m_name == "seat0") {
+        if (m_name == QStringLiteral("seat0")) {
             if (terminalId == -1) {
                 // find unused terminal
                 terminalId = findUnused(mainConfig.XDisplay.MinimumVT.get(), [&](const int number) {

--- a/src/daemon/Seat.cpp
+++ b/src/daemon/Seat.cpp
@@ -54,19 +54,23 @@ namespace SDDM {
     void Seat::createDisplay(int terminalId) {
         //reload config if needed
         mainConfig.load();
-        
-        if (terminalId == -1) {
+
+        if (m_name == "seat0") {
+            if (terminalId == -1) {
                 // find unused terminal
-            terminalId = findUnused(mainConfig.XDisplay.MinimumVT.get(), [&](const int number) {
-                return m_terminalIds.contains(number);
-            });
+                terminalId = findUnused(mainConfig.XDisplay.MinimumVT.get(), [&](const int number) {
+                    return m_terminalIds.contains(number);
+                });
+            }
+
+            // mark terminal as used
+            m_terminalIds << terminalId;
+
+            // log message
+            qDebug() << "Adding new display" << "on vt" << terminalId << "...";
+        } else {
+            qDebug() << "Adding new VT-less display...";
         }
-
-        // mark terminal as used
-        m_terminalIds << terminalId;
-
-        // log message
-        qDebug() << "Adding new display" << "on vt" << terminalId << "...";
 
         // create a new display
         Display *display = new Display(terminalId, this);

--- a/src/daemon/XorgDisplayServer.cpp
+++ b/src/daemon/XorgDisplayServer.cpp
@@ -161,7 +161,7 @@ namespace SDDM {
                  << QStringLiteral("-noreset")
                  << QStringLiteral("-displayfd") << QString::number(pipeFds[1])
                  << QStringLiteral("-seat") << displayPtr()->seat()->name();
-            if (displayPtr()->seat()->name() == "seat0")
+            if (displayPtr()->seat()->name() == QStringLiteral("seat0"))
                  args << QStringLiteral("vt%1").arg(displayPtr()->terminalId());
             qDebug() << "Running:"
                      << qPrintable(mainConfig.XDisplay.ServerPath.get())

--- a/src/daemon/XorgDisplayServer.cpp
+++ b/src/daemon/XorgDisplayServer.cpp
@@ -23,6 +23,7 @@
 #include "Configuration.h"
 #include "DaemonApp.h"
 #include "Display.h"
+#include "Seat.h"
 #include "SignalHandler.h"
 
 #include <QDebug>
@@ -159,7 +160,9 @@ namespace SDDM {
                  << QStringLiteral("-background") << QStringLiteral("none")
                  << QStringLiteral("-noreset")
                  << QStringLiteral("-displayfd") << QString::number(pipeFds[1])
-                 << QStringLiteral("vt%1").arg(displayPtr()->terminalId());
+                 << QStringLiteral("-seat") << displayPtr()->seat()->name();
+            if (displayPtr()->seat()->name() == "seat0")
+                 args << QStringLiteral("vt%1").arg(displayPtr()->terminalId());
             qDebug() << "Running:"
                      << qPrintable(mainConfig.XDisplay.ServerPath.get())
                      << qPrintable(args.join(QLatin1Char(' ')));


### PR DESCRIPTION
Only systemd-logind special seat named "seat0" can handle VTs, so there's no sense in allocating VTs for seats other than seat0.

This is a preparation step for multi-seat support (see issue #78). The missing parts for full multi-seat support (specially those regarding DBus interaction with systemd-logind) will come later.