### PR TITLE
XorgDisplayServer.cpp: Check pipe output if there is nothing

### DIFF
--- a/src/daemon/XorgDisplayServer.cpp
+++ b/src/daemon/XorgDisplayServer.cpp
@@ -187,14 +187,21 @@ namespace SDDM {
             QFile readPipe;
 
             if (!readPipe.open(pipeFds[0], QIODevice::ReadOnly)) {
-                qCritical("Failed to open pipe to start X Server ");
+                qCritical("Failed to open pipe to start X Server");
 
                 close(pipeFds[0]);
                 return false;
             }
             QByteArray displayNumber = readPipe.readLine();
+            if (displayNumber.size() < 2) {
+                // X server gave nothing (or a whitespace).
+                qCritical("Failed to read display number from pipe");
+
+                close(pipeFds[0]);
+                return false;
+            }
             displayNumber.prepend(QByteArray(":"));
-            displayNumber.remove(displayNumber.size() -1, 1); //trim trailing whitespace
+            displayNumber.remove(displayNumber.size() -1, 1); // trim trailing whitespace
             m_display = QString::fromLocal8Bit(displayNumber);
 
             // close our pipe


### PR DESCRIPTION
X server may break down without writing a display number to the pipe specified by `-displayfd`. SDDM should exit *explictly* in such cases. Otherwise, it will get a null string for display number, which leads `/usr/bin/xauth` gets bad parameters, i.e.

    /usr/bin/xauth: (stdin):1:  bad "remove" command line
    /usr/bin/xauth: (stdin):2:  bad "add" command line