### PR TITLE
add fish shell specific commands to Xsession and wayland-session

### DIFF
--- a/data/scripts/Xsession
+++ b/data/scripts/Xsession
@@ -38,6 +38,12 @@ case $SHELL in
     . $xsess_tmp
     rm -f $xsess_tmp
     ;;
+  */fish)
+    xsess_tmp=`mktemp /tmp/xsess-env-XXXXXX`
+    $SHELL --login -c "/bin/sh -c 'export -p' > $xsess_tmp"
+    . $xsess_tmp
+    rm -f $xsess_tmp
+    ;;
   *) # Plain sh, ksh, and anything we do not know.
     [ -f /etc/profile ] && . /etc/profile
     [ -f $HOME/.profile ] && . $HOME/.profile

--- a/data/scripts/wayland-session
+++ b/data/scripts/wayland-session
@@ -38,6 +38,12 @@ case $SHELL in
     . $wlsess_tmp
     rm -f $wlsess_tmp
     ;;
+  */fish)
+    xsess_tmp=`mktemp /tmp/xsess-env-XXXXXX`
+    $SHELL --login -c "/bin/sh -c 'export -p' > $xsess_tmp"
+    . $xsess_tmp
+    rm -f $xsess_tmp
+    ;;
   *) # Plain sh, ksh, and anything we do not know.
     [ -f /etc/profile ] && . /etc/profile
     [ -f $HOME/.profile ] && . $HOME/.profile


### PR DESCRIPTION
to get the fish-specific login environment instead of the catchall /etc/profile environment.

Prior to this, users with fish shell as default logging in via sddm got an environment as specified by `/etc/profile` but without user-specific configs that only execute on the login shell. In contrast, when logging in via virtual terminals or SSH, they got an environment as specified by `/usr/share/fish/config.fish` and with user-specific configs that execute on login shell.

With this path, an sddm user gets a consistent environment regardless of login method.