### PR TITLE
Stop assuming shadow(5) support is always available.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,10 @@ if(ENABLE_PAM)
 endif()
 add_feature_info("PAM" PAM_FOUND "PAM support")
 
+# getspnam and shadow(5) support
+include(CheckFunctionExists)
+check_function_exists(getspnam HAVE_GETSPNAM)
+
 # XCB
 find_package(XCB REQUIRED)
 

--- a/src/helper/CMakeLists.txt
+++ b/src/helper/CMakeLists.txt
@@ -24,6 +24,10 @@ else()
         ${HELPER_SOURCES}
         backend/PasswdBackend.cpp
     )
+
+   if(HAVE_GETSPNAM)
+       add_definitions(-DHAVE_GETSPNAM=1)
+   endif()
 endif()
 
 add_executable(sddm-helper ${HELPER_SOURCES})

--- a/src/helper/backend/PasswdBackend.cpp
+++ b/src/helper/backend/PasswdBackend.cpp
@@ -27,8 +27,11 @@
 
 #include <sys/types.h>
 #include <pwd.h>
-#include <shadow.h>
 #include <unistd.h>
+
+#ifdef HAVE_GETSPNAM
+#include <shadow.h>
+#endif
 
 namespace SDDM {
     PasswdBackend::PasswdBackend(HelperApp *parent)
@@ -71,7 +74,9 @@ namespace SDDM {
             m_app->error(QStringLiteral("Wrong user/password combination"), Auth::ERROR_AUTHENTICATION);
             return false;
         }
+        const char *system_passwd = pw->pw_passwd;
 
+#ifdef HAVE_GETSPNAM
         struct spwd *spw = getspnam(pw->pw_name);
         if (!spw) {
             qWarning() << "[Passwd] Could get passwd but not shadow";
@@ -81,8 +86,11 @@ namespace SDDM {
         if(!spw->sp_pwdp || !spw->sp_pwdp[0])
             return true;
 
-        char *crypted = crypt(qPrintable(password), spw->sp_pwdp);
-        if (0 == strcmp(crypted, spw->sp_pwdp)) {
+        system_passwd = spw->sp_pwdp;
+#endif
+
+        const char * const crypted = crypt(qPrintable(password), system_passwd);
+        if (0 == strcmp(crypted, system_passwd)) {
             return true;
         }
 


### PR DESCRIPTION
shadow and getspnam(3) are Linux-specific. Add a check for getspnam(3) to
CMake and only use the shadow functions if they exist, otherwise just use
getpwnam(), which on systems such as FreeBSD already performs the same
things shadow does on Linux.