### PR TITLE
Add IgnoreUsermodel to theme-metadata to disable userModel-generation…

### DIFF
--- a/docs/THEMING.md
+++ b/docs/THEMING.md
@@ -64,7 +64,8 @@ The model also provides, a `primary` property pointing to the index of the prima
 For each session, the model provides `file`, `name`, `exec` and `comment` properties.
 Also there is a `lastIndex` property, pointing to the last session the user successfully logged in.
 
-**userModel:** This is list model. Contains information about the users available on the system. This information is gathered by reading the user database provided by `getpwent()`. To prevent system users polluting the user model we only show users with user ids greater than a certain threshold. This threshold is adjustable through the config file and called `MinimumUid`.
+**userModel:** This is a list model. It contains information about the users available on the system. This information is gathered by reading the user database provided by `getpwent()`. To prevent system users polluting the user model we only show users with user ids in a certain range. This range is adjustable in the config file by `MinimumUid` and `MaximumUid`.
+Simply not using the userModel still generates the list. Themes not relying on the userModel can disable the generation of such by specifying `IgnoreUsermodel=true` in their respective metadata-file. This is especially useful for multi-user environments.
 
 For each user the model provides `name`, `realName`, `homeDir` and `icon` properties.
 This model also has a `lastIndex` property holding the index of the last user successfully logged in, and a `lastUser` property containing the name of the last user successfully logged in.

--- a/src/common/ThemeMetadata.cpp
+++ b/src/common/ThemeMetadata.cpp
@@ -28,6 +28,7 @@ namespace SDDM {
         QString mainScript { QStringLiteral("Main.qml") };
         QString configFile;
         QString translationsDirectory { QStringLiteral(".") };
+        bool ignoreUsermodel;
     };
 
     ThemeMetadata::ThemeMetadata(const QString &path, QObject *parent) : QObject(parent), d(new ThemeMetadataPrivate()) {
@@ -50,11 +51,16 @@ namespace SDDM {
         return d->translationsDirectory;
     }
 
+    const bool ThemeMetadata::ignoreUsermodel() const {
+        return d->ignoreUsermodel;
+    }
+
     void ThemeMetadata::setTo(const QString &path) {
         QSettings settings(path, QSettings::IniFormat);
         // read values
         d->mainScript = settings.value(QStringLiteral("SddmGreeterTheme/MainScript"), d->mainScript).toString();
         d->configFile = settings.value(QStringLiteral("SddmGreeterTheme/ConfigFile"), d->configFile).toString();
         d->translationsDirectory = settings.value(QStringLiteral("SddmGreeterTheme/TranslationsDirectory"), d->translationsDirectory).toString();
+        d->ignoreUsermodel = settings.value(QStringLiteral("SddmGreeterTheme/IgnoreUsermodel"), d->ignoreUsermodel).toBool();
     }
 }

--- a/src/common/ThemeMetadata.h
+++ b/src/common/ThemeMetadata.h
@@ -36,6 +36,7 @@ namespace SDDM {
         const QString &mainScript() const;
         const QString &configFile() const;
         const QString &translationsDirectory() const;
+        const bool ignoreUsermodel() const;
 
         void setTo(const QString &path);
 

--- a/src/greeter/GreeterApp.cpp
+++ b/src/greeter/GreeterApp.cpp
@@ -105,7 +105,11 @@ namespace SDDM {
         // create models
 
         m_sessionModel = new SessionModel();
-        m_userModel = new UserModel();
+
+        // only create UserModel if required by theme, otherwise this is NULL and should not be used by the theme
+        if(!m_metadata->ignoreUsermodel())
+            m_userModel = new UserModel();
+
         m_proxy = new GreeterProxy(socket);
         m_keyboard = new KeyboardModel();
 


### PR DESCRIPTION
…, update documentation

IgnoreUsermodel=true disables generation of the userModel, useful for multi-user environments.
If it is set to false or not specified in the theme-metadata, it behaves exactly as before.
Documentation updated accordingly.

Signed-off-by: Milan Stephan <milan.stephan@fau.de>
Signed-off-by: Thomas Preisner <thomas.preisner@fau.de>