### PR TITLE
Unlock Gnome keyring on login

### DIFF
--- a/services/sddm.pam
+++ b/services/sddm.pam
@@ -1,6 +1,13 @@
 #%PAM-1.0
 
 auth		include		system-login
+auth		optional	pam_gnome_keyring.so
+
 account		include		system-login
+
 password	include		system-login
+password	optional	pam_gnome_keyring.so use_authtok
+
+session		optional	pam_keyinit.so force revoke
 session		include		system-login
+session		optional	pam_gnome_keyring.so auto_start


### PR DESCRIPTION
Gnome's keyring stores user keys (eg: wifi passwords) encrypted, and uses a pam module to unlock them at login. 

This patch adds `optional` support for the gnome_keyring pam module, so Gnome can be launched successfully from SDDM. Without this, Gnome will ask for the users password again after logging in, the first time it needs to access the keyring, in order to unlock it.

Other display managers as the Gnome Display Manger [1], LightDM [2] and Enlightenment's Entrance [3] already do this.

[1] https://github.com/GNOME/gdm/blob/master/data/pam-arch/gdm-password.pam
[2] http://bazaar.launchpad.net/~lightdm-team/lightdm/trunk/view/head:/debian/lightdm.pam
[3] https://git.enlightenment.org/misc/entrance.git/tree/data/entrance