### PR TITLE
Fix typos in config documentation

### DIFF
--- a/src/common/ConfigReader.cpp
+++ b/src/common/ConfigReader.cpp
@@ -142,8 +142,8 @@ namespace SDDM {
     void ConfigBase::load()
     {
         //order of priority from least influence to most influence, is
-        // * m_sysConfigDir (system settings /usr/lib/sddm/sddm.conf.d) in alphabetical order
-        // * m_configDir (user settings in /etc/sddm.d/)  in alphabetical order
+        // * m_sysConfigDir (system settings /usr/lib/sddm/sddm.conf.d/) in alphabetical order
+        // * m_configDir (user settings in /etc/sddm.conf.d/) in alphabetical order
         // * m_path (classic fallback /etc/sddm.conf)
 
         QStringList files;


### PR DESCRIPTION
Mentions wrong path.