### PR TITLE
Session reuse: Only consider "online" sessions

### DIFF
--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -290,8 +290,8 @@ namespace SDDM {
             foreach(const SessionInfo &s, reply.value()) {
                 if (s.userName == user) {
                     OrgFreedesktopLogin1SessionInterface session(Logind::serviceName(), s.sessionPath.path(), QDBusConnection::systemBus());
-                    if (session.service() == QLatin1String("sddm")) {
-                        m_reuseSessionId =  s.sessionId;
+                    if (session.service() == QLatin1String("sddm") && session.state() == QLatin1String("online")) {
+                        m_reuseSessionId = s.sessionId;
                         break;
                     }
                 }


### PR DESCRIPTION
Otherwise it might switch to already dead sessions ("closing" or "lingering").