### PR TITLE
Support Non-Latin characters in theme settings

### DIFF
--- a/src/common/ThemeConfig.cpp
+++ b/src/common/ThemeConfig.cpp
@@ -35,6 +35,12 @@ namespace SDDM {
         QSettings settings(path, QSettings::IniFormat);
         QSettings userSettings(path + QStringLiteral(".user"), QSettings::IniFormat);
 
+        // Support non-latin strings in background picture path
+        // Warning: The codec must be set immediately after creating the QSettings object,
+        // before accessing any data.
+        settings.setIniCodec("UTF-8");
+        userSettings.setIniCodec("UTF-8");
+
         // read default keys
         for (const QString &key: settings.allKeys()) {
             insert(key, settings.value(key));


### PR DESCRIPTION
By default, QSettings doesn't support non-lating characters in config file. However, KCM will write background path into theme config file without escape. That means, we need to read UTF-8 strings.

This will fix #707 and #666 