### PR TITLE
PAM-Message Integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,7 @@ find_package(XCB REQUIRED)
 find_package(XKB REQUIRED)
 
 # Qt 5
-find_package(Qt5 5.6.0 CONFIG REQUIRED Core DBus Gui Qml Quick LinguistTools)
+find_package(Qt5 5.6.0 CONFIG REQUIRED Core DBus Gui Qml Quick LinguistTools Widgets)
 
 # find qt5 imports dir
 get_target_property(QMAKE_EXECUTABLE Qt5::qmake LOCATION)

--- a/src/common/Messages.h
+++ b/src/common/Messages.h
@@ -37,7 +37,8 @@ namespace SDDM {
         HostName,
         Capabilities,
         LoginSucceeded,
-        LoginFailed
+        LoginFailed,
+        PamConvMsg
     };
 
     enum Capability {

--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -68,6 +68,10 @@ namespace SDDM {
         // connect login result signals
         connect(this, SIGNAL(loginFailed(QLocalSocket*)), m_socketServer, SLOT(loginFailed(QLocalSocket*)));
         connect(this, SIGNAL(loginSucceeded(QLocalSocket*)), m_socketServer, SLOT(loginSucceeded(QLocalSocket*)));
+
+        // connect pam message signal
+        connect(this, SIGNAL(pamConvMsg(QLocalSocket*, const QString&)),
+                m_socketServer, SLOT(pamConvMsg(QLocalSocket*, const QString&)));
     }
 
     Display::~Display() {
@@ -339,9 +343,14 @@ namespace SDDM {
     }
 
     void Display::slotAuthInfo(const QString &message, Auth::Info info) {
-        // TODO: presentable to the user, eventually
         Q_UNUSED(info);
+        // TODO: handle more errors
         qWarning() << "Authentication information:" << message;
+
+        if (!m_socket)
+            return;
+
+        emit pamConvMsg(m_socket, message);
     }
 
     void Display::slotAuthError(const QString &message, Auth::Error error) {

--- a/src/daemon/Display.h
+++ b/src/daemon/Display.h
@@ -69,6 +69,8 @@ namespace SDDM {
         void loginFailed(QLocalSocket *socket);
         void loginSucceeded(QLocalSocket *socket);
 
+        void pamConvMsg(QLocalSocket *socket, const QString &message);
+
     private:
         QString findGreeterTheme() const;
         bool findSessionEntry(const QDir &dir, const QString &name) const;

--- a/src/daemon/Greeter.cpp
+++ b/src/daemon/Greeter.cpp
@@ -180,6 +180,7 @@ namespace SDDM {
             env.insert(QStringLiteral("XDG_VTNR"), QString::number(m_display->terminalId()));
             env.insert(QStringLiteral("XDG_SESSION_CLASS"), QStringLiteral("greeter"));
             env.insert(QStringLiteral("XDG_SESSION_TYPE"), m_display->sessionType());
+            env.insert(QStringLiteral("QT_IM_MODULE"), mainConfig.InputMethod.get());
 
             //some themes may use KDE components and that will automatically load KDE's crash handler which we don't want
             //counterintuitively setting this env disables that handler

--- a/src/daemon/SocketServer.cpp
+++ b/src/daemon/SocketServer.cpp
@@ -195,4 +195,8 @@ namespace SDDM {
     void SocketServer::loginSucceeded(QLocalSocket *socket) {
         SocketWriter(socket) << quint32(DaemonMessages::LoginSucceeded);
     }
+
+    void SocketServer::pamConvMsg(QLocalSocket *socket, const QString &message) {
+        SocketWriter(socket) << quint32(DaemonMessages::PamConvMsg) << message;
+    }
 }

--- a/src/daemon/SocketServer.h
+++ b/src/daemon/SocketServer.h
@@ -48,6 +48,9 @@ namespace SDDM {
         void loginFailed(QLocalSocket *socket);
         void loginSucceeded(QLocalSocket *socket);
 
+    public slots:
+        void pamConvMsg(QLocalSocket *socket, const QString &message);
+
     signals:
         void login(QLocalSocket *socket,
                    const QString &user, const QString &password,

--- a/src/greeter/CMakeLists.txt
+++ b/src/greeter/CMakeLists.txt
@@ -26,6 +26,7 @@ qt5_add_resources(RESOURCES ${CMAKE_CURRENT_BINARY_DIR}/theme.qrc)
 add_executable(sddm-greeter ${GREETER_SOURCES} ${RESOURCES})
 target_link_libraries(sddm-greeter
                       Qt5::Quick
+                      Qt5::Widgets
                       ${LIBXCB_LIBRARIES}
                       ${LIBXKB_LIBRARIES})
 

--- a/src/greeter/GreeterApp.h
+++ b/src/greeter/GreeterApp.h
@@ -21,7 +21,7 @@
 #ifndef GREETERAPP_H
 #define GREETERAPP_H
 
-#include <QGuiApplication>
+#include <QApplication>
 #include <QScreen>
 #include <QQuickView>
 
@@ -38,7 +38,7 @@ namespace SDDM {
     class KeyboardModel;
 
 
-    class GreeterApp : public QGuiApplication
+    class GreeterApp : public QApplication
     {
         Q_OBJECT
         Q_DISABLE_COPY(GreeterApp)
@@ -50,6 +50,9 @@ namespace SDDM {
     private slots:
         void addViewForScreen(QScreen *screen);
         void removeViewForScreen(QQuickView *view);
+        void pamShow();
+        void pamShowCloseGreeter();
+        void pamStoreMessage(const QString &message);
 
     private:
         static GreeterApp *self;
@@ -65,6 +68,7 @@ namespace SDDM {
         UserModel *m_userModel { nullptr };
         GreeterProxy *m_proxy { nullptr };
         KeyboardModel *m_keyboard { nullptr };
+        QStringList m_pamMessages;
 
         void activatePrimary();
     };

--- a/src/greeter/GreeterProxy.cpp
+++ b/src/greeter/GreeterProxy.cpp
@@ -204,6 +204,16 @@ namespace SDDM {
                     emit loginFailed();
                 }
                 break;
+                case DaemonMessages::PamConvMsg: {
+                    // log message
+                    qDebug() << "Message received from daemon: PamConvMsg";
+
+                    QString msg;
+                    input >> msg;
+
+                    emit storePamMessage(msg);
+                }
+                break;
                 default: {
                     // log message
                     qWarning() << "Unknown message received from daemon.";

--- a/src/greeter/GreeterProxy.h
+++ b/src/greeter/GreeterProxy.h
@@ -80,6 +80,7 @@ namespace SDDM {
 
         void loginFailed();
         void loginSucceeded();
+        void storePamMessage(const QString message);
 
     private:
         GreeterProxyPrivate *d { nullptr };


### PR DESCRIPTION
Displays PAM-messages to the user on successful login or failed login attempt.
Greeter stores multiple PAM-messages and displays one after another using "QMessageBox"es.

Signed-off-by: Milan Stephan <milan.stephan@fau.de>
Signed-off-by: Thomas Preisner <thomas.preisner@fau.de>

#782 