### PR TITLE
[WIP] Better support for ConsoleKit2 interfaces

### DIFF
--- a/src/daemon/LogindDBusTypes.cpp
+++ b/src/daemon/LogindDBusTypes.cpp
@@ -18,6 +18,7 @@ public:
     QString sessionIfaceName;
     QString seatIfaceName;
     QString userIfaceName;
+    QString newSeatSignalName;
 };
 
 LogindPathInternal::LogindPathInternal()
@@ -55,18 +56,20 @@ LogindPathInternal::LogindPathInternal()
         seatIfaceName = QStringLiteral("org.freedesktop.login1.Seat");
         sessionIfaceName = QStringLiteral("org.freedesktop.login1.Session");
         userIfaceName = QStringLiteral("org.freedesktop.login1.User");
+        newSeatSignalName = QStringLiteral("SeatNew");
         return;
     }
 
     if (QDBusConnection::systemBus().interface()->isServiceRegistered(QStringLiteral("org.freedesktop.ConsoleKit"))) {
-        qDebug() << "Console kit interface found";
+        qDebug() << "ConsoleKit interface found";
         available = true;
         serviceName = QStringLiteral("org.freedesktop.ConsoleKit");
         managerPath = QStringLiteral("/org/freedesktop/ConsoleKit/Manager");
-        managerIfaceName = QStringLiteral("/org.freedesktop.ConsoleKit.Manager"); //note this doesn't match logind
+        managerIfaceName = QStringLiteral("org.freedesktop.ConsoleKit.Manager"); //note this doesn't match logind
         seatIfaceName = QStringLiteral("org.freedesktop.ConsoleKit.Seat");
         sessionIfaceName = QStringLiteral("org.freedesktop.ConsoleKit.Session");
         userIfaceName = QStringLiteral("org.freedesktop.ConsoleKit.User");
+        newSeatSignalName = QStringLiteral("SeatAdded");
         return;
     }
     qDebug() << "No session manager found";
@@ -108,4 +111,9 @@ QString Logind::sessionIfaceName()
 QString Logind::userIfaceName()
 {
     return s_instance->userIfaceName;
+}
+
+QString Logind::newSeatSignalName()
+{
+    return s_instance->newSeatSignalName;
 }

--- a/src/daemon/LogindDBusTypes.h
+++ b/src/daemon/LogindDBusTypes.h
@@ -13,6 +13,7 @@ struct Logind
     static QString sessionIfaceName();
     static QString seatIfaceName();
     static QString userIfaceName();
+    static QString newSeatSignalName();
 };
 
 

--- a/src/daemon/SeatManager.cpp
+++ b/src/daemon/SeatManager.cpp
@@ -26,6 +26,7 @@
 #include <QDBusMessage>
 #include <QDBusPendingReply>
 #include <QDBusContext>
+#include <QDebug>
 
 #include "LogindDBusTypes.h"
 
@@ -59,6 +60,12 @@ namespace SDDM {
         QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(reply);
         connect(watcher, &QDBusPendingCallWatcher::finished, this, [=]() {
             watcher->deleteLater();
+            if (Logind::serviceName().contains(QStringLiteral("ConsoleKit"))) {
+                m_canGraphical = true;
+                emit canGraphicalChanged(m_canGraphical);
+                return;
+            }
+
             if (!reply.isValid())
                 return;
 
@@ -113,7 +120,7 @@ namespace SDDM {
             }
         });
 
-        QDBusConnection::systemBus().connect(Logind::serviceName(), Logind::managerPath(), Logind::managerIfaceName(), QStringLiteral("SeatNew"), this, SLOT(logindSeatAdded(QString,QDBusObjectPath)));
+        QDBusConnection::systemBus().connect(Logind::serviceName(), Logind::managerPath(), Logind::managerIfaceName(), Logind::newSeatSignalName(), this, SLOT(logindSeatAdded(QString,QDBusObjectPath)));
         QDBusConnection::systemBus().connect(Logind::serviceName(), Logind::managerPath(), Logind::managerIfaceName(), QStringLiteral("SeatRemoved"), this, SLOT(logindSeatRemoved(QString,QDBusObjectPath)));
     }
 


### PR DESCRIPTION
When ConsoleKit2/ConsoleKit2#102 is merged, ListSeats will be implemented in a way that SDDM expects.  However, SDDM's support is lacking in a few other ways:

* Random / character at the start of the interface class name
* SeatNew vs SeatAdded signal name (the interfaces are the same)


What works with this PR (and CK2 patch):

* Seats
* Input devices
* Reboot/sleep/shutdown buttons on the login screen

Problems still present in this PR:

* It doesn't seem to be opening a new session, though it is correctly using the seats given.
* The canGraphical hack I had to write is kind of ugly; ConsoleKit does not have such a property on seats.
* Maybe something else?  Needs more testing.