### PR TITLE
Add support for per-seat sddm.conf autologin settings

### DIFF
--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -94,9 +94,10 @@ namespace SDDM {
         );
 
         Section(Autologin,
-            Entry(User,                QString,     QString(),                                  _S("Username for autologin session"));
-            Entry(Session,             QString,     QString(),                                  _S("Name of session file for autologin session (if empty try last logged in)"));
-            Entry(Relogin,             bool,        false,                                      _S("Whether sddm should automatically log back into sessions when they exit"));
+            Entry(SeatName,            QStringList,     QStringList(),                          _S("Comma-separated list of seat name, same order for User,Session,Relogin"));
+            Entry(User,                QStringList,     QStringList(),                          _S("Comma-separated list of Username for autologin session"));
+            Entry(Session,             QStringList,     QStringList(),                          _S("Comma-separated list of Name of session file for autologin session (if empty try last logged in)"));
+            Entry(Relogin,             QStringList,     QStringList( ),                         _S("Comma-separated list of Whether sddm should automatically log back into sessions when they exit"));
         );
     );
 

--- a/src/daemon/DaemonApp.cpp
+++ b/src/daemon/DaemonApp.cpp
@@ -87,6 +87,17 @@ namespace SDDM {
         return QHostInfo::localHostName();
     }
 
+    bool DaemonApp::isFirstSeatRun(QString &seatName) {
+        if ( m_alreadyLaunchedSeat.contains(seatName) ) {
+            return false;
+        }
+        else {
+            m_alreadyLaunchedSeat.append(seatName);
+            return true;
+        }
+
+    }
+    
     DisplayManager *DaemonApp::displayManager() const {
         return m_displayManager;
     }

--- a/src/daemon/DaemonApp.h
+++ b/src/daemon/DaemonApp.h
@@ -21,6 +21,7 @@
 #define SDDM_DAEMONAPP_H
 
 #include <QCoreApplication>
+#include <QStringList>
 
 #define daemonApp DaemonApp::instance()
 
@@ -41,9 +42,9 @@ namespace SDDM {
 
         // TODO: move these two away
         bool testing() const;
-        bool first { true };
 
         QString hostName() const;
+        bool isFirstSeatRun(QString &seatName);
         DisplayManager *displayManager() const;
         PowerManager *powerManager() const;
         SeatManager *seatManager() const;
@@ -54,6 +55,7 @@ namespace SDDM {
 
     private:
         static DaemonApp *self;
+        QStringList m_alreadyLaunchedSeat;
 
         int m_lastSessionId { 0 };
 

--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -113,11 +113,9 @@ namespace SDDM {
         }
     }
 
-    bool Display::attemptAutologin() {
+    bool Display::attemptAutologin(QString &autologinSession, QString &autologinUserSession) {
         Session::Type sessionType = Session::X11Session;
 
-        // determine session type
-        QString autologinSession = mainConfig.Autologin.Session.get();
         // not configured: try last successful logged in
         if (autologinSession.isEmpty()) {
             autologinSession = stateConfig.Last.Session.get();
@@ -135,7 +133,7 @@ namespace SDDM {
         session.setTo(sessionType, autologinSession);
 
         m_auth->setAutologin(true);
-        startAuth(mainConfig.Autologin.User.get(), QString(), session);
+        startAuth(autologinUserSession, QString(), session);
 
         return true;
     }
@@ -151,15 +149,35 @@ namespace SDDM {
         // log message
         qDebug() << "Display server started.";
 
-        if ((daemonApp->first || mainConfig.Autologin.Relogin.get()) &&
-            !mainConfig.Autologin.User.get().isEmpty()) {
-            // reset first flag
-            daemonApp->first = false;
+        bool relogin=false;
+        QString seatName=seat()->name();
+        QString user;
+        QString session;        
+        int seatListIndex = mainConfig.Autologin.SeatName.get().indexOf(seatName);
+        if ( seatListIndex < 0 ) {
+            qDebug() << "Seat not configured for autologin : "<<seatName;
+        }
+        else
+        {
+            int listSize = mainConfig.Autologin.SeatName.get().size();
+            if ( (listSize !=  mainConfig.Autologin.Session.get().size()) ||
+                 (listSize !=  mainConfig.Autologin.Relogin.get().size()) ||
+                 (listSize !=  mainConfig.Autologin.User.get().size())) {
+                qFatal("All autologin parameters should have the same size");
+            }
+            relogin = mainConfig.Autologin.Relogin.get().at(seatListIndex) == QLatin1String("true");
+            user = mainConfig.Autologin.User.get().at(seatListIndex);
+            session = mainConfig.Autologin.Session.get().at(seatListIndex);
+            qDebug() << "Autologin for "<<user<<" ,session : "<<session<<" ,relogin :"<<relogin;
+        }
+
+        if ((daemonApp->isFirstSeatRun(seatName) || relogin ) &&
+            !user.isEmpty()) {
 
             // set flags
             m_started = true;
 
-            bool success = attemptAutologin();
+            bool success = attemptAutologin(session,user);
             if (success) {
                 return;
             }
@@ -187,9 +205,6 @@ namespace SDDM {
 
         // start greeter
         m_greeter->start();
-
-        // reset first flag
-        daemonApp->first = false;
 
         // set flags
         m_started = true;

--- a/src/daemon/Display.h
+++ b/src/daemon/Display.h
@@ -60,7 +60,7 @@ namespace SDDM {
         void login(QLocalSocket *socket,
                    const QString &user, const QString &password,
                    const Session &session);
-        bool attemptAutologin();
+        bool attemptAutologin(QString &autologinSession, QString &autologinUserSession);
         void displayServerStarted();
 
     signals:


### PR DESCRIPTION
Support per-seat Autologin configurations in sddm.conf.
Make it possible to enable/configure Autologin per seat.

Example:

```
[Autologin]
Relogin= false
SeatName= seat0
Session= plasma
User=  admin

```

```
[Autologin]
Relogin= false , true 
SeatName= seat0 , seat-2
Session= plasma , gnome
User=  admin , user

```
