### PR TITLE
Honor PAM's ambient supplemental groups (pam_group.so)

### DIFF
--- a/src/helper/UserSession.cpp
+++ b/src/helper/UserSession.cpp
@@ -152,11 +152,70 @@ namespace SDDM {
             free(buffer);
             exit(Auth::HELPER_OTHER_ERROR);
         }
+
+#ifdef USE_PAM
+
+        // fetch ambient groups from PAM's environment;
+        // these are set by modules such as pam_groups.so
+        int n_pam_groups = getgroups(0, NULL);
+        gid_t *pam_groups = NULL;
+        if (n_pam_groups > 0) {
+            pam_groups = new gid_t[n_pam_groups];
+            if ((n_pam_groups = getgroups(n_pam_groups, pam_groups)) == -1) {
+                qCritical() << "getgroups() failed to fetch supplemental"
+                            << "PAM groups for user:" << username;
+                exit(Auth::HELPER_OTHER_ERROR);
+            }
+        } else {
+            n_pam_groups = 0;
+        }
+
+        // fetch session's user's groups
+        int n_user_groups = 0;
+        gid_t *user_groups = NULL;
+        if (-1 == getgrouplist(username.constData(), pw.pw_gid,
+                               NULL, &n_user_groups)) {
+            user_groups = new gid_t[n_user_groups];
+            if ((n_user_groups = getgrouplist(username.constData(),
+                                              pw.pw_gid, user_groups,
+                                              &n_user_groups)) == -1 ) {
+                qCritical() << "getgrouplist(" << username << ", " << pw.pw_gid
+                            << ") failed";
+                free(buffer);
+                exit(Auth::HELPER_OTHER_ERROR);
+            }
+        }
+
+        // set groups to concatenation of PAM's ambient
+        // groups and the session's user's groups
+        int n_groups = n_pam_groups + n_user_groups;
+        if (n_groups > 0) {
+            gid_t *groups = new gid_t[n_groups];
+            memcpy(groups, pam_groups, (n_pam_groups * sizeof(gid_t)));
+            memcpy((groups + n_pam_groups), user_groups,
+                   (n_user_groups * sizeof(gid_t)));
+
+            // setgroups(2) handles duplicate groups
+            if (setgroups(n_groups, groups) != 0) {
+                qCritical() << "setgroups() failed for user: " << username;
+                free(buffer);
+                exit (Auth::HELPER_OTHER_ERROR);
+            }
+            delete[] groups;
+        }
+        delete[] pam_groups;
+        delete[] user_groups;
+
+#else
+
         if (initgroups(pw.pw_name, pw.pw_gid) != 0) {
             qCritical() << "initgroups(" << pw.pw_name << ", " << pw.pw_gid << ") failed for user: " << username;
             free(buffer);
             exit(Auth::HELPER_OTHER_ERROR);
         }
+
+#endif /* USE_PAM */
+
         if (setuid(pw.pw_uid) != 0) {
             qCritical() << "setuid(" << pw.pw_uid << ") failed for user: " << username;
             free(buffer);


### PR DESCRIPTION
This patch adds support for PAM's pam_group.so(8) module and fixes #414.

SDDM currently uses initgroups(3) in a PAM context. This is problematic when dynamically adding groups to the local host's session: while PAM correctly loads the groups into a session from /etc/security/groups.conf via pam_groups.so, SDDM's initgroups call then throws these away just before the setguid step.

This fix adds PAM's ambient groups to the set of user groups in a session by explicitly dealing with each set of groups. The old behavior is retained when compiling without USE_PAM, due to ambiguous group context when not running under PAM.


Disclosure:
The patch was originally developed by me for Paderborn University;  I have been given permission to contribute it under GPLv2+ to this project. We are currently using this patch in production.