### PR TITLE
Include <unistd.h> for crypt(3), not <crypt.h>

### DIFF
--- a/src/helper/backend/PasswdBackend.cpp
+++ b/src/helper/backend/PasswdBackend.cpp
@@ -28,7 +28,7 @@
 #include <sys/types.h>
 #include <pwd.h>
 #include <shadow.h>
-#include <crypt.h>
+#include <unistd.h>
 
 namespace SDDM {
     PasswdBackend::PasswdBackend(HelperApp *parent)


### PR DESCRIPTION
<crypt.h> is part of glibc and other libc implementations, and not available
on systems such as FreeBSD.

We can just drop the include and use <unistd.h> instead, which is the header
POSIX specifies that defines crypt(3).