### PR TITLE
Add a config option to enable high-DPI scaling

### DIFF
--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -42,6 +42,7 @@ namespace SDDM {
         Entry(Numlock,             NumState,    NUM_NONE,                                       _S("Initial NumLock state. Can be on, off or none.\n"
                                                                                                    "If property is set to none, numlock won't be changed\n"
                                                                                                    "NOTE: Currently ignored if autologin is enabled."));
+        Entry(EnableHiDPI,         bool,        true,                                           _S("Enable Qt's automatic high-DPI scaling"));
         Entry(InputMethod,         QString,     QString(),                                      _S("Input method module"));
         //  Name   Entries (but it's a regular class again)
         Section(Theme,

--- a/src/greeter/GreeterApp.cpp
+++ b/src/greeter/GreeterApp.cpp
@@ -242,7 +242,12 @@ int main(int argc, char **argv) {
     qInstallMessageHandler(SDDM::GreeterMessageHandler);
 
     // HiDPI
-    QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+    if (SDDM::mainConfig.EnableHiDPI.get()) {
+        qDebug() << "High-DPI autoscaling Enabled";
+        QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+    } else {
+        qDebug() << "High-DPI autoscaling Not Enabled";
+    }
 
     QStringList arguments;
 


### PR DESCRIPTION
The new EnableHiDPI boolean option permits to enable or not the
activation of Qt::AA_EnableHighDpiScaling attribute.

The default is enabled.

[ChangeLog][Greeter] Enable Qt's automatic high dpi scaling based on configuration

Signed-off-by: Stany MARCEL <stanypub@gmail.com>