### PR TITLE
Fixed spanish translation

### DIFF
--- a/data/translations/es.ts
+++ b/data/translations/es.ts
@@ -9,7 +9,7 @@
     </message>
     <message>
         <source>Warning, Caps Lock is ON!</source>
-        <translation>Atencio, Mayusculas estan encendidas!</translation>
+        <translation>¡Atención, el bloqueo de mayúsculas está activado!</translation>
     </message>
     <message>
         <source>Layout</source>
@@ -17,15 +17,15 @@
     </message>
     <message>
         <source>Login</source>
-        <translation>Iniciar sesiòn</translation>
+        <translation>Iniciar sesión</translation>
     </message>
     <message>
         <source>Login failed</source>
-        <translation>Inicio de sesiòn fallido</translation>
+        <translation>Inicio de sesión fallido</translation>
     </message>
     <message>
         <source>Login succeeded</source>
-        <translation>Inicio de sesiòn correcto</translation>
+        <translation>Inicio de sesión correcto</translation>
     </message>
     <message>
         <source>Password</source>
@@ -41,7 +41,7 @@
     </message>
     <message>
         <source>Session</source>
-        <translation>Sesiòn</translation>
+        <translation>Sesión</translation>
     </message>
     <message>
         <source>Shutdown</source>


### PR DESCRIPTION
* The acute marks were reversed.
* Corrected one spelling error ("Atencio").
* Rephrased "Caps Lock On" warning.