### PR TITLE
Fix loading the embedded theme and error reporting

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -17,6 +17,7 @@
     + Require Qt 5.6 or better.
     + Enable HiDPI support.
     + Refresh sessions list.
+    + Always fallback to an embedded theme if no suitable theme is found.
     - Actually change Qt platform theme.
     - Switch to Wayland session vt only when authentication
       succeeds.

--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -223,6 +223,12 @@ namespace SDDM {
 
     QString Display::findGreeterTheme() const {
         QString themeName = mainConfig.Theme.Current.get();
+
+        // an unconfigured theme means the user wants to load the
+        // default theme from the resources
+        if (themeName.isEmpty())
+            return QString();
+
         QDir dir(mainConfig.Theme.ThemeDir.get());
 
         // return the default theme if it exists
@@ -231,10 +237,18 @@ namespace SDDM {
 
         // otherwise return the first one in alphabetical order, but
         // return the default theme name if none is found
+        QString newThemePath;
         QStringList entries = dir.entryList(QDir::Dirs | QDir::NoDotAndDotDot | QDir::Readable, QDir::Name);
-        if (entries.count() == 0)
-            return dir.absoluteFilePath(themeName);
-        return dir.absoluteFilePath(entries.at(0));
+        if (entries.count() == 0) {
+            newThemePath = QString();
+            qWarning() << "The configured theme" << themeName << "doesn't exist, using the embedded theme instead";
+        } else {
+            QString newThemeName = entries.at(0);
+            newThemePath = dir.absoluteFilePath(newThemeName);
+            qWarning() << "The configured theme" << themeName << "doesn't exist, pick up"
+                       << newThemeName << "which is the first one in alphabetical order";
+        }
+        return newThemePath;
     }
 
     bool Display::findSessionEntry(const QDir &dir, const QString &name) const {

--- a/src/daemon/Greeter.cpp
+++ b/src/daemon/Greeter.cpp
@@ -33,6 +33,8 @@
 
 namespace SDDM {
     Greeter::Greeter(QObject *parent) : QObject(parent) {
+        m_metadata = new ThemeMetadata(QString());
+        m_themeConfig = new ThemeConfig(QString());
     }
 
     Greeter::~Greeter() {
@@ -57,17 +59,16 @@ namespace SDDM {
     void Greeter::setTheme(const QString &theme) {
         m_themePath = theme;
 
-        const QString path = QStringLiteral("%1/metadata.desktop").arg(m_themePath);
-        if (m_metadata)
+        if (theme.isEmpty()) {
+            m_metadata = new ThemeMetadata(QString());
+            m_themeConfig = new ThemeConfig(QString());
+        } else {
+            const QString path = QStringLiteral("%1/metadata.desktop").arg(m_themePath);
             m_metadata->setTo(path);
-        else
-            m_metadata = new ThemeMetadata(path);
 
-        QString configFile = QStringLiteral("%1/%2").arg(m_themePath).arg(m_metadata->configFile());
-        if (m_themeConfig)
+            QString configFile = QStringLiteral("%1/%2").arg(m_themePath).arg(m_metadata->configFile());
             m_themeConfig->setTo(configFile);
-        else
-            m_themeConfig = new ThemeConfig(configFile);
+        }
     }
 
     bool Greeter::start() {

--- a/src/greeter/UserModel.cpp
+++ b/src/greeter/UserModel.cpp
@@ -52,7 +52,7 @@ namespace SDDM {
 
     UserModel::UserModel(QObject *parent) : QAbstractListModel(parent), d(new UserModelPrivate()) {
         const QString facesDir = mainConfig.Theme.FacesDir.get();
-        const QString defaultFace = QStringLiteral("%1/.face.icon").arg(facesDir);
+        const QString defaultFace = QStringLiteral("file://%1/.face.icon").arg(facesDir);
 
         struct passwd *current_pw;
         while ((current_pw = getpwent()) != nullptr) {
@@ -107,8 +107,8 @@ namespace SDDM {
                 d->lastIndex = i;
 
             if (avatarsEnabled) {
-                const QString userFace = QStringLiteral("%1/.face.icon").arg(user->homeDir);
-                const QString systemFace = QStringLiteral("%1/%2.face.icon").arg(facesDir).arg(user->name);
+                const QString userFace = QStringLiteral("file://%1/.face.icon").arg(user->homeDir);
+                const QString systemFace = QStringLiteral("file://%1/%2.face.icon").arg(facesDir).arg(user->name);
 
                 if (QFile::exists(userFace))
                     user->icon = userFace;

--- a/src/greeter/theme.qrc
+++ b/src/greeter/theme.qrc
@@ -7,5 +7,7 @@
     <file alias="Main.qml">${CMAKE_CURRENT_BINARY_DIR}/theme/Main.qml</file>
     <file alias="reboot.png">${CMAKE_CURRENT_SOURCE_DIR}/theme/reboot.png</file>
     <file alias="shutdown.png">${CMAKE_CURRENT_SOURCE_DIR}/theme/shutdown.png</file>
+    <file alias="metadata.desktop">${CMAKE_CURRENT_SOURCE_DIR}/theme/metadata.desktop</file>
+    <file alias="theme.conf">${CMAKE_CURRENT_SOURCE_DIR}/theme/theme.conf</file>
 </qresource>
 </RCC>

--- a/src/greeter/theme/Main.qml
+++ b/src/greeter/theme/Main.qml
@@ -51,7 +51,7 @@ Rectangle {
 
     Background {
         anchors.fill: parent
-        source: config.background
+        source: "qrc:/theme/background.png"
         fillMode: Image.PreserveAspectCrop
         onStatusChanged: {
             if (status == Image.Error && source != config.defaultBackground) {
@@ -176,6 +176,18 @@ Rectangle {
                     font.pixelSize: 20
                 }
 
+                Text {
+                    id: errMessage
+                    anchors.top: txtMessage.bottom
+                    anchors.margins: 20
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    color: "red"
+                    text: "The current theme cannot be loaded due to the errors below, please select another theme.\n" + __sddm_errors
+                    wrapMode: Text.WordWrap
+                    width: parent.width - 60
+                    font.pixelSize: 20
+                    visible: __sddm_errors !== ""
+                }
             }
         }
 

--- a/src/greeter/theme/theme.conf
+++ b/src/greeter/theme/theme.conf
@@ -1,2 +1,2 @@
 [General]
-background=background.png
+background=qrc:/theme/background.png


### PR DESCRIPTION
We now handle correctly the following situations:

- Empty theme in the settings: fallback to the embedded theme.
- Selected theme doesn't exist: load the first one in alphabetical order like
  before, in addition to that fallback to the embedded theme if there are no
  themes at all.
- Selected theme has QML errors: fallback to the embedded theme and display
  the errors prompting the user to select another one.

This means that in any case we always let the user log in with a theme
embedded into the executable in order to be sure it always exist.

Closes: #551
Closes: #632