### PR TITLE
Parse desktop file sections

### DIFF
--- a/src/common/Session.cpp
+++ b/src/common/Session.cpp
@@ -31,10 +31,12 @@ namespace SDDM {
     Session::Session()
         : m_valid(false)
         , m_type(UnknownSession)
+        , m_isHidden(false)
     {
     }
 
     Session::Session(Type type, const QString &fileName)
+        : Session()
     {
         setTo(type, fileName);
     }
@@ -104,6 +106,11 @@ namespace SDDM {
         return m_desktopNames;
     }
 
+    bool Session::isHidden() const
+    {
+        return m_isHidden;
+    }
+
     void Session::setTo(Type type, const QString &_fileName)
     {
         QString fileName(_fileName);
@@ -168,6 +175,8 @@ namespace SDDM {
                 m_tryExec = line.mid(8);
             if (line.startsWith(QLatin1String("DesktopNames=")))
                 m_desktopNames = line.mid(13).replace(QLatin1Char(';'), QLatin1Char(':'));
+            if (line.startsWith(QLatin1String("Hidden=")))
+                m_isHidden = line.mid(7).toLower() == QLatin1String("true");
         }
 
         file.close();

--- a/src/common/Session.cpp
+++ b/src/common/Session.cpp
@@ -138,9 +138,21 @@ namespace SDDM {
         if (!file.open(QIODevice::ReadOnly))
             return;
 
+        QString current_section;
+
         QTextStream in(&file);
         while (!in.atEnd()) {
             QString line = in.readLine();
+
+            if (line.startsWith(QLatin1String("["))) {
+                // The section name ends before the last ] before the start of a comment
+                int end = line.lastIndexOf(QLatin1Char(']'), line.indexOf(QLatin1Char('#')));
+                if (end != -1)
+                    current_section = line.mid(1, end - 1);
+            }
+
+            if (current_section != QLatin1String("Desktop Entry"))
+                continue; // We are only interested in the "Desktop Entry" section
 
             if (line.startsWith(QLatin1String("Name="))) {
                 if (type == WaylandSession)

--- a/src/common/Session.h
+++ b/src/common/Session.h
@@ -59,6 +59,8 @@ namespace SDDM {
         QString desktopSession() const;
         QString desktopNames() const;
 
+        bool isHidden() const;
+
         void setTo(Type type, const QString &name);
 
         Session &operator=(const Session &other);
@@ -76,6 +78,7 @@ namespace SDDM {
         QString m_tryExec;
         QString m_xdgSessionType;
         QString m_desktopNames;
+        bool m_isHidden;
 
         friend class SessionModel;
     };

--- a/src/greeter/SessionModel.cpp
+++ b/src/greeter/SessionModel.cpp
@@ -143,7 +143,7 @@ namespace SDDM {
                 }
             }
             // add to sessions list
-            if (execAllowed)
+            if (!si->isHidden() && execAllowed)
                 d->sessions.push_back(si);
             else
                 delete si;


### PR DESCRIPTION
Some desktop files have multiple sections, but for now we're only
interested in [Desktop Entry]. Without this patch, every entry was seen
as part of the [Desktop Entry] session, resulting in values getting
overwritten.

Tested, correct name now shown for certain files.