### PR TITLE
Make the default cursor themed

### DIFF
--- a/src/greeter/GreeterApp.cpp
+++ b/src/greeter/GreeterApp.cpp
@@ -32,6 +32,7 @@
 #include "MessageHandler.h"
 
 #include <QGuiApplication>
+#include <QQuickItem>
 #include <QQuickView>
 #include <QQmlContext>
 #include <QQmlEngine>
@@ -210,6 +211,10 @@ namespace SDDM {
         // set main script as source
         qInfo("Loading %s...", qPrintable(mainScriptUrl.toString()));
         view->setSource(mainScriptUrl);
+
+        // set default cursor
+        QCursor cursor(Qt::ArrowCursor);
+        view->rootObject()->setCursor(cursor);
 
         // show
         qDebug() << "Adding view for" << screen->name() << screen->geometry();


### PR DESCRIPTION
The X root window uses an "X" as the default cursor. To use a themed one,
it has to be set explicitly, e.g. by QML MouseAreas. For themes which do
not have a MouseArea that spans the entire screen, the "X" cursor would
be visible. By setting a cursor in the root QML object, the themed cursor
will be used by default. (https://bugs.kde.org/show_bug.cgi?id=337083)

[ChangeLog][Greeter] Fix default cursor appearance