### PR TITLE
Fix error when session command has multiple arguments

### DIFF
--- a/data/scripts/Xsession
+++ b/data/scripts/Xsession
@@ -94,7 +94,7 @@ if [ -f "$USERXSESSION" ]; then
   . "$USERXSESSION"
 fi
 
-if [ -z "$@" ]; then
+if [ -z "$*" ]; then
     exec xmessage -center -buttons OK:0 -default OK "Sorry, $DESKTOP_SESSION is no valid session."
 else
     exec $@


### PR DESCRIPTION
This fixes an error like:
```
/usr/share/sddm/scripts/Xsession: line 91: [: /usr/bin/ck-launch-session : binary operator expected
```