### PR TITLE
Fix the translations

### DIFF
--- a/data/translations/CMakeLists.txt
+++ b/data/translations/CMakeLists.txt
@@ -12,22 +12,26 @@ set(TRANSLATION_FILES
     hu.ts
     it.ts
     ja.ts
+    kk.ts
     ko.ts
     lt.ts
     lv.ts
     nb.ts
+    nl.ts
     nn.ts
     pl.ts
     pt_BR.ts
     pt_PT.ts
     ro.ts
-    sr.ts
-    sr@ijekavian.ts
-    sr@ijekavianlatin.ts
-    sr@latin.ts
-    sv.ts
     ru.ts
+    sk.ts
+    sr@ijekavianlatin.ts
+    sr@ijekavian.ts
+    sr@latin.ts
+    sr.ts
+    sv.ts
     tr.ts
+    uk.ts
     zh_CN.ts
     zh_TW.ts
 )

--- a/data/translations/ca.ts
+++ b/data/translations/ca.ts
@@ -21,7 +21,7 @@
     </message>
     <message>
         <source>Login failed</source>
-        <translation>Inici de sessió fracassat</translation>
+        <translation>Inici de sessió no reeixit</translation>
     </message>
     <message>
         <source>Login succeeded</source>

--- a/data/translations/uk.ts
+++ b/data/translations/uk.ts
@@ -49,7 +49,7 @@
     </message>
     <message>
         <source>User name</source>
-        <translation>Ім'я користувача/translation>
+        <translation>Ім'я користувача</translation>
     </message>
     <message>
         <source>Select your user and enter password</source>


### PR DESCRIPTION
Actually list a bunch of already included languages in CMakeLists
Reorder the languages in CMakeLists so it's easier to check with `ls`
Fix formatting of uk.ts