### PR TITLE
Simplify reading lists from configuration

### DIFF
--- a/src/common/ConfigReader.cpp
+++ b/src/common/ConfigReader.cpp
@@ -31,13 +31,10 @@
 QTextStream &operator>>(QTextStream &str, QStringList &list)  {
     list.clear();
     QString line = str.readLine();
-    while (!line.isNull()) {
-        Q_FOREACH (const QStringRef &s, line.splitRef(QLatin1Char(','))) {
-            QStringRef trimmed = s.trimmed();
-            if (!trimmed.isEmpty())
-                list.append(trimmed.toString());
-        }
-        line = str.readLine();
+    Q_FOREACH (const QStringRef &s, line.splitRef(QLatin1Char(','))) {
+        QStringRef trimmed = s.trimmed();
+        if (!trimmed.isEmpty())
+            list.append(trimmed.toString());
     }
     return str;
 }


### PR DESCRIPTION
Remove unnecessary loop when parsing lists. The issue fixed in
56f64173991204a1eea4bf6789d68555b94e3eae was caused by a dangling-reference
error.  Store readLine() so that it doesn't go out-of-scope while we
process splitRef().