### PR TITLE
Reset the login-form after idle-timeout

### DIFF
--- a/data/man/sddm.conf.rst.in
+++ b/data/man/sddm.conf.rst.in
@@ -49,6 +49,11 @@ OPTIONS
         or "compose" for dead keys support.
         Leave this empty if unsure.
 
+`FormResetTime=`
+	Idle timeout in seconds until sddm resets the form. Useful for
+	multi-user-environments. Set to 0 to disable this feature.
+	Default is 0.
+
 [Theme] section:
 
 `ThemeDir=`

--- a/data/man/sddm.conf.rst.in
+++ b/data/man/sddm.conf.rst.in
@@ -54,6 +54,14 @@ OPTIONS
 	multi-user-environments. Set to 0 to disable this feature.
 	Default is 0.
 
+`DefaultSession=`
+	This specifies the `absolute path` of the default session which is preselected on
+	startup and restored on a form-reset-event (caused by `FormResetTime`).
+	Leave empty to use the last-used session (Caution: this is not a user-specific setting!).
+	To use the user's previous session, use `lightdm-xsession` or a equivalent session.
+	All available sessions are listed in the syslog-file as debug output.
+	Default value is empty.
+
 [Theme] section:
 
 `ThemeDir=`

--- a/data/themes/elarun/Main.qml
+++ b/data/themes/elarun/Main.qml
@@ -42,6 +42,13 @@ Rectangle {
         onLoginFailed: {
             pw_entry.text = ""
         }
+        onFormReset: {
+            user_entry.text = ""
+            pw_entry.text = ""
+            session.index = sessionModel.lastIndex
+            menu_session.index = sessionModel.lastIndex
+            user_entry.focus = true
+        }
     }
 
     Background {

--- a/data/themes/elarun/metadata.desktop
+++ b/data/themes/elarun/metadata.desktop
@@ -46,4 +46,4 @@ TranslationsDirectory=translations
 Theme-Id=elarun
 Theme-API=${COMPONENTS_VERSION}
 Website=https://github.com/sddm/sddm
-
+FormResetSupport=true

--- a/data/themes/maldives/Main.qml
+++ b/data/themes/maldives/Main.qml
@@ -48,6 +48,14 @@ Rectangle {
             errorMessage.color = "red"
             errorMessage.text = textConstants.loginFailed
         }
+
+        onFormReset: {
+            name.text = ""
+            password.text = ""
+            session.index = sessionModel.lastIndex
+            errorMessage.text = ""
+            name.focus = true
+        }
     }
 
     Background {

--- a/data/themes/maldives/metadata.desktop
+++ b/data/themes/maldives/metadata.desktop
@@ -14,3 +14,4 @@ TranslationsDirectory=translations
 Email=abdurrahmanavci@gmail.com
 Theme-Id=maldives
 Theme-API=${COMPONENTS_VERSION}
+FormResetSupport=true

--- a/data/themes/maya/Main.qml
+++ b/data/themes/maya/Main.qml
@@ -93,6 +93,13 @@ Rectangle {
 
       anim_failure.start()
     }
+    onFormReset: {
+      maya_username.text = ""
+      maya_password.text = ""
+      maya_session.index = sessionModel.lastIndex
+      prompt_txt.text = ""
+      maya_username.focus = true
+    }
   }
 
 

--- a/data/themes/maya/metadata.desktop
+++ b/data/themes/maya/metadata.desktop
@@ -14,3 +14,4 @@ TranslationsDirectory=translations
 Email=spremi@ymail.com
 Theme-Id=maya
 Theme-API=${COMPONENTS_VERSION}
+FormResetSupport=true

--- a/docs/THEMING.md
+++ b/docs/THEMING.md
@@ -51,6 +51,8 @@ We provide a proxy object, called as `sddm` to the themes as a context property.
 
 **loginSucceeded():** Emitted when a requested login operation succeeds.
 
+**formReset():** Emitted when the greeter requests a reset of the login-form. Only emitted if the theme has the metadata-feature-flag `FormResetSupport` set to `true`.
+
 ## Data Models
 Besides the proxy object we offer a few models that can be hooked to the views to handle multiple screens or enable selection of users or sessions.
 

--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -45,6 +45,8 @@ namespace SDDM {
         Entry(EnableHiDPI,         bool,        true,                                           _S("Enable Qt's automatic high-DPI scaling"));
         Entry(InputMethod,         QString,     QString(),                                      _S("Input method module"));
         Entry(FormResetTime,       int,         0,                                              _S("Idle timeout in seconds until sddm resets the form (0 = disabled)"));
+        Entry(DefaultSession,      QString,     QString(),                                      _S("Default session (preselected and used for form-reset).\n"
+                                                                                                   "If not set, the (globally) last used session is being used."));
 
         //  Name   Entries (but it's a regular class again)
         Section(Theme,

--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -44,6 +44,8 @@ namespace SDDM {
                                                                                                    "NOTE: Currently ignored if autologin is enabled."));
         Entry(EnableHiDPI,         bool,        true,                                           _S("Enable Qt's automatic high-DPI scaling"));
         Entry(InputMethod,         QString,     QString(),                                      _S("Input method module"));
+        Entry(FormResetTime,       int,         0,                                              _S("Idle timeout in seconds until sddm resets the form (0 = disabled)"));
+
         //  Name   Entries (but it's a regular class again)
         Section(Theme,
             Entry(ThemeDir,            QString,     _S(DATA_INSTALL_DIR "/themes"),             _S("Theme directory path"));

--- a/src/common/ThemeMetadata.cpp
+++ b/src/common/ThemeMetadata.cpp
@@ -28,6 +28,7 @@ namespace SDDM {
         QString mainScript { QStringLiteral("Main.qml") };
         QString configFile;
         QString translationsDirectory { QStringLiteral(".") };
+        bool formResetSupport;
     };
 
     ThemeMetadata::ThemeMetadata(const QString &path, QObject *parent) : QObject(parent), d(new ThemeMetadataPrivate()) {
@@ -50,11 +51,16 @@ namespace SDDM {
         return d->translationsDirectory;
     }
 
+    const bool ThemeMetadata::formResetSupport() const {
+        return d->formResetSupport;
+    }
+
     void ThemeMetadata::setTo(const QString &path) {
         QSettings settings(path, QSettings::IniFormat);
         // read values
         d->mainScript = settings.value(QStringLiteral("SddmGreeterTheme/MainScript"), d->mainScript).toString();
         d->configFile = settings.value(QStringLiteral("SddmGreeterTheme/ConfigFile"), d->configFile).toString();
         d->translationsDirectory = settings.value(QStringLiteral("SddmGreeterTheme/TranslationsDirectory"), d->translationsDirectory).toString();
+        d->formResetSupport = settings.value(QStringLiteral("SddmGreeterTheme/FormResetSupport"), d->formResetSupport).toBool();
     }
 }

--- a/src/common/ThemeMetadata.h
+++ b/src/common/ThemeMetadata.h
@@ -36,6 +36,7 @@ namespace SDDM {
         const QString &mainScript() const;
         const QString &configFile() const;
         const QString &translationsDirectory() const;
+        const bool formResetSupport() const;
 
         void setTo(const QString &path);
 

--- a/src/greeter/GreeterApp.h
+++ b/src/greeter/GreeterApp.h
@@ -24,6 +24,7 @@
 #include <QGuiApplication>
 #include <QScreen>
 #include <QQuickView>
+#include <QTimer>
 
 class QTranslator;
 
@@ -47,6 +48,9 @@ namespace SDDM {
 
         static GreeterApp *instance() { return self; }
 
+    protected:
+        bool notify(QObject *receiver, QEvent *event);
+
     private slots:
         void addViewForScreen(QScreen *screen);
         void removeViewForScreen(QQuickView *view);
@@ -65,6 +69,7 @@ namespace SDDM {
         UserModel *m_userModel { nullptr };
         GreeterProxy *m_proxy { nullptr };
         KeyboardModel *m_keyboard { nullptr };
+        QTimer m_formResetTimer { this };
 
         void activatePrimary();
     };

--- a/src/greeter/GreeterProxy.cpp
+++ b/src/greeter/GreeterProxy.cpp
@@ -52,6 +52,10 @@ namespace SDDM {
         d->socket->connectToServer(socket);
     }
 
+    void GreeterProxy::formResetAction() {
+        emit formReset();
+    }
+
     GreeterProxy::~GreeterProxy() {
         delete d;
     }

--- a/src/greeter/GreeterProxy.h
+++ b/src/greeter/GreeterProxy.h
@@ -63,6 +63,7 @@ namespace SDDM {
         void hybridSleep();
 
         void login(const QString &user, const QString &password, const int sessionIndex) const;
+        void formResetAction();
 
     private slots:
         void connected();
@@ -80,6 +81,7 @@ namespace SDDM {
 
         void loginFailed();
         void loginSucceeded();
+        void formReset();
 
     private:
         GreeterProxyPrivate *d { nullptr };

--- a/src/greeter/SessionModel.cpp
+++ b/src/greeter/SessionModel.cpp
@@ -148,11 +148,21 @@ namespace SDDM {
             else
                 delete si;
         }
+
+        QString defaultSession = SDDM::mainConfig.DefaultSession.get();
+
         // find out index of the last session
         for (int i = 0; i < d->sessions.size(); ++i) {
-            if (d->sessions.at(i)->fileName() == stateConfig.Last.Session.get()) {
-                d->lastIndex = i;
-                break;
+            if (defaultSession.length() > 0) {
+                if (d->sessions.at(i)->fileName() == defaultSession) {
+                    d->lastIndex = i;
+                    break;
+                }
+            } else {
+                if (d->sessions.at(i)->fileName() == stateConfig.Last.Session.get()) {
+                    d->lastIndex = i;
+                    break;
+                }
             }
         }
     }


### PR DESCRIPTION
Useful for multi-user-environments. Resets the form after a configurable idle-timeout to always present users clean forms.
#781 