### PR TITLE
[WIP] Add optional sanitization of screen scale factors

### DIFF
--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -71,6 +71,7 @@ namespace SDDM {
             Entry(DisplayStopCommand,  QString,     _S(DATA_INSTALL_DIR "/scripts/Xstop"),      _S("Path to a script to execute when stopping the display server"));
             Entry(MinimumVT,           int,         MINIMUM_VT,                                 _S("The lowest virtual terminal number that will be used."));
             Entry(EnableHiDPI,         bool,        false,                                      _S("Enable Qt's automatic high-DPI scaling"));
+            Entry(SanitizeScreenDPI,   bool,        true,                                       _S("Try to work around incorrect DPI values reported by monitors"));
         );
 
         Section(Wayland,

--- a/src/greeter/CMakeLists.txt
+++ b/src/greeter/CMakeLists.txt
@@ -2,6 +2,7 @@ include_directories(
     "${CMAKE_SOURCE_DIR}/src/common"
     "${CMAKE_BINARY_DIR}/src/common"
     "${LIBXCB_INCLUDE_DIR}"
+    "${Qt5Gui_PRIVATE_INCLUDE_DIRS}"
 )
 
 set(GREETER_SOURCES


### PR DESCRIPTION
This is inspired by KScreens detection of the proper screen scale factors.
It should catch common errors in monitor EDIDs while still allowing most HiDPI
displays to use the appropriate scale.

Pros:
- Should allow `EnableHiDPI` to be enabled by default
- Normally no manual editing of `ServerArguments` for `-dpi 192` or similiar required

Cons:
- Uses private API :-/