### PR TITLE
Keep string termination characters in utmp entries

### DIFF
--- a/src/helper/HelperApp.cpp
+++ b/src/helper/HelperApp.cpp
@@ -277,18 +277,18 @@ namespace SDDM {
             tty.append(vt);
             QByteArray ttyBa = tty.toLocal8Bit();
             const char* ttyChar = ttyBa.constData();
-            strncpy(entry.ut_line, ttyChar, sizeof(entry.ut_line));
+            strncpy(entry.ut_line, ttyChar, sizeof(entry.ut_line) - 1);
         }
 
         // ut_host: displayName
         QByteArray displayBa = displayName.toLocal8Bit();
         const char* displayChar = displayBa.constData();
-        strncpy(entry.ut_host, displayChar, sizeof(entry.ut_host));
+        strncpy(entry.ut_host, displayChar, sizeof(entry.ut_host) - 1);
 
         // ut_user: user
         QByteArray userBa = user.toLocal8Bit();
         const char* userChar = userBa.constData();
-        strncpy(entry.ut_user, userChar, sizeof(entry.ut_user));
+        strncpy(entry.ut_user, userChar, sizeof(entry.ut_user) -1);
 
         gettimeofday(&tv, NULL);
         entry.ut_tv.tv_sec = tv.tv_sec;
@@ -325,13 +325,13 @@ namespace SDDM {
             tty.append(vt);
             QByteArray ttyBa = tty.toLocal8Bit();
             const char* ttyChar = ttyBa.constData();
-            strncpy(entry.ut_line, ttyChar, sizeof(entry.ut_line));
+            strncpy(entry.ut_line, ttyChar, sizeof(entry.ut_line) - 1);
         }
 
         // ut_host: displayName
         QByteArray displayBa = displayName.toLocal8Bit();
         const char* displayChar = displayBa.constData();
-        strncpy(entry.ut_host, displayChar, sizeof(entry.ut_host));
+        strncpy(entry.ut_host, displayChar, sizeof(entry.ut_host) - 1);
 
         gettimeofday(&tv, NULL);
         entry.ut_tv.tv_sec = tv.tv_sec;


### PR DESCRIPTION
strncpy copied N characters and does not resolve termination characters.
If entry.ut_line is 5 chars long, and our source is > 5 bytes we will
copy 5 leaving no null termination.

entry is all zeroed out on construction, so making sure we strncpy one
char less should be enough.

Not a security issue as it seems utmp does safe string copying out.