### PR TITLE
Specify arguments of SessionCommand in manpage

### DIFF
--- a/data/man/sddm.conf.rst.in
+++ b/data/man/sddm.conf.rst.in
@@ -98,7 +98,9 @@ OPTIONS
 	Default value is "/usr/share/xsessions".
 
 `SessionCommand=`
-	Path of script to execute when starting the desktop session.
+	Path of script to execute when starting the desktop session. This script
+  receives the value of the "Exec" setting in the ".desktop" file of the selected
+  session as the first argument.
 	Default value is "@SESSION_COMMAND@".
 
 `SessionLogFile=`


### PR DESCRIPTION
I was wondering why both SessionCommand and the Exec option of the desktop files in SessionDir are
needed, so I found out that actually, sddm doesn't directly execute the script specified in the Exec
option but instead passes that as an argument to the SessionCommand script when a session should be
started. I think this should be stated in the documentation.