### PR TITLE
Added missing utmp/wtmp/btmp handling

### DIFF
--- a/src/helper/HelperApp.cpp
+++ b/src/helper/HelperApp.cpp
@@ -34,6 +34,9 @@
 #include <unistd.h>
 #include <sys/socket.h>
 
+#include <utmp.h>
+#include <utmpx.h>
+#include <QByteArray>
 
 namespace SDDM {
     HelperApp::HelperApp(int& argc, char** argv)
@@ -115,12 +118,26 @@ namespace SDDM {
 
         if (!m_backend->start(m_user)) {
             authenticated(QString());
+
+            // write failed login to btmp
+            QProcessEnvironment env = m_session->processEnvironment();
+            QString displayId = env.value(QStringLiteral("DISPLAY"));
+            QString vt = env.value(QStringLiteral("XDG_VTNR"));
+            utmpLogin(vt, displayId, m_user, 0, false);
+
             exit(Auth::HELPER_AUTH_ERROR);
             return;
         }
 
         if (!m_backend->authenticate()) {
             authenticated(QString());
+
+            // write failed login to btmp
+            QProcessEnvironment env = m_session->processEnvironment();
+            QString displayId = env.value(QStringLiteral("DISPLAY"));
+            QString vt = env.value(QStringLiteral("XDG_VTNR"));
+            utmpLogin(vt, displayId, m_user, 0, false);
+
             exit(Auth::HELPER_AUTH_ERROR);
             return;
         }
@@ -139,6 +156,16 @@ namespace SDDM {
             }
 
             sessionOpened(true);
+
+            // write successful login to utmp/wtmp
+            QProcessEnvironment env = m_session->processEnvironment();
+            QString displayId = env.value(QStringLiteral("DISPLAY"));
+            QString vt = env.value(QStringLiteral("XDG_VTNR"));
+            if (env.value(QStringLiteral("XDG_SESSION_CLASS")) != QLatin1String("greeter")) {
+                // cache pid for session end
+                m_session->setCachedProcessId(m_session->processId());
+                utmpLogin(vt, displayId, m_user, m_session->processId(), true);
+            }
         }
         else
             exit(Auth::HELPER_SUCCESS);
@@ -147,6 +174,16 @@ namespace SDDM {
 
     void HelperApp::sessionFinished(int status) {
         m_backend->closeSession();
+
+        // write logout to utmp/wtmp
+        qint64 pid = m_session->cachedProcessId();
+        QProcessEnvironment env = m_session->processEnvironment();
+        if (env.value(QStringLiteral("XDG_SESSION_CLASS")) != QLatin1String("greeter")) {
+            QString vt = env.value(QStringLiteral("XDG_VTNR"));
+            QString displayId = env.value(QStringLiteral("DISPLAY"));
+            utmpLogout(vt, displayId, pid);
+        }
+
         exit(status);
     }
 
@@ -223,6 +260,90 @@ namespace SDDM {
 
     HelperApp::~HelperApp() {
 
+    }
+
+    void HelperApp::utmpLogin(const QString &vt, const QString &displayName, const QString &user, qint64 pid, bool authSuccessful) {
+        struct utmpx entry;
+        struct timeval tv;
+
+        entry = { 0 };
+        entry.ut_type = USER_PROCESS;
+        entry.ut_pid = pid;
+
+        // ut_line: vt
+        if (!vt.isEmpty()) {
+            QString tty = QStringLiteral("tty");
+            tty.append(vt);
+            QByteArray ttyBa = tty.toLocal8Bit();
+            const char* ttyChar = ttyBa.constData();
+            strncpy(entry.ut_line, ttyChar, sizeof(entry.ut_line));
+        }
+
+        // ut_host: displayName
+        QByteArray displayBa = displayName.toLocal8Bit();
+        const char* displayChar = displayBa.constData();
+        strncpy(entry.ut_host, displayChar, sizeof(entry.ut_host));
+
+        // ut_user: user
+        QByteArray userBa = user.toLocal8Bit();
+        const char* userChar = userBa.constData();
+        strncpy(entry.ut_user, userChar, sizeof(entry.ut_user));
+
+        gettimeofday(&tv, NULL);
+        entry.ut_tv.tv_sec = tv.tv_sec;
+        entry.ut_tv.tv_usec = tv.tv_usec;
+
+        // write to utmp
+        setutxent();
+        if (!pututxline (&entry))
+            qWarning() << "Failed to write utmpx: " << strerror(errno);
+        endutxent();
+
+        // append to failed login database btmp
+        if (!authSuccessful) {
+            updwtmpx("/var/log/btmp", &entry);
+        }
+
+        // append to wtmp
+        else {
+            updwtmpx("/var/log/wtmp", &entry);
+        }
+    }
+
+    void HelperApp::utmpLogout(const QString &vt, const QString &displayName, qint64 pid) {
+        struct utmpx entry;
+        struct timeval tv;
+
+        entry = { 0 };
+        entry.ut_type = DEAD_PROCESS;
+        entry.ut_pid = pid;
+
+        // ut_line: vt
+        if (!vt.isEmpty()) {
+            QString tty = QStringLiteral("tty");
+            tty.append(vt);
+            QByteArray ttyBa = tty.toLocal8Bit();
+            const char* ttyChar = ttyBa.constData();
+            strncpy(entry.ut_line, ttyChar, sizeof(entry.ut_line));
+        }
+
+        // ut_host: displayName
+        QByteArray displayBa = displayName.toLocal8Bit();
+        const char* displayChar = displayBa.constData();
+        strncpy(entry.ut_host, displayChar, sizeof(entry.ut_host));
+
+        gettimeofday(&tv, NULL);
+        entry.ut_tv.tv_sec = tv.tv_sec;
+        entry.ut_tv.tv_usec = tv.tv_usec;
+
+        // write to utmp
+        setutxent();
+        if (!pututxline (&entry))
+            qWarning() << "Failed to write utmpx: " << strerror(errno);
+        endutxent();
+
+        // append to wtmp
+        updwtmpx("/var/log/wtmp", &entry);
     }
 }
 

--- a/src/helper/HelperApp.h
+++ b/src/helper/HelperApp.h
@@ -63,6 +63,24 @@ namespace SDDM {
         QString m_user { };
         // TODO: get rid of this in a nice clean way along the way with moving to user session X server
         QString m_cookie { };
+
+        /*!
+         \brief Write utmp/wtmp/btmp records when a user logs in
+         \param vt  Virtual terminal (tty7, tty8,...)
+         \param displayName  Display (:0, :1,...)
+         \param user  User logging in
+         \param pid  User process ID (e.g. PID of startkde)
+         \param authSuccessful  Was authentication successful
+        */
+        void utmpLogin(const QString &vt, const QString &displayName, const QString &user, qint64 pid, bool authSuccessful);
+
+        /*!
+         \brief Write utmp/wtmp records when a user logs out
+         \param vt  Virtual terminal (tty7, tty8,...)
+         \param displayName  Display (:0, :1,...)
+         \param pid  User process ID (e.g. PID of startkde)
+        */
+        void utmpLogout(const QString &vt, const QString &displayName, qint64 pid);
     };
 }
 

--- a/src/helper/UserSession.cpp
+++ b/src/helper/UserSession.cpp
@@ -198,4 +198,13 @@ namespace SDDM {
             pclose(fp);
         }
     }
+
+    void UserSession::setCachedProcessId(qint64 pid) {
+        m_cachedProcessId = pid;
+    }
+
+    qint64 UserSession::cachedProcessId() {
+        return m_cachedProcessId;
+    }
+
 }

--- a/src/helper/UserSession.h
+++ b/src/helper/UserSession.h
@@ -40,11 +40,25 @@ namespace SDDM {
         void setPath(const QString &path);
         QString path() const;
 
+        /*!
+         \brief Sets m_cachedProcessId. Needed for getting the PID of a finished UserSession
+                and calling HelperApp::utmpLogout
+         \param pid  The process ID
+        */
+        void setCachedProcessId(qint64 pid);
+
+        /*!
+         \brief Gets m_cachedProcessId
+         \return  The cached process ID
+        */
+        qint64 cachedProcessId();
+
     protected:
         void setupChildProcess();
 
     private:
         QString m_path { };
+        qint64 m_cachedProcessId;
     };
 }
 


### PR DESCRIPTION
This patch implements the missing utmp / wtmp / btmp logging. This makes the utilities who, w, finger, last,... correctly report current or last logins:

$ who
robert    tty7         2017-11-10 15:09 (:0)

$ last
robert tty7         :0               Fri Nov 10 11:15 - 11:17  (00:01)
robert tty7         :0               Fri Nov 10 11:04 - 11:06  (00:01)
robert tty8         :1               Fri Nov 10 10:18 - 10:20  (00:02)
...

Tested on Ubuntu bionic.