### PR TITLE
helper: Declare dependency on Qt5::Qml.

### DIFF
--- a/src/helper/CMakeLists.txt
+++ b/src/helper/CMakeLists.txt
@@ -31,7 +31,7 @@ else()
 endif()
 
 add_executable(sddm-helper ${HELPER_SOURCES})
-target_link_libraries(sddm-helper Qt5::Network Qt5::DBus)
+target_link_libraries(sddm-helper Qt5::Network Qt5::DBus Qt5::Qml)
 if(PAM_FOUND)
     target_link_libraries(sddm-helper ${PAM_LIBRARIES})
 else()


### PR DESCRIPTION
`Authrequest.h` includes `<QtQml>`, so make sure it's found on systems
where it exists in a different directory from the rest of Qt.