### PR TITLE
Set a default InputMethod

### DIFF
--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -42,7 +42,7 @@ namespace SDDM {
         Entry(Numlock,             NumState,    NUM_NONE,                                       _S("Initial NumLock state. Can be on, off or none.\n"
                                                                                                    "If property is set to none, numlock won't be changed\n"
                                                                                                    "NOTE: Currently ignored if autologin is enabled."));
-        Entry(InputMethod,         QString,     QString(),                                      _S("Input method module"));
+        Entry(InputMethod,         QString,     QStringLiteral("qtvirtualkeyboard"),                   _S("Input method module"));
         //  Name   Entries (but it's a regular class again)
         Section(Theme,
             Entry(ThemeDir,            QString,     _S(DATA_INSTALL_DIR "/themes"),             _S("Theme directory path"));


### PR DESCRIPTION
Otherwise we choke by default when importing QtVirtualKeyboard