### PR TITLE
Fixes #879 - Adds sourcing of /etc/profile to fish

### DIFF
--- a/data/scripts/Xsession
+++ b/data/scripts/Xsession
@@ -39,6 +39,7 @@ case $SHELL in
     rm -f $xsess_tmp
     ;;
   */fish)
+    [ -f /etc/profile ] && . /etc/profile
     xsess_tmp=`mktemp /tmp/xsess-env-XXXXXX`
     $SHELL --login -c "/bin/sh -c 'export -p' > $xsess_tmp"
     . $xsess_tmp

--- a/data/scripts/wayland-session
+++ b/data/scripts/wayland-session
@@ -39,6 +39,7 @@ case $SHELL in
     rm -f $wlsess_tmp
     ;;
   */fish)
+    [ -f /etc/profile ] && . /etc/profile
     xsess_tmp=`mktemp /tmp/xsess-env-XXXXXX`
     $SHELL --login -c "/bin/sh -c 'export -p' > $xsess_tmp"
     . $xsess_tmp


### PR DESCRIPTION
This ensures the right paths are set by upstream apps that use the
/etc/profile(.d) method for setting paths, for example xdg or snap.

Signed-off-by: James Turnbull <james@lovedthanlost.net>