### PR TITLE
Add Hindi translations

### DIFF
--- a/data/translations/CMakeLists.txt
+++ b/data/translations/CMakeLists.txt
@@ -7,6 +7,7 @@ set(TRANSLATION_FILES
     et.ts
     fi.ts
     fr.ts
+    hi_IN.ts
     hu.ts
     it.ts
     ja.ts

--- a/data/translations/hi_IN.ts
+++ b/data/translations/hi_IN.ts
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="hi_IN">
+<context>
+    <name>TextConstants</name>
+    <message>
+        <source>Welcome to %1</source>
+        <translation>%1 में आपका स्वागत है।</translation>
+    </message>
+    <message>
+        <source>Warning, Caps Lock is ON!</source>
+        <translation>सावधान! कैप्स लॉक सक्रिय है।</translation>
+    </message>
+    <message>
+        <source>Layout</source>
+        <translation>विन्यास</translation>
+    </message>
+    <message>
+        <source>Login</source>
+        <translation>सत्यापन कीजिए</translation>
+    </message>
+    <message>
+        <source>Login failed</source>
+        <translation>सत्यापन विफल रहा।</translation>
+    </message>
+    <message>
+        <source>Login succeeded</source>
+        <translation>सत्यापन सफल हुआ।</translation>
+    </message>
+    <message>
+        <source>Password</source>
+        <translation>कूटशब्द</translation>
+    </message>
+    <message>
+        <source>Enter your username and password</source>
+        <translation>अपनी पहचान और संबंधित कूटशब्द डालिए।</translation>
+    </message>
+    <message>
+        <source>Reboot</source>
+        <translation>पुनः शुरु कीजिए</translation>
+    </message>
+    <message>
+        <source>Session</source>
+        <translation>सत्र</translation>
+    </message>
+    <message>
+        <source>Shutdown</source>
+        <translation>बंद कीजिए</translation>
+    </message>
+    <message>
+        <source>User name</source>
+        <translation>आपकी पहचान</translation>
+    </message>
+    <message>
+        <source>Select your user and enter password</source>
+        <translation>अपनी पहचान का चयन कीजिए और संबंधित कूटशब्द डालिए।</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
Translations are based on usage (noun/ verb) in the default (English) greeter.
However, wasn't able to test in either production/ test mode on my Fedora 23 desktop.