### PR TITLE
Include errno.h and string.h where needed.

### DIFF
--- a/src/daemon/VirtualTerminal.cpp
+++ b/src/daemon/VirtualTerminal.cpp
@@ -22,6 +22,8 @@
 
 #include "VirtualTerminal.h"
 
+#include <errno.h>
+#include <string.h>
 #include <unistd.h>
 #include <fcntl.h>
 #include <signal.h>

--- a/src/helper/UserSession.cpp
+++ b/src/helper/UserSession.cpp
@@ -25,6 +25,8 @@
 
 #include <sys/types.h>
 #include <sys/ioctl.h>
+#include <errno.h>
+#include <string.h>
 #include <unistd.h>
 #include <pwd.h>
 #include <grp.h>


### PR DESCRIPTION
Do not rely on them being implicitly included by other headers; include
errno.h and string.h whenever errno and strerror(3) are used.