### PR TITLE
Fix sddm-greeter terminated unexpectedly while unplugging a monitor

### DIFF
--- a/src/greeter/GreeterApp.cpp
+++ b/src/greeter/GreeterApp.cpp
@@ -143,7 +143,7 @@ namespace SDDM {
         // need to be careful here since Qt will move the view to
         // another screen before this signal is emitted so we
         // pass a pointer to the view to our slot
-        connect(qGuiApp, &QGuiApplication::screenRemoved, this, [view, this](QScreen *) {
+        connect(screen, &QObject::destroyed, this, [view, this](QObject *) {
             removeViewForScreen(view);
         });
 


### PR DESCRIPTION
Hi folks,
I use 2 monitors with Kubuntu 18.04 which uses SDDM v0.17.0 and I get a problem with sddm-greeter. 
I booted my laptop with an external monitors connected and waited until got the login screen from sddm-greeter displayed in both monitors. I unplugged the external monitor and got the black screen with the other. The sddm-greeter terminated and I could not login to my laptop. I make this PR to solve this issue.
Regards,