### PR TITLE
Cache dependencies, local build and fetch Qt official binaries for CI

### DIFF
--- a/.ci/fetch-cmake
+++ b/.ci/fetch-cmake
@@ -1,0 +1,62 @@
+#!/bin/bash
+#
+# Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. The name of the author may not be used to endorse or promote products
+#    derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+# NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+# THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+cmake_series=3.3
+cmake_ver=3.3.0
+
+ecm_series=5.12
+ecm_ver=5.12.0
+
+dir=`pwd`
+
+export PATH=$dir/.cmake/$cmake_series/bin:$PATH
+
+# cmake
+if [ ! -d $dir/.cmake/$cmake_series/bin ]; then
+    rm -rf $dir/.cmake/$cmake_series
+    mkdir -p $dir/.cmake
+    cmake_basename="cmake-${cmake_ver}-Linux-x86_64"
+    wget --no-check-certificate http://www.cmake.org/files/v${cmake_series}/${cmake_basename}.tar.gz -O cmake.tar.gz
+    tar -xzf cmake.tar.gz -C $dir
+    mv $dir/${cmake_basename} $dir/.cmake/$cmake_series
+fi
+cmake --version
+
+# extra-cmake-modules
+if [ ! -d $dir/.cmake/$cmake_series/share/ECM ]; then
+    ecm_basename="extra-cmake-modules-${ecm_ver}"
+    wget --no-check-certificate http://download.kde.org/stable/frameworks/${ecm_series}/${ecm_basename}.tar.xz -O ecm.tar.xz
+    tar -xJf ecm.tar.xz
+    pushd ${ecm_basename}
+    rm -rf build
+    mkdir build
+    cd build
+    cmake .. -DCMAKE_INSTALL_PREFIX=$dir/.cmake/$cmake_series
+    make && make install
+    popd
+fi

--- a/.ci/fetch-qt
+++ b/.ci/fetch-qt
@@ -1,0 +1,48 @@
+#!/bin/bash
+#
+# Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. The name of the author may not be used to endorse or promote products
+#    derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+# NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+# THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+qt_series=5.6
+qt_ver=5.6.0
+
+dir=`pwd`
+
+export PATH=$dir/.qt/$qt_series/bin:$PATH
+
+# Qt
+if [ ! -d $dir/.qt/$qt_series/$qt_series/gcc_64 ]; then
+    rm -rf $dir/.qt/$qt_series
+    mkdir -p $dir/.qt
+    qt_url="http://download.qt.io/official_releases/qt/${qt_series}/${qt_ver}"
+    qt_basename="qt-opensource-linux-x64-${qt_ver}"
+    wget --no-check-certificate ${qt_url}/${qt_basename}.run
+    wget --no-check-certificate ${qt_url}/${qt_basename}.run.sha256
+    sha256sum -c ${qt_basename}.run.sha256 || exit $?
+    curl https://raw.githubusercontent.com/hawaii-desktop/repotools/master/ci/extract-qt-installer >extract-qt-installer
+    chmod u+x extract-qt-installer
+    QT_QPA_PLATFORM=minimal ./extract-qt-installer ${qt_basename}.run $dir/.qt/$qt_series
+fi

--- a/.ci/fetch-xcb
+++ b/.ci/fetch-xcb
@@ -1,0 +1,56 @@
+#!/bin/bash
+#
+# Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. The name of the author may not be used to endorse or promote products
+#    derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+# NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+# THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+xcb_series=1.11
+xcb_ver=1.11.1
+
+dir=`pwd`
+
+export PATH=$dir/.xcb/$xcb_series/bin:$PATH
+
+# xcb
+if [ ! -d $dir/.xcb/$xcb_series/bin ]; then
+    rm -rf $dir/.xcb/$xcb_series
+    mkdir -p $dir/.xcb
+
+    xcb_proto_basename="xcb-proto-$xcb_series"
+    wget --no-check-certificate http://xcb.freedesktop.org/dist/xcb-proto-1.11.tar.bz2 -O proto.tar.bz2
+    tar -xjf proto.tar.bz2
+    pushd ${xcb_proto_basename}
+    ./configure --prefix=$dir/.xcb/$xcb_series
+    make && make install
+    popd
+
+    xcb_basename="libxcb-${xcb_ver}"
+    wget --no-check-certificate http://xcb.freedesktop.org/dist/${xcb_basename}.tar.bz2 -O xcb.tar.bz2
+    tar -xjf xcb.tar.bz2
+    pushd ${xcb_basename}
+    ./configure --prefix=$dir/.xcb/$xcb_series --enable-xkb
+    make && make install
+    popd
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,56 +1,49 @@
+sudo: false
+
 language: cpp
 
 compiler:
-  - clang
   - gcc
+  - clang
 
 env:
   - PAM=0
   - PAM=1
 
-before_install:
-  - if [ "$CXX" == "g++" ]; then sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test; fi
-  #- if [ "$CXX" == "clang++" ]; then sudo add-apt-repository -y ppa:h-rayflood/gcc-upper; sudo add-apt-repository -y ppa:h-rayflood/llvm; fi
-  - sudo add-apt-repository -y ppa:beineri/opt-qt542
-  - sudo apt-get update -y
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - gcc-4.8
+      - g++-4.8
+      - libpam0g-dev
+      - libX11-dev
+      - libx11-xcb-dev
 
-install:
-  # gcc
-  - if [ "$CC" == "gcc" ]; then sudo apt-get install -qq gcc-4.8; fi
-  - if [ "$CC" == "gcc" ]; then export CC="gcc-4.8"; fi
-  - if [ "$CXX" == "g++" ]; then sudo apt-get install -qq g++-4.8; fi
-  - if [ "$CXX" == "g++" ]; then export CXX="g++-4.8"; fi
-  # clang
-  #- if [ "$CXX" == "clang++" ]; then sudo apt-get install -qq clang-3.6; fi
-  #- if [ "$CXX" == "clang++" ]; then export CXX="clang++-3.6"; fi
-  # qt
-  - sudo apt-get update
-  - sudo apt-get -y install qt54declarative qt54tools
-  # pam
-  - if [ "$PAM" == "1" ]; then sudo apt-get install -qq libpam0g-dev; fi
-  # x11
-  - sudo apt-get install -qq libpam0g-dev libX11-dev libx11-xcb-dev
-  # xcb
-  - sudo wget http://mirrors.kernel.org/ubuntu/pool/main/libx/libxcb/libxcb1_1.10-2ubuntu1_amd64.deb
-  - sudo wget http://mirrors.kernel.org/ubuntu/pool/main/libx/libxcb/libxcb-xkb1_1.10-2ubuntu1_amd64.deb
-  - sudo wget http://mirrors.kernel.org/ubuntu/pool/main/libx/libxcb/libxcb1-dev_1.10-2ubuntu1_amd64.deb
-  - sudo wget http://mirrors.kernel.org/ubuntu/pool/main/libx/libxcb/libxcb-xkb-dev_1.10-2ubuntu1_amd64.deb
-  - sudo dpkg --force-depends -i libxcb1_1.10-2ubuntu1_amd64.deb
-  - sudo dpkg --force-depends -i libxcb-xkb1_1.10-2ubuntu1_amd64.deb
-  - sudo dpkg --force-depends -i libxcb1-dev_1.10-2ubuntu1_amd64.deb
-  - sudo dpkg --force-depends -i libxcb-xkb-dev_1.10-2ubuntu1_amd64.deb
+cache:
+  directories:
+    - .cmake/3.3
+    - .qt/5.6
+    - .xcb/1.11
 
 before_script:
-  # cmake
-  - wget --no-check-certificate http://www.cmake.org/files/v3.3/cmake-3.3.0-Linux-x86_64.tar.gz -O cmake.tar.gz
-  - tar -xzf cmake.tar.gz -C $HOME
-  - export PATH=$HOME/cmake-3.3.0-Linux-x86_64/bin:$PATH
-  - cmake --version
-  # prepare
-  - source /opt/qt54/bin/qt54-env.sh
+  # Setup compilers
+  - export CC=gcc-4.8
+  - export CXX=g++-4.8
+  # Fetch and install dependencies if cache miss
+  - bash -x .ci/fetch-cmake || exit 127
+  - bash -x .ci/fetch-qt || exit 127
+  - bash -x .ci/fetch-xcb || exit 127
+  - export PATH=`pwd`/.cmake/3.3/bin:`pwd`/.qt/5.6/5.6/gcc_64/bin:`pwd`/.xcb/1.11/bin:$PATH
+  - export LD_LIBRARY_PATH=`pwd`/.qt/5.6/5.6/gcc_64/lib:`pwd`/.xcb/1.11/lib:$LD_LIBRARY_PATH
+  - export CMAKE_PREFIX_PATH=`pwd`/.qt/5.6/5.6/gcc_64/lib/cmake
+  - export PKG_CONFIG_PATH=`pwd`/.xcb/1.11/lib/pkgconfig:$PKG_CONFIG_PATH
+  # Prepare
   - mkdir build
   - cd build
   - if [ "$PAM" == "0" ]; then cmake -DENABLE_PAM:BOOL=OFF ..; fi
   - if [ "$PAM" == "1" ]; then cmake -DENABLE_PAM:BOOL=ON ..; fi
 
-script: make
+script:
+  - make


### PR DESCRIPTION
Build cmake and ECM with scripts, fetch Qt official binaries from the
installer and cache dependencies to make CI builds faster.

Also, switch to the new container infrastructure.