### PR TITLE
sddm-helper: x11: fix unsupported number of arguements error for unity session

### DIFF
--- a/src/helper/UserSession.cpp
+++ b/src/helper/UserSession.cpp
@@ -46,7 +46,7 @@ namespace SDDM {
         if (env.value(QStringLiteral("XDG_SESSION_CLASS")) == QLatin1String("greeter")) {
             QProcess::start(m_path);
         } else if (env.value(QStringLiteral("XDG_SESSION_TYPE")) == QLatin1String("x11")) {
-            const QString cmd = QStringLiteral("%1 %2").arg(mainConfig.X11.SessionCommand.get()).arg(m_path);
+            const QString cmd = QStringLiteral("%1 \"%2\"").arg(mainConfig.X11.SessionCommand.get()).arg(m_path);
             qInfo() << "Starting:" << cmd;
             QProcess::start(cmd);
         } else if (env.value(QStringLiteral("XDG_SESSION_TYPE")) == QLatin1String("wayland")) {


### PR DESCRIPTION
Currently AFAICT the /etc/X11/Xsession script in Ubuntu is expecting 1 and only 1 arguments as the running command, as showed as the following fraction of /etc/X11/Xsession.d/20x11-common_process-args:

```sh
case $# in
  0)
    # No arguments given; use default behavior.
    ;;
  1)
    # One argument given; see what it was.
    case "$1" in
      failsafe)
        # Failsafe session was requested.
        if has_option allow-failsafe; then
          if [ -e /usr/bin/x-terminal-emulator ]; then
            if [ -x /usr/bin/x-terminal-emulator ]; then
              exec x-terminal-emulator -geometry +1+1
            else
              # fatal error
              errormsg "unable to launch failsafe X session ---" \
                       "x-terminal-emulator not executable; aborting."
            fi
          else
            # fatal error
            errormsg "unable to launch failsafe X session ---" \
                     "x-terminal-emulator not found; aborting."
          fi
        fi
        ;;
      default)
        # Default behavior was requested.
        ;;
      *)
        # Specific program was requested.
        STARTUP_FULL_PATH=$(/usr/bin/which "${1%% *}" || true)
        if [ -n "$STARTUP_FULL_PATH" ] && [ -e "$STARTUP_FULL_PATH" ]; then
          if [ -x "$STARTUP_FULL_PATH" ]; then
            STARTUP="$1"
          else
            message "unable to launch \"$1\" X session ---" \
                    "\"$1\" not executable; falling back to default session."
          fi
        else
          message "unable to launch \"$1\" X session ---" \
                  "\"$1\" not found; falling back to default session."
        fi
        ;;
    esac
    ;;
  *)
    # More than one argument given; we don't know what to do.
    message "unsupported number of arguments ($#); falling back to default" \
            "session."
    ;;
esac
```

Currently SDDM runs the Xsession script without quoting the second argument, which causes all xsessions that Exec key contains command-line arguments(like Unity(gnome-session --session=ubuntu)) causes Xsession to bail out with message like "Xsession: unsupported number of arguments (2); falling back to default session."

This patch fixes the issue by quoting the %2 argument in the SessionCommand.

Signed-off-by: 林博仁 <Buo.Ren.Lin@gmail.com>