### PR TITLE
Do not install sddm.conf by default

### DIFF
--- a/src/daemon/CMakeLists.txt
+++ b/src/daemon/CMakeLists.txt
@@ -69,12 +69,3 @@ if(JOURNALD_FOUND)
 endif()
 
 install(TARGETS sddm DESTINATION "${CMAKE_INSTALL_BINDIR}")
-
-# Generate and install the default config file
-add_custom_command(COMMAND sddm --example-config > "${CMAKE_BINARY_DIR}/sddm.conf"
-    OUTPUT "${CMAKE_BINARY_DIR}/sddm.conf"
-    COMMENT "Generate default sddm.conf file"
-    DEPENDS sddm
-)
-add_custom_target(generate_config_file ALL DEPENDS "${CMAKE_BINARY_DIR}/sddm.conf")
-install(FILES "${CMAKE_BINARY_DIR}/sddm.conf" DESTINATION "${CMAKE_INSTALL_FULL_SYSCONFDIR}")


### PR DESCRIPTION
sddm.conf overrides the configuration from the conf.d
directories and we don't want that.

SDDM still reads it if users keep the file after an
upgrade, but since the introduction of conf.d directories
we shouldn't install sddm.conf by default.

[ChangeLog][Daemon] Do not install /etc/sddm.conf anymore