### PR TITLE
Add support for theme supplied default avatars.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,17 @@
+# remove files from deployment using `git archive`
+
+# common files
+.commit-template  export-ignore
+.gitattributes    export-ignore
+.gitignore        export-ignore
+.mailmap          export-ignore
+.travis.yml       export-ignore
+
+# several files and directories we never want to export 
+# a little bit belt and braces as the most of these files
+# should never ever be in the repository
+
+*~         export-ignore
+.kdev4     export-ignore
+*build*    export-ignore
+*.user     export-ignore

--- a/src/greeter/UserModel.cpp
+++ b/src/greeter/UserModel.cpp
@@ -95,7 +95,7 @@ namespace SDDM {
 
             // search for face icon
             if (QFile::exists(themeDefaultFace)) 
-                user->icon =QStringLiteral("file://%1").arg(themeDefaultFace);
+                user->icon = QStringLiteral("file://%1").arg(themeDefaultFace);
             else 
                 user->icon = QStringLiteral("file://%1").arg(defaultFace);
 

--- a/src/greeter/UserModel.cpp
+++ b/src/greeter/UserModel.cpp
@@ -52,7 +52,10 @@ namespace SDDM {
 
     UserModel::UserModel(QObject *parent) : QAbstractListModel(parent), d(new UserModelPrivate()) {
         const QString facesDir = mainConfig.Theme.FacesDir.get();
-        const QString defaultFace = QStringLiteral("file://%1/.face.icon").arg(facesDir);
+        const QString themeDir = mainConfig.Theme.ThemeDir.get();
+        const QString currentTheme = mainConfig.Theme.Current.get();
+        const QString themeDefaultFace = QStringLiteral("%1/%2/faces/.face.icon").arg(themeDir).arg(currentTheme);
+        const QString defaultFace = QStringLiteral("%1/.face.icon").arg(facesDir);
 
         struct passwd *current_pw;
         while ((current_pw = getpwent()) != nullptr) {
@@ -91,7 +94,10 @@ namespace SDDM {
             user->needsPassword = strcmp(current_pw->pw_passwd, "") != 0;
 
             // search for face icon
-            user->icon = defaultFace;
+            if (QFile::exists(themeDefaultFace)) 
+                user->icon =QStringLiteral("file://%1").arg(themeDefaultFace);
+            else 
+                user->icon = QStringLiteral("file://%1").arg(defaultFace);
 
             // add user
             d->users << user;


### PR DESCRIPTION
This patch adds support for custom default avatars under $ThemeDir/themeName/faces.

This fixes the issue that by default sddm will use non-breeze avatar icons, which look quite different compared to breeze icons.

Without the patch:
![Login screen before the patch](https://i.imgur.com/fpNQGNK.png)
compared to the lockscreen:
![Lockscreen](https://i.imgur.com/G4sfa9B.png)

After the patch with a custom icon in breeze/faces:
![Login screen after the patch](https://i.imgur.com/3xH6EfD.png)
