### PR TITLE
Add LIBXCB_INCLUDE_DIR to the list of include directories.

### DIFF
--- a/src/daemon/CMakeLists.txt
+++ b/src/daemon/CMakeLists.txt
@@ -1,8 +1,9 @@
 include_directories(
     "${CMAKE_SOURCE_DIR}/src/common"
     "${CMAKE_SOURCE_DIR}/src/auth"
+    "${CMAKE_BINARY_DIR}/src/common"
+    "${LIBXCB_INCLUDE_DIR}"
 )
-include_directories("${CMAKE_BINARY_DIR}/src/common")
 
 set(DAEMON_SOURCES
     ${CMAKE_SOURCE_DIR}/src/common/Configuration.cpp

--- a/src/greeter/CMakeLists.txt
+++ b/src/greeter/CMakeLists.txt
@@ -1,5 +1,8 @@
-include_directories("${CMAKE_SOURCE_DIR}/src/common")
-include_directories("${CMAKE_BINARY_DIR}/src/common")
+include_directories(
+    "${CMAKE_SOURCE_DIR}/src/common"
+    "${CMAKE_BINARY_DIR}/src/common"
+    "${LIBXCB_INCLUDE_DIR}"
+)
 
 set(GREETER_SOURCES
     ${CMAKE_SOURCE_DIR}/src/common/Configuration.cpp


### PR DESCRIPTION
The daemon and the greeter include xcb/xcb.h, but they were relying on xcb's
include directory being implicitly added by the compiler instead of making
sure it was always passed to the compiler.
