### PR TITLE
Remove quotes from ServerArguments in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Xorg yourself.  An easy way is to pass an additional argument to Xorg.
 Edit ``/etc/sddm.conf``, go to the ``X11`` section and change ``ServerArguments`` like this:
 
 ```
-ServerArguments="-nolisten tcp -dpi 192"
+ServerArguments=-nolisten tcp -dpi 192
 ```
 
 to set DPI to 192.


### PR DESCRIPTION
Remove quotes from ServerArguments since it goes directly in the command line:
Running: /usr/bin/X "-nolisten tcp -dpi 192" -auth /var/run/sddm/{...}  -background none -noreset -displayfd 21 vt1

I'm on ArchLinux with sddm 0.14.0