### PR TITLE
Don't quit on SIGHUP

### DIFF
--- a/src/daemon/DaemonApp.cpp
+++ b/src/daemon/DaemonApp.cpp
@@ -68,8 +68,7 @@ namespace SDDM {
         // initialize signal signalHandler
         SignalHandler::initialize();
 
-        // quit when SIGHUP, SIGINT, SIGTERM received
-        connect(m_signalHandler, SIGNAL(sighupReceived()), this, SLOT(quit()));
+        // quit when SIGINT, SIGTERM received
         connect(m_signalHandler, SIGNAL(sigintReceived()), this, SLOT(quit()));
         connect(m_signalHandler, SIGNAL(sigtermReceived()), this, SLOT(quit()));
 


### PR DESCRIPTION
SIGHUP is sent to daemons on reload, so they should reread their configuration.
Currently sddm would just quit on reload, which is very unexpected.