### PR TITLE
UserModel: lazily load user list

### DIFF
--- a/src/greeter/UserModel.cpp
+++ b/src/greeter/UserModel.cpp
@@ -48,9 +48,17 @@ namespace SDDM {
     public:
         int lastIndex { 0 };
         QList<UserPtr> users;
+        bool populated { false };
     };
 
     UserModel::UserModel(QObject *parent) : QAbstractListModel(parent), d(new UserModelPrivate()) {
+    }
+
+    UserModel::~UserModel() {
+        delete d;
+    }
+
+    void UserModel::populate() const {
         const QString facesDir = mainConfig.Theme.FacesDir.get();
         const QString themeDir = mainConfig.Theme.ThemeDir.get();
         const QString currentTheme = mainConfig.Theme.Current.get();
@@ -129,10 +137,8 @@ namespace SDDM {
                     user->icon = QStringLiteral("file://%1").arg(systemFace);
             }
         }
-    }
 
-    UserModel::~UserModel() {
-        delete d;
+        d->populated = true;
     }
 
     QHash<int, QByteArray> UserModel::roleNames() const {
@@ -148,6 +154,8 @@ namespace SDDM {
     }
 
     const int UserModel::lastIndex() const {
+        if (!d->populated)
+            populate();
         return d->lastIndex;
     }
 
@@ -156,10 +164,15 @@ namespace SDDM {
     }
 
     int UserModel::rowCount(const QModelIndex &parent) const {
+        if (!d->populated)
+            populate();
         return d->users.length();
     }
 
     QVariant UserModel::data(const QModelIndex &index, int role) const {
+        if (!d->populated)
+            populate();
+
         if (index.row() < 0 || index.row() > d->users.count())
             return QVariant();
 

--- a/src/greeter/UserModel.h
+++ b/src/greeter/UserModel.h
@@ -56,7 +56,8 @@ namespace SDDM {
 
         int disableAvatarsThreshold() const;
     private:
-        UserModelPrivate *d { nullptr };
+        mutable UserModelPrivate *d { nullptr };
+        void populate() const;
     };
 }
 


### PR DESCRIPTION
In large environments loading user list can take some time and the list
is not usable anyway. The theme may opt not to show list at all, however
we create the model unconditionally. Let's lazily load data into the
model so that users disabling it do not have to pay the price.