### PR TITLE
Skip theme for greeter call if none is set

### DIFF
--- a/src/daemon/Greeter.cpp
+++ b/src/daemon/Greeter.cpp
@@ -89,8 +89,10 @@ namespace SDDM {
 
         // greeter command
         QStringList args;
-        args << QLatin1String("--socket") << m_socket
-             << QLatin1String("--theme") << m_themePath;
+        args << QLatin1String("--socket") << m_socket;
+
+        if (!m_themePath.isEmpty())
+             args << QLatin1String("--theme") << m_themePath;
         if (!platformTheme.isEmpty())
             args << QLatin1String("-platformtheme") << platformTheme;
         if (!style.isEmpty())


### PR DESCRIPTION
- fix loading default theme if none is set, otherwise the greeter does not start