### PR TITLE
Fix missing include in HelperApp.cc

### DIFF
--- a/src/helper/HelperApp.cpp
+++ b/src/helper/HelperApp.cpp
@@ -33,6 +33,7 @@
 #include <iostream>
 #include <unistd.h>
 #include <sys/socket.h>
+#include <sys/time.h>
 
 #include <utmp.h>
 #include <utmpx.h>


### PR DESCRIPTION
SDDM did not compile on musl libc, since HelperApp.cpp was using
gettimeofday(), which is defined in <sys/time.h>, without importing it.