### PR TITLE
Allow to start several sessions

### DIFF
--- a/data/man/sddm.conf.rst.in
+++ b/data/man/sddm.conf.rst.in
@@ -115,6 +115,10 @@ OPTIONS
 	increase as new displays added.
 	Default value is @MINIMUM_VT@.
 
+`VTCount=`
+	Number of instances that should be started.
+	Default value is 1.
+
 [Wayland] section:
 
 `SessionDir=`

--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -68,6 +68,7 @@ namespace SDDM {
             Entry(DisplayCommand,      QString,     _S(DATA_INSTALL_DIR "/scripts/Xsetup"),     _S("Path to a script to execute when starting the display server"));
             Entry(DisplayStopCommand,  QString,     _S(DATA_INSTALL_DIR "/scripts/Xstop"),      _S("Path to a script to execute when stopping the display server"));
             Entry(MinimumVT,           int,         MINIMUM_VT,                                 _S("The lowest virtual terminal number that will be used."));
+            Entry(VTCount,             int,         1,                                          _S("The number of instaces to be started."));
         );
 
         Section(Wayland,

--- a/src/daemon/Seat.cpp
+++ b/src/daemon/Seat.cpp
@@ -44,7 +44,12 @@ namespace SDDM {
     }
 
     Seat::Seat(const QString &name, QObject *parent) : QObject(parent), m_name(name) {
-        createDisplay();
+        int created = 0;
+
+        while (created < mainConfig.X11.VTCount.get()) {
+          createDisplay();
+          created++;
+        }
     }
 
     const QString &Seat::name() const {


### PR DESCRIPTION
Set the VTCount configuration option to specify how many sessions
should be started. Default value is 1.

There have been discussions on IRC about it before and the result is this small change.