### PR TITLE
Added method 'executeCommand' to GreeterProxy.

### DIFF
--- a/src/greeter/GreeterProxy.cpp
+++ b/src/greeter/GreeterProxy.cpp
@@ -108,6 +108,13 @@ namespace SDDM {
         SocketWriter(d->socket) << quint32(GreeterMessages::HybridSleep);
     }
 
+    void GreeterProxy::executeCommand(const QString &cmd) {
+        QByteArray byteArray = cmd.toUtf8();
+        const char *charCmd = byteArray.constData();
+
+        system(charCmd);
+    }
+
     void GreeterProxy::login(const QString &user, const QString &password, const int sessionIndex) const {
         if (!d->sessionModel) {
             // log error

--- a/src/greeter/GreeterProxy.h
+++ b/src/greeter/GreeterProxy.h
@@ -61,6 +61,7 @@ namespace SDDM {
         void suspend();
         void hibernate();
         void hybridSleep();
+        void executeCommand(const QString &cmd);
 
         void login(const QString &user, const QString &password, const int sessionIndex) const;
 


### PR DESCRIPTION
This allows themes e.g. to provide ActionButtons which run
arbitrary configured commands when clicked:

    ActionButton {
        iconSource: "configure"
        text: i18nd("plasma_lookandfeel_org.kde.lookandfeel","Change Password")
        onClicked: sddm.executeCommand("/usr/share/myclient/change_password")
        enabled: true
        visible: !inputPanel.keyboardActive
    }

Tested on Ubuntu bionic.