### PR TITLE
Explicity set XDG_SEAT env var when starting the user session.

### DIFF
--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -324,6 +324,8 @@ namespace SDDM {
         env.insert(QStringLiteral("XDG_CURRENT_DESKTOP"), session.desktopNames());
         env.insert(QStringLiteral("XDG_SESSION_CLASS"), QStringLiteral("user"));
         env.insert(QStringLiteral("XDG_SESSION_TYPE"), session.xdgSessionType());
+        env.insert(QStringLiteral("XDG_SEAT"), seat()->name());
+
         env.insert(QStringLiteral("XDG_SESSION_DESKTOP"), session.desktopNames());
         if (seat()->name() == QLatin1String("seat0")) {
             env.insert(QStringLiteral("XDG_VTNR"), QString::number(vt));


### PR DESCRIPTION
Removed during the logind seat tracking. I think I did it deliberately as we passed the seat to X..but it was so long ago I can't remember.

In any case, it seems to be needed. If I login, loginctl list-sessions has the right stuff.