### PR TITLE
Logind Multi Seat Support

### DIFF
--- a/src/auth/Auth.cpp
+++ b/src/auth/Auth.cpp
@@ -52,6 +52,7 @@ namespace SDDM {
         Q_OBJECT
     public:
         Private(Auth *parent);
+        ~Private();
         void setSocket(QLocalSocket *socket);
     public slots:
         void dataPending();
@@ -135,6 +136,12 @@ namespace SDDM {
         connect(request, SIGNAL(finished()), this, SLOT(requestFinished()));
         connect(request, SIGNAL(promptsChanged()), parent, SIGNAL(requestChanged()));
     }
+
+    Auth::Private::~Private()
+    {
+        SocketServer::instance()->helpers.remove(id);
+    }
+
 
     void Auth::Private::setSocket(QLocalSocket *socket) {
         this->socket = socket;

--- a/src/daemon/CMakeLists.txt
+++ b/src/daemon/CMakeLists.txt
@@ -21,6 +21,7 @@ set(DAEMON_SOURCES
     DisplayServer.cpp
     XorgDisplayServer.cpp
     Greeter.cpp
+    LogindDBusTypes.cpp
     PowerManager.cpp
     Seat.cpp
     SeatManager.cpp

--- a/src/daemon/DaemonApp.cpp
+++ b/src/daemon/DaemonApp.cpp
@@ -75,9 +75,6 @@ namespace SDDM {
 
         // log message
         qDebug() << "Starting...";
-
-        // add a seat
-        m_seatManager->createSeat(QStringLiteral("seat0"));
     }
 
     bool DaemonApp::testing() const {

--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -288,15 +288,17 @@ namespace SDDM {
         env.insert(QStringLiteral("PATH"), mainConfig.Users.DefaultPath.get());
         if (session.xdgSessionType() == QLatin1String("x11"))
             env.insert(QStringLiteral("DISPLAY"), name());
-        env.insert(QStringLiteral("XDG_SEAT"), seat()->name());
         env.insert(QStringLiteral("XDG_SEAT_PATH"), daemonApp->displayManager()->seatPath(seat()->name()));
         env.insert(QStringLiteral("XDG_SESSION_PATH"), daemonApp->displayManager()->sessionPath(QStringLiteral("Session%1").arg(daemonApp->newSessionId())));
-        env.insert(QStringLiteral("XDG_VTNR"), QString::number(vt));
         env.insert(QStringLiteral("DESKTOP_SESSION"), session.desktopSession());
         env.insert(QStringLiteral("XDG_CURRENT_DESKTOP"), session.desktopNames());
         env.insert(QStringLiteral("XDG_SESSION_CLASS"), QStringLiteral("user"));
         env.insert(QStringLiteral("XDG_SESSION_TYPE"), session.xdgSessionType());
         env.insert(QStringLiteral("XDG_SESSION_DESKTOP"), session.desktopNames());
+        if (seat()->name() == QLatin1String("seat0")) {
+            env.insert(QStringLiteral("XDG_VTNR"), QString::number(vt));
+        }
+
         m_auth->insertEnvironment(env);
 
         m_auth->setUser(user);

--- a/src/daemon/LogindDBusTypes.cpp
+++ b/src/daemon/LogindDBusTypes.cpp
@@ -1,0 +1,111 @@
+#include "LogindDBusTypes.h"
+
+#include <QDBusArgument>
+#include <QDBusMetaType>
+
+#include <QDBusConnection>
+#include <QDBusConnectionInterface>
+
+#include <QDebug>
+
+class LogindPathInternal {
+public:
+    LogindPathInternal();
+    bool available = false;
+    QString serviceName;
+    QString managerPath;
+    QString managerIfaceName;
+    QString sessionIfaceName;
+    QString seatIfaceName;
+    QString userIfaceName;
+};
+
+LogindPathInternal::LogindPathInternal()
+{
+    qRegisterMetaType<NamedSeatPath>("NamedSeatPath");
+    qDBusRegisterMetaType<NamedSeatPath>();
+
+    qRegisterMetaType<NamedSeatPathList>("NamedSeatPathList");
+    qDBusRegisterMetaType<NamedSeatPathList>();
+
+    qRegisterMetaType<NamedSessionPath>("NamedSessionPath");
+    qDBusRegisterMetaType<NamedSessionPath>();
+
+    qRegisterMetaType<NamedSessionPathList>("NamedSessionPathList");
+    qDBusRegisterMetaType<NamedSessionPathList>();
+
+    qRegisterMetaType<SessionInfo>("SessionInfo");
+    qDBusRegisterMetaType<SessionInfo>();
+
+    qRegisterMetaType<SessionInfoList>("SessionInfoList");
+    qDBusRegisterMetaType<SessionInfoList>();
+
+    qRegisterMetaType<UserInfo>("UserInfo");
+    qDBusRegisterMetaType<UserInfo>();
+
+    qRegisterMetaType<UserInfoList>("UserInfoList");
+    qDBusRegisterMetaType<UserInfoList>();
+
+    if (QDBusConnection::systemBus().interface()->isServiceRegistered(QStringLiteral("org.freedesktop.login1"))) {
+        qDebug() << "Logind interface found";
+        available = true;
+        serviceName = QStringLiteral("org.freedesktop.login1");
+        managerPath = QStringLiteral("/org/freedesktop/login1");
+        managerIfaceName = QStringLiteral("org.freedesktop.login1.Manager");
+        seatIfaceName = QStringLiteral("org.freedesktop.login1.Seat");
+        sessionIfaceName = QStringLiteral("org.freedesktop.login1.Session");
+        userIfaceName = QStringLiteral("org.freedesktop.login1.User");
+        return;
+    }
+
+    if (QDBusConnection::systemBus().interface()->isServiceRegistered(QStringLiteral("org.freedesktop.ConsoleKit"))) {
+        qDebug() << "Console kit interface found";
+        available = true;
+        serviceName = QStringLiteral("org.freedesktop.ConsoleKit");
+        managerPath = QStringLiteral("/org/freedesktop/ConsoleKit/Manager");
+        managerIfaceName = QStringLiteral("/org.freedesktop.ConsoleKit.Manager"); //note this doesn't match logind
+        seatIfaceName = QStringLiteral("org.freedesktop.ConsoleKit.Seat");
+        sessionIfaceName = QStringLiteral("org.freedesktop.ConsoleKit.Session");
+        userIfaceName = QStringLiteral("org.freedesktop.ConsoleKit.User");
+        return;
+    }
+    qDebug() << "No session manager found";
+}
+
+Q_GLOBAL_STATIC(LogindPathInternal, s_instance);
+
+bool Logind::isAvailable()
+{
+    return s_instance->available;
+}
+
+QString Logind::serviceName()
+{
+    return s_instance->serviceName;
+}
+
+QString Logind::managerPath()
+{
+    return s_instance->managerPath;
+}
+
+QString Logind::managerIfaceName()
+{
+    return s_instance->managerIfaceName;
+}
+
+
+QString Logind::seatIfaceName()
+{
+    return s_instance->seatIfaceName;
+}
+
+QString Logind::sessionIfaceName()
+{
+    return s_instance->sessionIfaceName;
+}
+
+QString Logind::userIfaceName()
+{
+    return s_instance->userIfaceName;
+}

--- a/src/daemon/LogindDBusTypes.h
+++ b/src/daemon/LogindDBusTypes.h
@@ -1,0 +1,194 @@
+#ifndef LOGIND_DBUSTYPES
+#define LOGIND_DBUSTYPES
+
+#include <QDBusObjectPath>
+#include <QDBusArgument>
+
+struct Logind
+{
+    static bool isAvailable();
+    static QString serviceName();
+    static QString managerPath();
+    static QString managerIfaceName();
+    static QString sessionIfaceName();
+    static QString seatIfaceName();
+    static QString userIfaceName();
+};
+
+
+struct SessionInfo
+{
+    QString sessionId;
+    uint userId;
+    QString userName;
+    QString seatId;
+    QDBusObjectPath sessionPath;
+};
+
+typedef QList<SessionInfo> SessionInfoList;
+
+inline QDBusArgument &operator<<(QDBusArgument &argument, const SessionInfo& sessionInfo)
+{
+    argument.beginStructure();
+    argument << sessionInfo.sessionId;
+    argument << sessionInfo.userId;
+    argument << sessionInfo.userName;
+    argument << sessionInfo.seatId;
+    argument << sessionInfo.sessionPath;
+    argument.endStructure();
+
+    return argument;
+}
+
+inline const QDBusArgument &operator>>(const QDBusArgument &argument, SessionInfo &sessionInfo)
+{
+    argument.beginStructure();
+    argument >> sessionInfo.sessionId;
+    argument >> sessionInfo.userId;
+    argument >> sessionInfo.userName;
+    argument >> sessionInfo.seatId;
+    argument >> sessionInfo.sessionPath;
+    argument.endStructure();
+
+    return argument;
+}
+
+struct UserInfo
+{
+    uint userId;
+    QString name;
+    QDBusObjectPath path;
+};
+
+typedef QList<UserInfo> UserInfoList;
+
+inline QDBusArgument &operator<<(QDBusArgument &argument, const UserInfo& userInfo)
+{
+    argument.beginStructure();
+    argument << userInfo.userId;
+    argument << userInfo.name;
+    argument << userInfo.path;
+    argument.endStructure();
+
+    return argument;
+}
+
+inline const QDBusArgument &operator>>(const QDBusArgument &argument, UserInfo& userInfo)
+{
+    argument.beginStructure();
+    argument >> userInfo.userId;
+    argument >> userInfo.name;
+    argument >> userInfo.path;
+    argument.endStructure();
+
+    return argument;
+}
+
+struct NamedSeatPath
+{
+    QString name;
+    QDBusObjectPath path;
+};
+
+inline QDBusArgument &operator<<(QDBusArgument &argument, const NamedSeatPath& namedSeat)
+{
+    argument.beginStructure();
+    argument << namedSeat.name;
+    argument << namedSeat.path;
+    argument.endStructure();
+    return argument;
+}
+
+inline const QDBusArgument &operator>>(const QDBusArgument &argument, NamedSeatPath& namedSeat)
+{
+    argument.beginStructure();
+    argument >> namedSeat.name;
+    argument >> namedSeat.path;
+    argument.endStructure();
+    return argument;
+}
+
+typedef QList<NamedSeatPath> NamedSeatPathList;
+
+typedef NamedSeatPath NamedSessionPath;
+typedef NamedSeatPathList NamedSessionPathList;
+
+class NamedUserPath
+{
+public:
+    uint userId;
+    QDBusObjectPath path;
+};
+
+inline QDBusArgument &operator<<(QDBusArgument &argument, const NamedUserPath& namedUser)
+{
+    argument.beginStructure();
+    argument << namedUser.userId;
+    argument << namedUser.path;
+    argument.endStructure();
+    return argument;
+}
+
+inline const QDBusArgument &operator>>(const QDBusArgument &argument, NamedUserPath& namedUser)
+{
+    argument.beginStructure();
+    argument >> namedUser.userId;
+    argument >> namedUser.path;
+    argument.endStructure();
+    return argument;
+}
+
+class Inhibitor
+{
+public:
+    QString what;
+    QString who;
+    QString why;
+    QString mode;
+    int userId;
+    uint processId;
+};
+
+typedef QList<Inhibitor> InhibitorList;
+
+inline QDBusArgument &operator<<(QDBusArgument &argument, const Inhibitor& inhibitor)
+{
+    argument.beginStructure();
+    argument << inhibitor.what;
+    argument << inhibitor.who;
+    argument << inhibitor.why;
+    argument << inhibitor.mode;
+    argument << inhibitor.userId;
+    argument << inhibitor.processId;
+    argument.endStructure();
+    return argument;
+}
+
+inline const QDBusArgument &operator>>(const QDBusArgument &argument, Inhibitor& inhibitor)
+{
+    argument.beginStructure();
+    argument >> inhibitor.what;
+    argument >> inhibitor.who;
+    argument >> inhibitor.why;
+    argument >> inhibitor.mode;
+    argument >> inhibitor.userId;
+    argument >> inhibitor.processId;
+    argument.endStructure();
+    return argument;
+}
+
+Q_DECLARE_METATYPE(SessionInfo);
+Q_DECLARE_METATYPE(QList<SessionInfo>);
+
+Q_DECLARE_METATYPE(UserInfo);
+Q_DECLARE_METATYPE(QList<UserInfo>);
+
+Q_DECLARE_METATYPE(NamedSeatPath);
+Q_DECLARE_METATYPE(QList<NamedSeatPath>);
+
+Q_DECLARE_METATYPE(NamedUserPath);
+
+Q_DECLARE_METATYPE(Inhibitor);
+Q_DECLARE_METATYPE(QList<Inhibitor>);
+
+#endif

--- a/src/daemon/SeatManager.cpp
+++ b/src/daemon/SeatManager.cpp
@@ -19,10 +19,102 @@
 
 #include "SeatManager.h"
 
+#include "DaemonApp.h"
 #include "Seat.h"
 
+#include <QDBusConnection>
+#include <QDBusMessage>
+#include <QDBusPendingReply>
+#include <QDBusContext>
+
+#include "LogindDBusTypes.h"
+
 namespace SDDM {
+
+    class LogindSeat : public QObject {
+    Q_OBJECT
+    public:
+        LogindSeat(const QString &name, const QDBusObjectPath &objectPath, QObject *parent);
+        QString name() const;
+        bool canGraphical() const;
+    Q_SIGNALS:
+        void canGraphicalChanged(bool);
+    private Q_SLOTS:
+        void propertiesChanged(const QString &interface, QVariantMap &changedProperties , const QStringList &invalidatedProperties);
+    private:
+        QString m_name;
+        bool m_canGraphical;
+    };
+
+    LogindSeat::LogindSeat(const QString& name, const QDBusObjectPath& objectPath, QObject* parent):
+        m_name(name),
+        m_canGraphical(false)
+    {
+        QDBusConnection::systemBus().connect(Logind::serviceName(), objectPath.path(), QStringLiteral("org.freedesktop.DBus.Properties"), QStringLiteral("PropertiesChanged"), this, SLOT(propertiesChanged(QString,QVariantMap,QStringList)));
+
+        auto canGraphicalMsg = QDBusMessage::createMethodCall(Logind::serviceName(), objectPath.path(), QStringLiteral("org.freedesktop.DBus.Properties"), QStringLiteral("Get"));
+        canGraphicalMsg << Logind::seatIfaceName() << QStringLiteral("CanGraphical");
+
+        QDBusPendingReply<QVariant> reply = QDBusConnection::systemBus().asyncCall(canGraphicalMsg);
+        QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(reply);
+        connect(watcher, &QDBusPendingCallWatcher::finished, this, [=]() {
+            watcher->deleteLater();
+            if (!reply.isValid())
+                return;
+
+            bool value = reply.value().toBool();
+            if (value != m_canGraphical) {
+                m_canGraphical = value;
+                emit canGraphicalChanged(m_canGraphical);
+            }
+        });
+    }
+
+    bool LogindSeat::canGraphical() const
+    {
+        return m_canGraphical;
+    }
+
+    QString LogindSeat::name() const
+    {
+        return m_name;
+    }
+
+    void LogindSeat::propertiesChanged(const QString& interface, QVariantMap& changedProperties, const QStringList& invalidatedProperties)
+    {
+        Q_UNUSED(invalidatedProperties);
+        if (interface != Logind::seatIfaceName()) {
+            return;
+        }
+
+        if (changedProperties.contains(QStringLiteral("CanGraphical"))) {
+            m_canGraphical = changedProperties[QStringLiteral("CanGraphical")].toBool();
+            emit canGraphicalChanged(m_canGraphical);
+        }
+    }
+
     SeatManager::SeatManager(QObject *parent) : QObject(parent) {
+
+        if (DaemonApp::instance()->testing() || !Logind::isAvailable()) {
+            //if we don't have logind/CK2, just create a single seat immediately and don't do any other connections
+            createSeat(QStringLiteral("seat0"));
+            return;
+        }
+
+        //fetch seats
+        auto listSeatsMsg = QDBusMessage::createMethodCall(Logind::serviceName(), Logind::managerPath(), Logind::managerIfaceName(), QStringLiteral("ListSeats"));
+        QDBusPendingReply<NamedSeatPathList> reply = QDBusConnection::systemBus().asyncCall(listSeatsMsg);
+
+        QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(reply);
+        connect(watcher, &QDBusPendingCallWatcher::finished, this, [=]() {
+            watcher->deleteLater();
+            foreach(const NamedSeatPath &seat, reply.value()) {
+                logindSeatAdded(seat.name, seat.path);
+            }
+        });
+
+        QDBusConnection::systemBus().connect(Logind::serviceName(), Logind::managerPath(), Logind::managerIfaceName(), QStringLiteral("SeatNew"), this, SLOT(logindSeatAdded(QString,QDBusObjectPath)));
+        QDBusConnection::systemBus().connect(Logind::serviceName(), Logind::managerPath(), Logind::managerIfaceName(), QStringLiteral("SeatRemoved"), this, SLOT(logindSeatRemoved(QString,QDBusObjectPath)));
     }
 
     void SeatManager::createSeat(const QString &name) {
@@ -59,4 +151,28 @@ namespace SDDM {
         // switch to greeter
         m_seats.value(name)->createDisplay();
     }
+
+    void SDDM::SeatManager::logindSeatAdded(const QString& name, const QDBusObjectPath& objectPath)
+    {
+        auto logindSeat = new LogindSeat(name, objectPath, this);
+        connect(logindSeat, &LogindSeat::canGraphicalChanged, this, [=]() {
+            if (logindSeat->canGraphical()) {
+                createSeat(logindSeat->name());
+            } else {
+                removeSeat(logindSeat->name());
+            }
+        });
+
+        m_systemSeats.insert(name, logindSeat);
+    }
+
+    void SDDM::SeatManager::logindSeatRemoved(const QString& name, const QDBusObjectPath& objectPath)
+    {
+        Q_UNUSED(objectPath);
+        auto logindSeat = m_systemSeats.take(name);
+        delete logindSeat;
+        removeSeat(name);
+    }
 }
+
+#include "SeatManager.moc"

--- a/src/daemon/SeatManager.h
+++ b/src/daemon/SeatManager.h
@@ -22,28 +22,32 @@
 
 #include <QObject>
 #include <QHash>
+#include <QDBusObjectPath>
 
 namespace SDDM {
     class Seat;
+    class LogindSeat;
 
     class SeatManager : public QObject {
         Q_OBJECT
-        Q_DISABLE_COPY(SeatManager)
     public:
         explicit SeatManager(QObject *parent = 0);
 
-    public slots:
         void createSeat(const QString &name);
         void removeSeat(const QString &name);
-
         void switchToGreeter(const QString &seat);
 
-    signals:
+    Q_SIGNALS:
         void seatCreated(const QString &name);
         void seatRemoved(const QString &name);
 
+    private Q_SLOTS:
+        void logindSeatAdded(const QString &name, const QDBusObjectPath &objectPath);
+        void logindSeatRemoved(const QString &name, const QDBusObjectPath &objectPath);
+
     private:
-        QHash<QString, Seat *> m_seats;
+        QHash<QString, Seat *> m_seats; //these will exist only for graphical seats
+        QHash<QString, LogindSeat*> m_systemSeats; //these will exist for all seats
     };
 }
 

--- a/src/daemon/XorgDisplayServer.cpp
+++ b/src/daemon/XorgDisplayServer.cpp
@@ -24,6 +24,7 @@
 #include "DaemonApp.h"
 #include "Display.h"
 #include "SignalHandler.h"
+#include "Seat.h"
 
 #include <QDebug>
 #include <QFile>
@@ -159,7 +160,11 @@ namespace SDDM {
                  << QStringLiteral("-background") << QStringLiteral("none")
                  << QStringLiteral("-noreset")
                  << QStringLiteral("-displayfd") << QString::number(pipeFds[1])
-                 << QStringLiteral("vt%1").arg(displayPtr()->terminalId());
+                 << QStringLiteral("-seat") << displayPtr()->seat()->name();
+
+            if (displayPtr()->seat()->name() == QLatin1String("seat0")) {
+                args << QStringLiteral("vt%1").arg(displayPtr()->terminalId());
+            }
             qDebug() << "Running:"
                      << qPrintable(mainConfig.X11.ServerPath.get())
                      << qPrintable(args.join(QLatin1Char(' ')));
@@ -191,7 +196,7 @@ namespace SDDM {
             displayNumber.prepend(QByteArray(":"));
             displayNumber.remove(displayNumber.size() -1, 1); //trim trailing whitespace
             m_display = QString::fromLocal8Bit(displayNumber);
-    
+
             // close our pipe
             close(pipeFds[0]);
 


### PR DESCRIPTION
Edit.

It turns out we can't drop the legacy support. logind provides 95% of features, but no implementation of switchToGreeter().

We can't drop it for the forseeable future. However, it does seems it's possible to both track automatic seats through logind, and expose the old FDO interface.
