### PR TITLE
man: sddm.greeter.rst.in fix syntax error

### DIFF
--- a/data/man/sddm-greeter.rst.in
+++ b/data/man/sddm-greeter.rst.in
@@ -50,7 +50,7 @@ FILES
 **@SYSTEM_CONFIG_DIR@**
         System configuration directory
 
-*@CONFIG_DIR@**
+**@CONFIG_DIR@**
         Local configuration directory
 
 **@CONFIG_FILE@**


### PR DESCRIPTION
missing *