### PR TITLE
Adjust order of components in the default PATH

### DIFF
--- a/data/man/sddm.conf.rst.in
+++ b/data/man/sddm.conf.rst.in
@@ -165,7 +165,7 @@ OPTIONS
 
 `DefaultPath=`
 	Default path to set after successfully logging in.
-	Default value is "/bin:/usr/bin:/usr/local/bin".
+	Default value is "/usr/local/bin:/usr/bin:/bin".
 
 `MinimumUid=`
 	Minimum user id of the users to be listed in the

--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -80,7 +80,7 @@ namespace SDDM {
         );
 
         Section(Users,
-            Entry(DefaultPath,         QString,     _S("/bin:/usr/bin:/usr/local/bin"),         _S("Default $PATH for logged in users"));
+            Entry(DefaultPath,         QString,     _S("/usr/local/bin:/usr/bin:/bin"),         _S("Default $PATH for logged in users"));
             Entry(MinimumUid,          int,         UID_MIN,                                    _S("Minimum user id for displayed users"));
             Entry(MaximumUid,          int,         UID_MAX,                                    _S("Maximum user id for displayed users"));
             Entry(HideUsers,           QStringList, QStringList(),                              _S("Comma-separated list of users that should not be listed"));


### PR DESCRIPTION
There is no reason to prefer executables in /bin over others, this has
in fact caused issues on a system where /bin is a symlink to usr/bin
(https://gitlab.kitware.com/cmake/cmake/issues/17330).

This order also matches systemd's default for bin (see systemd.exec(5)).
___
This default was revealed since Arch Linux changed its default profile (in testing) to respect previously set PATHs: https://bugs.archlinux.org/task/47884