### PR TITLE
Don't add session files with NoDisplay=true to SessionModel

### DIFF
--- a/src/common/Session.cpp
+++ b/src/common/Session.cpp
@@ -32,6 +32,7 @@ namespace SDDM {
         : m_valid(false)
         , m_type(UnknownSession)
         , m_isHidden(false)
+        , m_isNoDisplay(false)
     {
     }
 
@@ -111,6 +112,11 @@ namespace SDDM {
         return m_isHidden;
     }
 
+    bool Session::isNoDisplay() const
+    {
+        return m_isNoDisplay;
+    }
+
     void Session::setTo(Type type, const QString &_fileName)
     {
         QString fileName(_fileName);
@@ -177,6 +183,8 @@ namespace SDDM {
                 m_desktopNames = line.mid(13).replace(QLatin1Char(';'), QLatin1Char(':'));
             if (line.startsWith(QLatin1String("Hidden=")))
                 m_isHidden = line.mid(7).toLower() == QLatin1String("true");
+            if (line.startsWith(QLatin1String("NoDisplay=")))
+                m_isNoDisplay = line.mid(10).toLower() == QLatin1String("true");
         }
 
         file.close();

--- a/src/common/Session.h
+++ b/src/common/Session.h
@@ -60,6 +60,7 @@ namespace SDDM {
         QString desktopNames() const;
 
         bool isHidden() const;
+        bool isNoDisplay() const;
 
         void setTo(Type type, const QString &name);
 
@@ -79,6 +80,7 @@ namespace SDDM {
         QString m_xdgSessionType;
         QString m_desktopNames;
         bool m_isHidden;
+        bool m_isNoDisplay;
 
         friend class SessionModel;
     };

--- a/src/greeter/SessionModel.cpp
+++ b/src/greeter/SessionModel.cpp
@@ -143,7 +143,7 @@ namespace SDDM {
                 }
             }
             // add to sessions list
-            if (!si->isHidden() && execAllowed)
+            if (!si->isHidden() && !si->isNoDisplay() && execAllowed)
                 d->sessions.push_back(si);
             else
                 delete si;


### PR DESCRIPTION
Same treatment as for Hidden. SessionModel is not used for autologin,
so for all intents and purposes it's the same. If a user logged in with
a NoDisplay=true session, the last session index will be incorrect, but
IMO that's the intended behaviour of NoDisplay.