### PR TITLE
autologin: try last successful session if no autologin session is set

### DIFF
--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -91,7 +91,7 @@ namespace SDDM {
 
         Section(Autologin,
             Entry(User,                QString,     QString(),                                  _S("Username for autologin session"));
-            Entry(Session,             QString,     QString(),                                  _S("Name of session file for autologin session"));
+            Entry(Session,             QString,     QString(),                                  _S("Name of session file for autologin session (if empty try last logged in)"));
             Entry(Relogin,             bool,        false,                                      _S("Whether sddm should automatically log back into sessions when they exit"));
         );
     );

--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -109,7 +109,11 @@ namespace SDDM {
         Session::Type sessionType = Session::X11Session;
 
         // determine session type
-        const QString &autologinSession = mainConfig.Autologin.Session.get();
+        QString autologinSession = mainConfig.Autologin.Session.get();
+        // not configured: try last successful logged in
+        if (autologinSession.isEmpty()) {
+            autologinSession = stateConfig.Last.Session.get();
+        }
         if (findSessionEntry(mainConfig.X11.SessionDir.get(), autologinSession)) {
             sessionType = Session::X11Session;
         } else if (findSessionEntry(mainConfig.Wayland.SessionDir.get(), autologinSession)) {
@@ -140,7 +144,7 @@ namespace SDDM {
         qDebug() << "Display server started.";
 
         if ((daemonApp->first || mainConfig.Autologin.Relogin.get()) &&
-            !mainConfig.Autologin.User.get().isEmpty() && !mainConfig.Autologin.Session.get().isEmpty()) {
+            !mainConfig.Autologin.User.get().isEmpty()) {
             // reset first flag
             daemonApp->first = false;
 


### PR DESCRIPTION
* By this the user can decide which session to select for autologin without
  touching priviledged configuration file.
* If session is set in configuration, the behaviour is same as before

Signed-off-by: Andreas Müller <schnitzeltony@googlemail.com>