### PR TITLE
Keep list of users who logged in and show them in greeter (#479)

### DIFF
--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -86,7 +86,7 @@ namespace SDDM {
             Entry(HideUsers,           QStringList, QStringList(),                              _S("Comma-separated list of users that should not be listed"));
             Entry(HideShells,          QStringList, QStringList(),                              _S("Comma-separated list of shells.\n"
                                                                                                    "Users with these shells as their default won't be listed"));
-            Entry(ShowSavedLogins,     bool,        false,                                       _S("Remember the last successfully logged in user"));
+            Entry(ShowSavedLogins,     bool,        false,                                      _S("Save users which logged in and display them in greeter"));
             Entry(RememberLastUser,    bool,        true,                                       _S("Remember the last successfully logged in user"));
             Entry(RememberLastSession, bool,        true,                                       _S("Remember the session of the last successfully logged in user"));
 

--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -86,6 +86,7 @@ namespace SDDM {
             Entry(HideUsers,           QStringList, QStringList(),                              _S("Comma-separated list of users that should not be listed"));
             Entry(HideShells,          QStringList, QStringList(),                              _S("Comma-separated list of shells.\n"
                                                                                                    "Users with these shells as their default won't be listed"));
+            Entry(ShowSavedLogins,     bool,        false,                                       _S("Remember the last successfully logged in user"));
             Entry(RememberLastUser,    bool,        true,                                       _S("Remember the last successfully logged in user"));
             Entry(RememberLastSession, bool,        true,                                       _S("Remember the session of the last successfully logged in user"));
 

--- a/src/greeter/GreeterProxy.cpp
+++ b/src/greeter/GreeterProxy.cpp
@@ -133,7 +133,11 @@ namespace SDDM {
     void GreeterProxy::saveLoginUser(const QString username) const {
 
         const QString loginList = QStringLiteral("%1/logins.log").arg(QStringLiteral(STATE_DIR));
+        bool saveLogins = mainConfig.Users.ShowSavedLogins.get();
         QFile file(loginList);
+
+        if(!saveLogins)
+            return;
 
         if(!file.open(QIODevice::ReadWrite | QIODevice::Text))
         {

--- a/src/greeter/GreeterProxy.h
+++ b/src/greeter/GreeterProxy.h
@@ -62,7 +62,7 @@ namespace SDDM {
         void hibernate();
         void hybridSleep();
 
-        void login(const QString &user, const QString &password, const int sessionIndex) const;
+        void login(const QString &user, const QString &password, const int sessionIndex);
 
     private slots:
         void connected();
@@ -83,6 +83,8 @@ namespace SDDM {
 
     private:
         GreeterProxyPrivate *d { nullptr };
+        QString loginUser;
+        void saveLoginUser(const QString loginUser) const;
     };
 }
 

--- a/src/greeter/UserModel.cpp
+++ b/src/greeter/UserModel.cpp
@@ -24,6 +24,7 @@
 
 #include <QFile>
 #include <QList>
+#include <QProcess>
 #include <QTextStream>
 #include <QStringList>
 
@@ -99,6 +100,44 @@ namespace SDDM {
 
         endpwent();
 
+        bool savedLogins = mainConfig.Users.ShowSavedLogins.get();
+
+        // read users from logins.log before sort
+        if(savedLogins)
+        {
+            const QString loginList = QStringLiteral("%1/logins.log").arg(QStringLiteral(STATE_DIR));
+            QFile file(loginList);
+            bool insert = false;
+
+            if(!file.open(QIODevice::ReadOnly | QIODevice::Text))
+                qWarning("Failed to open %s", qPrintable(loginList));
+            else
+            {
+                // TODO: inefficient search for users in QList, should be hash list
+                while(!file.atEnd())
+                {
+                    insert = true;
+
+                    // login user
+                    QString luser = QLatin1String(file.readLine());
+                    luser = luser.trimmed(); // remove \n
+
+                    // user already in model?
+                    for(int i = 0; i < d->users.size(); i++) {
+                        if(!luser.compare(d->users.at(i)->name))
+                        {
+                            insert = false;
+                            break;
+                        }
+                    }
+
+                    if(insert)
+                        add(luser, defaultFace);
+                }
+                file.close();
+            }
+        }
+
         // sort users by username
         std::sort(d->users.begin(), d->users.end(), [&](const UserPtr &u1, const UserPtr &u2) { return u1->name < u2->name; });
 
@@ -137,6 +176,8 @@ namespace SDDM {
         roleNames[HomeDirRole] = QByteArrayLiteral("homeDir");
         roleNames[IconRole] = QByteArrayLiteral("icon");
         roleNames[NeedsPasswordRole] = QByteArrayLiteral("needsPassword");
+        //roleNames[UidRole] = QByteArrayLiteral("uid");
+        //roleNames[GidRole] = QByteArrayLiteral("gid");
 
         return roleNames;
     }
@@ -171,9 +212,52 @@ namespace SDDM {
             return user->icon;
         else if (role == NeedsPasswordRole)
             return user->needsPassword;
+        //else if (role == UidRole)
+        //    return user->uid;
+        //else if (role == GidRole)
+        //    return user->gid;
 
         // return empty value
         return QVariant();
+    }
+
+    // remember user who where logging in, add to model
+    void UserModel::add(const QString username, QString defaultFace) {
+        // skip if user already in model
+        foreach(UserPtr duser, d->users)
+            if(username == duser->name)
+                return;
+
+        // get user data with getent()
+        QProcess cmd;
+        cmd.start(QStringLiteral("getent passwd ") + username);
+        cmd.waitForFinished(1000 /* ms */);
+        QString output(QLatin1String(cmd.readAllStandardOutput()));
+
+        if(output.isEmpty())
+        {
+            // ignore deleted or unknown users
+            qDebug("Login list: Ignore saved user %s, user unknown", qPrintable(username));
+        }
+        else
+        {
+            QStringList result = output.split(QLatin1Char(':'));
+
+            UserPtr user { new User() };
+            user->name = username;
+            user->realName = result.at(4).section(QLatin1Char(','),0,0);
+            user->homeDir = result.at(5);
+            // show always input field
+            user->needsPassword = result.at(1).startsWith(QStringLiteral("x"));
+            user->icon = defaultFace;
+            //user->uid = result.at(2).toInt();
+            //user->gid = result.at(3).toInt();
+
+            // append user to model
+            d->users << user;
+
+            qDebug("Login list: Added saved user %s to greeter", qPrintable(username));
+        }
     }
 
     int UserModel::disableAvatarsThreshold() const {

--- a/src/greeter/UserModel.h
+++ b/src/greeter/UserModel.h
@@ -35,11 +35,15 @@ namespace SDDM {
         Q_PROPERTY(int count READ rowCount CONSTANT)
         Q_PROPERTY(int disableAvatarsThreshold READ disableAvatarsThreshold CONSTANT)
     public:
+        Q_INVOKABLE void add(QString username, QString defaultFace);
+
         enum UserRoles {
             NameRole = Qt::UserRole + 1,
             RealNameRole,
             HomeDirRole,
             IconRole,
+            //UidRole,
+            //GidRole,
             NeedsPasswordRole
         };
 


### PR DESCRIPTION
Save users who already logged in to list (/var/lib/sddm/logins.log) and add them to user model, i.e. show them in greeter.
This will help to select users shown in greeter if min./max. UID or HideUsers selection in sddm.conf is not enough. Prevents full user model list.
New sddm config entry is named ShowSavedLogins currently.
Makes only sense for themes with user name input field.
Solves [#479](https://github.com/sddm/sddm/issues/479).