### PR TITLE
UserModel: optimize setting of default user icon

### DIFF
--- a/src/greeter/UserModel.cpp
+++ b/src/greeter/UserModel.cpp
@@ -56,6 +56,8 @@ namespace SDDM {
         const QString currentTheme = mainConfig.Theme.Current.get();
         const QString themeDefaultFace = QStringLiteral("%1/%2/faces/.face.icon").arg(themeDir).arg(currentTheme);
         const QString defaultFace = QStringLiteral("%1/.face.icon").arg(facesDir);
+        const QString iconURI = QStringLiteral("file://%1").arg(
+                QFile::exists(themeDefaultFace) ? themeDefaultFace : defaultFace);
 
         struct passwd *current_pw;
         while ((current_pw = getpwent()) != nullptr) {
@@ -85,12 +87,7 @@ namespace SDDM {
             // if shadow is used pw_passwd will be 'x' nevertheless, so this
             // will always be true
             user->needsPassword = strcmp(current_pw->pw_passwd, "") != 0;
-
-            // search for face icon
-            if (QFile::exists(themeDefaultFace))
-                user->icon = QStringLiteral("file://%1").arg(themeDefaultFace);
-            else
-                user->icon = QStringLiteral("file://%1").arg(defaultFace);
+            user->icon = iconURI;
 
             // add user
             d->users << user;


### PR DESCRIPTION
Instead of checking for existence of theme-specific icon and re-creating
string literals every time we add a new user to the list, do it once.
It helps in large organizations with a lot of users.