### PR TITLE
Reuse existing sessions

### DIFF
--- a/data/interfaces/org.freedesktop.login1.Manager.xml
+++ b/data/interfaces/org.freedesktop.login1.Manager.xml
@@ -1,0 +1,220 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+ <interface name="org.freedesktop.login1.Manager">
+  <property name="NAutoVTs" type="u" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="KillOnlyUsers" type="as" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="KillExcludeUsers" type="as" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="KillUserProcesses" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="IdleHint" type="b" access="read">
+  </property>
+  <property name="IdleSinceHint" type="t" access="read">
+  </property>
+  <property name="IdleSinceHintMonotonic" type="t" access="read">
+  </property>
+  <property name="BlockInhibited" type="s" access="read">
+  </property>
+  <property name="DelayInhibited" type="s" access="read">
+  </property>
+  <property name="InhibitDelayMaxUSec" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="HandlePowerKey" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="HandleSuspendKey" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="HandleHibernateKey" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="HandleLidSwitch" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="IdleAction" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="IdleActionUSec" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="PreparingForShutdown" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="PreparingForSleep" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <method name="GetSession">
+   <arg type="s" direction="in"/>
+   <arg type="o" direction="out"/>
+  </method>
+  <method name="GetSessionByPID">
+   <arg type="u" direction="in"/>
+   <arg type="o" direction="out"/>
+  </method>
+  <method name="GetUser">
+   <arg type="u" direction="in"/>
+   <arg type="o" direction="out"/>
+  </method>
+  <method name="GetUserByPID">
+   <arg type="u" direction="in"/>
+   <arg type="o" direction="out"/>
+  </method>
+  <method name="GetSeat">
+   <arg type="s" direction="in"/>
+   <arg type="o" direction="out"/>
+  </method>
+  <method name="ListSessions">
+   <arg type="a(susso)" direction="out"/>
+   <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="SessionInfoList"/>
+  </method>
+  <method name="ListUsers">
+   <arg type="a(uso)" direction="out"/>
+   <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="UserInfoList"/>
+  </method>
+  <method name="ListSeats">
+   <arg type="a(so)" direction="out"/>
+   <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="NamedSeatPathList"/>
+  </method>
+  <method name="ListInhibitors">
+   <arg type="a(ssssuu)" direction="out"/>
+   <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="InhibitorList"/>
+  </method>
+  <method name="ReleaseSession">
+   <arg type="s" direction="in"/>
+   <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
+  </method>
+  <method name="ActivateSession">
+   <arg type="s" direction="in"/>
+  </method>
+  <method name="ActivateSessionOnSeat">
+   <arg type="s" direction="in"/>
+   <arg type="s" direction="in"/>
+  </method>
+  <method name="LockSession">
+   <arg type="s" direction="in"/>
+   <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
+  </method>
+  <method name="UnlockSession">
+   <arg type="s" direction="in"/>
+   <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
+  </method>
+  <method name="LockSessions">
+   <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
+  </method>
+  <method name="UnlockSessions">
+   <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
+  </method>
+  <method name="KillSession">
+   <arg type="s" direction="in"/>
+   <arg type="s" direction="in"/>
+   <arg type="i" direction="in"/>
+   <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
+  </method>
+  <method name="KillUser">
+   <arg type="u" direction="in"/>
+   <arg type="i" direction="in"/>
+   <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
+  </method>
+  <method name="TerminateSession">
+   <arg type="s" direction="in"/>
+   <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
+  </method>
+  <method name="TerminateUser">
+   <arg type="u" direction="in"/>
+   <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
+  </method>
+  <method name="TerminateSeat">
+   <arg type="s" direction="in"/>
+   <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
+  </method>
+  <method name="SetUserLinger">
+   <arg type="u" direction="in"/>
+   <arg type="b" direction="in"/>
+   <arg type="b" direction="in"/>
+  </method>
+  <method name="AttachDevice">
+   <arg type="s" direction="in"/>
+   <arg type="s" direction="in"/>
+   <arg type="b" direction="in"/>
+  </method>
+  <method name="FlushDevices">
+   <arg type="b" direction="in"/>
+  </method>
+  <method name="PowerOff">
+   <arg type="b" direction="in"/>
+  </method>
+  <method name="Reboot">
+   <arg type="b" direction="in"/>
+  </method>
+  <method name="Suspend">
+   <arg type="b" direction="in"/>
+  </method>
+  <method name="Hibernate">
+   <arg type="b" direction="in"/>
+  </method>
+  <method name="HybridSleep">
+   <arg type="b" direction="in"/>
+  </method>
+  <method name="CanPowerOff">
+   <arg type="s" direction="out"/>
+  </method>
+  <method name="CanReboot">
+   <arg type="s" direction="out"/>
+  </method>
+  <method name="CanSuspend">
+   <arg type="s" direction="out"/>
+  </method>
+  <method name="CanHibernate">
+   <arg type="s" direction="out"/>
+  </method>
+  <method name="CanHybridSleep">
+   <arg type="s" direction="out"/>
+  </method>
+  <method name="Inhibit">
+   <arg type="s" direction="in"/>
+   <arg type="s" direction="in"/>
+   <arg type="s" direction="in"/>
+   <arg type="s" direction="in"/>
+   <arg type="h" direction="out"/>
+  </method>
+  <signal name="SessionNew">
+   <arg type="s"/>
+   <arg type="o"/>
+  </signal>
+  <signal name="SessionRemoved">
+   <arg type="s"/>
+   <arg type="o"/>
+  </signal>
+  <signal name="UserNew">
+   <arg type="u"/>
+   <arg type="o"/>
+  </signal>
+  <signal name="UserRemoved">
+   <arg type="u"/>
+   <arg type="o"/>
+  </signal>
+  <signal name="SeatNew">
+   <arg type="s"/>
+   <arg type="o"/>
+  </signal>
+  <signal name="SeatRemoved">
+   <arg type="s"/>
+   <arg type="o"/>
+  </signal>
+  <signal name="PrepareForShutdown">
+   <arg type="b"/>
+  </signal>
+  <signal name="PrepareForSleep">
+   <arg type="b"/>
+  </signal>
+ </interface>
+</node>
+

--- a/data/interfaces/org.freedesktop.login1.Seat.xml
+++ b/data/interfaces/org.freedesktop.login1.Seat.xml
@@ -1,0 +1,43 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+  <interface name="org.freedesktop.login1.Seat">
+  <property name="Id" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="ActiveSession" type="(so)" access="read">
+   <annotation name="org.qtproject.QtDBus.QtTypeName" value="NamedSessionPath"/>
+  </property>
+  <property name="CanMultiSession" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="CanTTY" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="CanGraphical" type="b" access="read">
+  </property>
+  <property name="Sessions" type="a(so)" access="read">
+   <annotation name="org.qtproject.QtDBus.QtTypeName" value="QList<NamedSessionPath>"/>
+  </property>
+  <property name="IdleHint" type="b" access="read">
+  </property>
+  <property name="IdleSinceHint" type="t" access="read">
+  </property>
+  <property name="IdleSinceHintMonotonic" type="t" access="read">
+  </property>
+  <method name="Terminate">
+   <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
+  </method>
+  <method name="ActivateSession">
+   <arg type="s" direction="in"/>
+  </method>
+  <method name="SwitchTo">
+   <arg type="u" direction="in"/>
+  </method>
+  <method name="SwitchToNext">
+  </method>
+  <method name="SwitchToPrevious">
+  </method>
+ </interface>
+</node>
+

--- a/data/interfaces/org.freedesktop.login1.Session.xml
+++ b/data/interfaces/org.freedesktop.login1.Session.xml
@@ -1,0 +1,132 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+ <interface name="org.freedesktop.login1.Session">
+  <property name="Id" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="User" type="(uo)" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+   <annotation name="org.qtproject.QtDBus.QtTypeName" value="NamedUserPath"/>
+  </property>
+  <property name="Name" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Timestamp" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="TimestampMonotonic" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="VTNr" type="u" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Seat" type="(so)" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+   <annotation name="org.qtproject.QtDBus.QtTypeName" value="NamedSeatPath"/>
+  </property>
+  <property name="TTY" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Display" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Remote" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="RemoteHost" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="RemoteUser" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Service" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Desktop" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Scope" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Leader" type="u" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Audit" type="u" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Type" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Class" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+   <annotation name="org.qtproject.QtDBus.PropertyGetter" value="className"/>
+  </property>
+  <property name="Active" type="b" access="read">
+  </property>
+  <property name="State" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="IdleHint" type="b" access="read">
+  </property>
+  <property name="IdleSinceHint" type="t" access="read">
+  </property>
+  <property name="IdleSinceHintMonotonic" type="t" access="read">
+  </property>
+  <method name="Terminate">
+   <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
+  </method>
+  <method name="Activate">
+  </method>
+  <method name="Lock">
+   <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
+    <annotation name="org.qtproject.QtDBus.MethodName" value="requestLock"/>
+  </method>
+  <method name="Unlock">
+   <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
+   <annotation name="org.qtproject.QtDBus.MethodName" value="requestUnlock"/>
+  </method>
+  <method name="SetIdleHint">
+   <arg type="b" direction="in"/>
+  </method>
+  <method name="Kill">
+   <arg type="s" direction="in"/>
+   <arg type="i" direction="in"/>
+   <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
+  </method>
+  <method name="TakeControl">
+   <arg type="b" direction="in"/>
+  </method>
+  <method name="ReleaseControl">
+  </method>
+  <method name="TakeDevice">
+   <arg type="u" direction="in"/>
+   <arg type="u" direction="in"/>
+   <arg type="h" direction="out"/>
+   <arg type="b" direction="out"/>
+  </method>
+  <method name="ReleaseDevice">
+   <arg type="u" direction="in"/>
+   <arg type="u" direction="in"/>
+  </method>
+  <method name="PauseDeviceComplete">
+   <arg type="u" direction="in"/>
+   <arg type="u" direction="in"/>
+  </method>
+  <signal name="PauseDevice">
+   <arg type="u"/>
+   <arg type="u"/>
+   <arg type="s"/>
+  </signal>
+  <signal name="ResumeDevice">
+   <arg type="u"/>
+   <arg type="u"/>
+   <arg type="h"/>
+  </signal>
+  <signal name="Lock">
+  </signal>
+  <signal name="Unlock">
+  </signal>
+ </interface>
+</node>
+

--- a/data/interfaces/org.freedesktop.login1.User.xml
+++ b/data/interfaces/org.freedesktop.login1.User.xml
@@ -1,0 +1,56 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+ <interface name="org.freedesktop.login1.User">
+  <property name="UID" type="u" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="GID" type="u" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Name" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Timestamp" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="TimestampMonotonic" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="RuntimePath" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Service" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Slice" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Display" type="(so)" access="read">
+   <annotation name="org.qtproject.QtDBus.QtTypeName" value="NamedSessionPath"/>
+  </property>
+  <property name="State" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="Sessions" type="a(so)" access="read">
+   <annotation name="org.qtproject.QtDBus.QtTypeName" value="QList<NamedSessionPath>"/>
+  </property>
+  <property name="IdleHint" type="b" access="read">
+  </property>
+  <property name="IdleSinceHint" type="t" access="read">
+  </property>
+  <property name="IdleSinceHintMonotonic" type="t" access="read">
+  </property>
+  <property name="Linger" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <method name="Terminate">
+   <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
+  </method>
+  <method name="Kill">
+   <arg type="i" direction="in"/>
+   <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
+  </method>
+ </interface>
+</node>
+

--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -88,6 +88,8 @@ namespace SDDM {
                                                                                                    "Users with these shells as their default won't be listed"));
             Entry(RememberLastUser,    bool,        true,                                       _S("Remember the last successfully logged in user"));
             Entry(RememberLastSession, bool,        true,                                       _S("Remember the session of the last successfully logged in user"));
+
+            Entry(ReuseSession,        bool,        false,                                      _S("When logging in as the same user twice, restore the original session, rather than create a new one"));
         );
 
         Section(Autologin,

--- a/src/daemon/CMakeLists.txt
+++ b/src/daemon/CMakeLists.txt
@@ -22,6 +22,7 @@ set(DAEMON_SOURCES
     DisplayServer.cpp
     XorgDisplayServer.cpp
     Greeter.cpp
+    LogindDBusTypes.cpp
     PowerManager.cpp
     Seat.cpp
     SeatManager.cpp

--- a/src/daemon/CMakeLists.txt
+++ b/src/daemon/CMakeLists.txt
@@ -16,13 +16,14 @@ set(DAEMON_SOURCES
     ${CMAKE_SOURCE_DIR}/src/auth/Auth.cpp
     ${CMAKE_SOURCE_DIR}/src/auth/AuthPrompt.cpp
     ${CMAKE_SOURCE_DIR}/src/auth/AuthRequest.cpp
+
     DaemonApp.cpp
     Display.cpp
     DisplayManager.cpp
     DisplayServer.cpp
+    LogindDBusTypes.cpp
     XorgDisplayServer.cpp
     Greeter.cpp
-    LogindDBusTypes.cpp
     PowerManager.cpp
     Seat.cpp
     SeatManager.cpp
@@ -34,6 +35,22 @@ set(DAEMON_SOURCES
 qt5_add_dbus_adaptor(DAEMON_SOURCES "${CMAKE_SOURCE_DIR}/data/interfaces/org.freedesktop.DisplayManager.xml"          "DisplayManager.h" SDDM::DisplayManager)
 qt5_add_dbus_adaptor(DAEMON_SOURCES "${CMAKE_SOURCE_DIR}/data/interfaces/org.freedesktop.DisplayManager.Seat.xml"     "DisplayManager.h" SDDM::DisplayManagerSeat)
 qt5_add_dbus_adaptor(DAEMON_SOURCES "${CMAKE_SOURCE_DIR}/data/interfaces/org.freedesktop.DisplayManager.Session.xml"  "DisplayManager.h" SDDM::DisplayManagerSession)
+
+
+set_source_files_properties("${CMAKE_SOURCE_DIR}/data/interfaces/org.freedesktop.login1.Manager.xml" PROPERTIES
+   INCLUDE "LogindDBusTypes.h"
+)
+set_source_files_properties("${CMAKE_SOURCE_DIR}/data/interfaces/org.freedesktop.login1.Seat.xml" PROPERTIES
+   INCLUDE "LogindDBusTypes.h"
+)
+
+set_source_files_properties("${CMAKE_SOURCE_DIR}/data/interfaces/org.freedesktop.login1.Session.xml" PROPERTIES
+   INCLUDE "LogindDBusTypes.h"
+)
+
+qt5_add_dbus_interface(DAEMON_SOURCES "${CMAKE_SOURCE_DIR}/data/interfaces/org.freedesktop.login1.Manager.xml"  "Login1Manager")
+qt5_add_dbus_interface(DAEMON_SOURCES "${CMAKE_SOURCE_DIR}/data/interfaces/org.freedesktop.login1.Seat.xml"  "Login1Seat")
+qt5_add_dbus_interface(DAEMON_SOURCES "${CMAKE_SOURCE_DIR}/data/interfaces/org.freedesktop.login1.Session.xml"  "Login1Session")
 
 add_executable(sddm ${DAEMON_SOURCES})
 target_link_libraries(sddm

--- a/src/daemon/DaemonApp.cpp
+++ b/src/daemon/DaemonApp.cpp
@@ -75,9 +75,6 @@ namespace SDDM {
 
         // log message
         qDebug() << "Starting...";
-
-        // add a seat
-        m_seatManager->createSeat(QStringLiteral("seat0"));
     }
 
     bool DaemonApp::testing() const {

--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -292,15 +292,17 @@ namespace SDDM {
         env.insert(QStringLiteral("PATH"), mainConfig.Users.DefaultPath.get());
         if (session.xdgSessionType() == QLatin1String("x11"))
             env.insert(QStringLiteral("DISPLAY"), name());
-        env.insert(QStringLiteral("XDG_SEAT"), seat()->name());
         env.insert(QStringLiteral("XDG_SEAT_PATH"), daemonApp->displayManager()->seatPath(seat()->name()));
         env.insert(QStringLiteral("XDG_SESSION_PATH"), daemonApp->displayManager()->sessionPath(QStringLiteral("Session%1").arg(daemonApp->newSessionId())));
-        env.insert(QStringLiteral("XDG_VTNR"), QString::number(vt));
         env.insert(QStringLiteral("DESKTOP_SESSION"), session.desktopSession());
         env.insert(QStringLiteral("XDG_CURRENT_DESKTOP"), session.desktopNames());
         env.insert(QStringLiteral("XDG_SESSION_CLASS"), QStringLiteral("user"));
         env.insert(QStringLiteral("XDG_SESSION_TYPE"), session.xdgSessionType());
         env.insert(QStringLiteral("XDG_SESSION_DESKTOP"), session.desktopNames());
+        if (seat()->name() == QLatin1String("seat0")) {
+            env.insert(QStringLiteral("XDG_VTNR"), QString::number(vt));
+        }
+
         m_auth->insertEnvironment(env);
 
         m_auth->setUser(user);

--- a/src/daemon/LogindDBusTypes.cpp
+++ b/src/daemon/LogindDBusTypes.cpp
@@ -1,0 +1,111 @@
+#include "LogindDBusTypes.h"
+
+#include <QDBusArgument>
+#include <QDBusMetaType>
+
+#include <QDBusConnection>
+#include <QDBusConnectionInterface>
+
+#include <QDebug>
+
+class LogindPathInternal {
+public:
+    LogindPathInternal();
+    bool available = false;
+    QString serviceName;
+    QString managerPath;
+    QString managerIfaceName;
+    QString sessionIfaceName;
+    QString seatIfaceName;
+    QString userIfaceName;
+};
+
+LogindPathInternal::LogindPathInternal()
+{
+    qRegisterMetaType<NamedSeatPath>("NamedSeatPath");
+    qDBusRegisterMetaType<NamedSeatPath>();
+
+    qRegisterMetaType<NamedSeatPathList>("NamedSeatPathList");
+    qDBusRegisterMetaType<NamedSeatPathList>();
+
+    qRegisterMetaType<NamedSessionPath>("NamedSessionPath");
+    qDBusRegisterMetaType<NamedSessionPath>();
+
+    qRegisterMetaType<NamedSessionPathList>("NamedSessionPathList");
+    qDBusRegisterMetaType<NamedSessionPathList>();
+
+    qRegisterMetaType<SessionInfo>("SessionInfo");
+    qDBusRegisterMetaType<SessionInfo>();
+
+    qRegisterMetaType<SessionInfoList>("SessionInfoList");
+    qDBusRegisterMetaType<SessionInfoList>();
+
+    qRegisterMetaType<UserInfo>("UserInfo");
+    qDBusRegisterMetaType<UserInfo>();
+
+    qRegisterMetaType<UserInfoList>("UserInfoList");
+    qDBusRegisterMetaType<UserInfoList>();
+
+    if (QDBusConnection::systemBus().interface()->isServiceRegistered(QStringLiteral("org.freedesktop.login1"))) {
+        qDebug() << "Logind interface found";
+        available = true;
+        serviceName = QStringLiteral("org.freedesktop.login1");
+        managerPath = QStringLiteral("/org/freedesktop/login1");
+        managerIfaceName = QStringLiteral("org.freedesktop.login1.Manager");
+        seatIfaceName = QStringLiteral("org.freedesktop.login1.Seat");
+        sessionIfaceName = QStringLiteral("org.freedesktop.login1.Session");
+        userIfaceName = QStringLiteral("org.freedesktop.login1.User");
+        return;
+    }
+
+    if (QDBusConnection::systemBus().interface()->isServiceRegistered(QStringLiteral("org.freedesktop.ConsoleKit"))) {
+        qDebug() << "Console kit interface found";
+        available = true;
+        serviceName = QStringLiteral("org.freedesktop.ConsoleKit");
+        managerPath = QStringLiteral("/org/freedesktop/ConsoleKit/Manager");
+        managerIfaceName = QStringLiteral("/org.freedesktop.ConsoleKit.Manager"); //note this doesn't match logind
+        seatIfaceName = QStringLiteral("org.freedesktop.ConsoleKit.Seat");
+        sessionIfaceName = QStringLiteral("org.freedesktop.ConsoleKit.Session");
+        userIfaceName = QStringLiteral("org.freedesktop.ConsoleKit.User");
+        return;
+    }
+    qDebug() << "No session manager found";
+}
+
+Q_GLOBAL_STATIC(LogindPathInternal, s_instance);
+
+bool Logind::isAvailable()
+{
+    return s_instance->available;
+}
+
+QString Logind::serviceName()
+{
+    return s_instance->serviceName;
+}
+
+QString Logind::managerPath()
+{
+    return s_instance->managerPath;
+}
+
+QString Logind::managerIfaceName()
+{
+    return s_instance->managerIfaceName;
+}
+
+
+QString Logind::seatIfaceName()
+{
+    return s_instance->seatIfaceName;
+}
+
+QString Logind::sessionIfaceName()
+{
+    return s_instance->sessionIfaceName;
+}
+
+QString Logind::userIfaceName()
+{
+    return s_instance->userIfaceName;
+}

--- a/src/daemon/LogindDBusTypes.h
+++ b/src/daemon/LogindDBusTypes.h
@@ -1,0 +1,194 @@
+#ifndef LOGIND_DBUSTYPES
+#define LOGIND_DBUSTYPES
+
+#include <QDBusObjectPath>
+#include <QDBusArgument>
+
+struct Logind
+{
+    static bool isAvailable();
+    static QString serviceName();
+    static QString managerPath();
+    static QString managerIfaceName();
+    static QString sessionIfaceName();
+    static QString seatIfaceName();
+    static QString userIfaceName();
+};
+
+
+struct SessionInfo
+{
+    QString sessionId;
+    uint userId;
+    QString userName;
+    QString seatId;
+    QDBusObjectPath sessionPath;
+};
+
+typedef QList<SessionInfo> SessionInfoList;
+
+inline QDBusArgument &operator<<(QDBusArgument &argument, const SessionInfo& sessionInfo)
+{
+    argument.beginStructure();
+    argument << sessionInfo.sessionId;
+    argument << sessionInfo.userId;
+    argument << sessionInfo.userName;
+    argument << sessionInfo.seatId;
+    argument << sessionInfo.sessionPath;
+    argument.endStructure();
+
+    return argument;
+}
+
+inline const QDBusArgument &operator>>(const QDBusArgument &argument, SessionInfo &sessionInfo)
+{
+    argument.beginStructure();
+    argument >> sessionInfo.sessionId;
+    argument >> sessionInfo.userId;
+    argument >> sessionInfo.userName;
+    argument >> sessionInfo.seatId;
+    argument >> sessionInfo.sessionPath;
+    argument.endStructure();
+
+    return argument;
+}
+
+struct UserInfo
+{
+    uint userId;
+    QString name;
+    QDBusObjectPath path;
+};
+
+typedef QList<UserInfo> UserInfoList;
+
+inline QDBusArgument &operator<<(QDBusArgument &argument, const UserInfo& userInfo)
+{
+    argument.beginStructure();
+    argument << userInfo.userId;
+    argument << userInfo.name;
+    argument << userInfo.path;
+    argument.endStructure();
+
+    return argument;
+}
+
+inline const QDBusArgument &operator>>(const QDBusArgument &argument, UserInfo& userInfo)
+{
+    argument.beginStructure();
+    argument >> userInfo.userId;
+    argument >> userInfo.name;
+    argument >> userInfo.path;
+    argument.endStructure();
+
+    return argument;
+}
+
+struct NamedSeatPath
+{
+    QString name;
+    QDBusObjectPath path;
+};
+
+inline QDBusArgument &operator<<(QDBusArgument &argument, const NamedSeatPath& namedSeat)
+{
+    argument.beginStructure();
+    argument << namedSeat.name;
+    argument << namedSeat.path;
+    argument.endStructure();
+    return argument;
+}
+
+inline const QDBusArgument &operator>>(const QDBusArgument &argument, NamedSeatPath& namedSeat)
+{
+    argument.beginStructure();
+    argument >> namedSeat.name;
+    argument >> namedSeat.path;
+    argument.endStructure();
+    return argument;
+}
+
+typedef QList<NamedSeatPath> NamedSeatPathList;
+
+typedef NamedSeatPath NamedSessionPath;
+typedef NamedSeatPathList NamedSessionPathList;
+
+class NamedUserPath
+{
+public:
+    uint userId;
+    QDBusObjectPath path;
+};
+
+inline QDBusArgument &operator<<(QDBusArgument &argument, const NamedUserPath& namedUser)
+{
+    argument.beginStructure();
+    argument << namedUser.userId;
+    argument << namedUser.path;
+    argument.endStructure();
+    return argument;
+}
+
+inline const QDBusArgument &operator>>(const QDBusArgument &argument, NamedUserPath& namedUser)
+{
+    argument.beginStructure();
+    argument >> namedUser.userId;
+    argument >> namedUser.path;
+    argument.endStructure();
+    return argument;
+}
+
+class Inhibitor
+{
+public:
+    QString what;
+    QString who;
+    QString why;
+    QString mode;
+    int userId;
+    uint processId;
+};
+
+typedef QList<Inhibitor> InhibitorList;
+
+inline QDBusArgument &operator<<(QDBusArgument &argument, const Inhibitor& inhibitor)
+{
+    argument.beginStructure();
+    argument << inhibitor.what;
+    argument << inhibitor.who;
+    argument << inhibitor.why;
+    argument << inhibitor.mode;
+    argument << inhibitor.userId;
+    argument << inhibitor.processId;
+    argument.endStructure();
+    return argument;
+}
+
+inline const QDBusArgument &operator>>(const QDBusArgument &argument, Inhibitor& inhibitor)
+{
+    argument.beginStructure();
+    argument >> inhibitor.what;
+    argument >> inhibitor.who;
+    argument >> inhibitor.why;
+    argument >> inhibitor.mode;
+    argument >> inhibitor.userId;
+    argument >> inhibitor.processId;
+    argument.endStructure();
+    return argument;
+}
+
+Q_DECLARE_METATYPE(SessionInfo);
+Q_DECLARE_METATYPE(QList<SessionInfo>);
+
+Q_DECLARE_METATYPE(UserInfo);
+Q_DECLARE_METATYPE(QList<UserInfo>);
+
+Q_DECLARE_METATYPE(NamedSeatPath);
+Q_DECLARE_METATYPE(QList<NamedSeatPath>);
+
+Q_DECLARE_METATYPE(NamedUserPath);
+
+Q_DECLARE_METATYPE(Inhibitor);
+Q_DECLARE_METATYPE(QList<Inhibitor>);
+
+#endif

--- a/src/daemon/SeatManager.cpp
+++ b/src/daemon/SeatManager.cpp
@@ -19,10 +19,102 @@
 
 #include "SeatManager.h"
 
+#include "DaemonApp.h"
 #include "Seat.h"
 
+#include <QDBusConnection>
+#include <QDBusMessage>
+#include <QDBusPendingReply>
+#include <QDBusContext>
+
+#include "LogindDBusTypes.h"
+
 namespace SDDM {
+
+    class LogindSeat : public QObject {
+    Q_OBJECT
+    public:
+        LogindSeat(const QString &name, const QDBusObjectPath &objectPath, QObject *parent);
+        QString name() const;
+        bool canGraphical() const;
+    Q_SIGNALS:
+        void canGraphicalChanged(bool);
+    private Q_SLOTS:
+        void propertiesChanged(const QString &interface, QVariantMap &changedProperties , const QStringList &invalidatedProperties);
+    private:
+        QString m_name;
+        bool m_canGraphical;
+    };
+
+    LogindSeat::LogindSeat(const QString& name, const QDBusObjectPath& objectPath, QObject* parent):
+        m_name(name),
+        m_canGraphical(false)
+    {
+        QDBusConnection::systemBus().connect(Logind::serviceName(), objectPath.path(), QStringLiteral("org.freedesktop.DBus.Properties"), QStringLiteral("PropertiesChanged"), this, SLOT(propertiesChanged(QString,QVariantMap,QStringList)));
+
+        auto canGraphicalMsg = QDBusMessage::createMethodCall(Logind::serviceName(), objectPath.path(), QStringLiteral("org.freedesktop.DBus.Properties"), QStringLiteral("Get"));
+        canGraphicalMsg << Logind::seatIfaceName() << QStringLiteral("CanGraphical");
+
+        QDBusPendingReply<QVariant> reply = QDBusConnection::systemBus().asyncCall(canGraphicalMsg);
+        QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(reply);
+        connect(watcher, &QDBusPendingCallWatcher::finished, this, [=]() {
+            watcher->deleteLater();
+            if (!reply.isValid())
+                return;
+
+            bool value = reply.value().toBool();
+            if (value != m_canGraphical) {
+                m_canGraphical = value;
+                emit canGraphicalChanged(m_canGraphical);
+            }
+        });
+    }
+
+    bool LogindSeat::canGraphical() const
+    {
+        return m_canGraphical;
+    }
+
+    QString LogindSeat::name() const
+    {
+        return m_name;
+    }
+
+    void LogindSeat::propertiesChanged(const QString& interface, QVariantMap& changedProperties, const QStringList& invalidatedProperties)
+    {
+        Q_UNUSED(invalidatedProperties);
+        if (interface != Logind::seatIfaceName()) {
+            return;
+        }
+
+        if (changedProperties.contains(QStringLiteral("CanGraphical"))) {
+            m_canGraphical = changedProperties[QStringLiteral("CanGraphical")].toBool();
+            emit canGraphicalChanged(m_canGraphical);
+        }
+    }
+
     SeatManager::SeatManager(QObject *parent) : QObject(parent) {
+
+        if (DaemonApp::instance()->testing() || !Logind::isAvailable()) {
+            //if we don't have logind/CK2, just create a single seat immediately and don't do any other connections
+            createSeat(QStringLiteral("seat0"));
+            return;
+        }
+
+        //fetch seats
+        auto listSeatsMsg = QDBusMessage::createMethodCall(Logind::serviceName(), Logind::managerPath(), Logind::managerIfaceName(), QStringLiteral("ListSeats"));
+        QDBusPendingReply<NamedSeatPathList> reply = QDBusConnection::systemBus().asyncCall(listSeatsMsg);
+
+        QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(reply);
+        connect(watcher, &QDBusPendingCallWatcher::finished, this, [=]() {
+            watcher->deleteLater();
+            foreach(const NamedSeatPath &seat, reply.value()) {
+                logindSeatAdded(seat.name, seat.path);
+            }
+        });
+
+        QDBusConnection::systemBus().connect(Logind::serviceName(), Logind::managerPath(), Logind::managerIfaceName(), QStringLiteral("SeatNew"), this, SLOT(logindSeatAdded(QString,QDBusObjectPath)));
+        QDBusConnection::systemBus().connect(Logind::serviceName(), Logind::managerPath(), Logind::managerIfaceName(), QStringLiteral("SeatRemoved"), this, SLOT(logindSeatRemoved(QString,QDBusObjectPath)));
     }
 
     void SeatManager::createSeat(const QString &name) {
@@ -59,4 +151,28 @@ namespace SDDM {
         // switch to greeter
         m_seats.value(name)->createDisplay();
     }
+
+    void SDDM::SeatManager::logindSeatAdded(const QString& name, const QDBusObjectPath& objectPath)
+    {
+        auto logindSeat = new LogindSeat(name, objectPath, this);
+        connect(logindSeat, &LogindSeat::canGraphicalChanged, this, [=]() {
+            if (logindSeat->canGraphical()) {
+                createSeat(logindSeat->name());
+            } else {
+                removeSeat(logindSeat->name());
+            }
+        });
+
+        m_systemSeats.insert(name, logindSeat);
+    }
+
+    void SDDM::SeatManager::logindSeatRemoved(const QString& name, const QDBusObjectPath& objectPath)
+    {
+        Q_UNUSED(objectPath);
+        auto logindSeat = m_systemSeats.take(name);
+        delete logindSeat;
+        removeSeat(name);
+    }
 }
+
+#include "SeatManager.moc"

--- a/src/daemon/SeatManager.h
+++ b/src/daemon/SeatManager.h
@@ -22,28 +22,32 @@
 
 #include <QObject>
 #include <QHash>
+#include <QDBusObjectPath>
 
 namespace SDDM {
     class Seat;
+    class LogindSeat;
 
     class SeatManager : public QObject {
         Q_OBJECT
-        Q_DISABLE_COPY(SeatManager)
     public:
         explicit SeatManager(QObject *parent = 0);
 
-    public slots:
         void createSeat(const QString &name);
         void removeSeat(const QString &name);
-
         void switchToGreeter(const QString &seat);
 
-    signals:
+    Q_SIGNALS:
         void seatCreated(const QString &name);
         void seatRemoved(const QString &name);
 
+    private Q_SLOTS:
+        void logindSeatAdded(const QString &name, const QDBusObjectPath &objectPath);
+        void logindSeatRemoved(const QString &name, const QDBusObjectPath &objectPath);
+
     private:
-        QHash<QString, Seat *> m_seats;
+        QHash<QString, Seat *> m_seats; //these will exist only for graphical seats
+        QHash<QString, LogindSeat*> m_systemSeats; //these will exist for all seats
     };
 }
 

--- a/src/daemon/XorgDisplayServer.cpp
+++ b/src/daemon/XorgDisplayServer.cpp
@@ -24,6 +24,7 @@
 #include "DaemonApp.h"
 #include "Display.h"
 #include "SignalHandler.h"
+#include "Seat.h"
 
 #include <QDebug>
 #include <QFile>
@@ -159,7 +160,11 @@ namespace SDDM {
                  << QStringLiteral("-background") << QStringLiteral("none")
                  << QStringLiteral("-noreset")
                  << QStringLiteral("-displayfd") << QString::number(pipeFds[1])
-                 << QStringLiteral("vt%1").arg(displayPtr()->terminalId());
+                 << QStringLiteral("-seat") << displayPtr()->seat()->name();
+
+            if (displayPtr()->seat()->name() == QLatin1String("seat0")) {
+                args << QStringLiteral("vt%1").arg(displayPtr()->terminalId());
+            }
             qDebug() << "Running:"
                      << qPrintable(mainConfig.X11.ServerPath.get())
                      << qPrintable(args.join(QLatin1Char(' ')));
@@ -191,7 +196,7 @@ namespace SDDM {
             displayNumber.prepend(QByteArray(":"));
             displayNumber.remove(displayNumber.size() -1, 1); //trim trailing whitespace
             m_display = QString::fromLocal8Bit(displayNumber);
-    
+
             // close our pipe
             close(pipeFds[0]);
 

--- a/src/helper/CMakeLists.txt
+++ b/src/helper/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
 endif()
 
 add_executable(sddm-helper ${HELPER_SOURCES})
-target_link_libraries(sddm-helper Qt5::Network)
+target_link_libraries(sddm-helper Qt5::Network Qt5::DBus)
 if(PAM_FOUND)
     target_link_libraries(sddm-helper ${PAM_LIBRARIES})
 else()

--- a/src/helper/HelperApp.cpp
+++ b/src/helper/HelperApp.cpp
@@ -34,6 +34,7 @@
 #include <unistd.h>
 #include <sys/socket.h>
 
+
 namespace SDDM {
     HelperApp::HelperApp(int& argc, char** argv)
             : QCoreApplication(argc, argv)


### PR DESCRIPTION
```
Most desktop environments don't support logging in as the same user
twice, especially with system changes that means the DBUS session bus is
the same.

With this patch if a user tries to log in as a user that is already
logged in we unlock and activate that session rather than creating a new
session.

This behaviour is configurable with a config option. The default matches
the current behaviour.
```
