### PR TITLE
Remove chVt() from declarations.

### DIFF
--- a/src/daemon/VirtualTerminal.h
+++ b/src/daemon/VirtualTerminal.h
@@ -24,7 +24,6 @@ namespace SDDM {
     namespace VirtualTerminal {
         int setUpNewVt();
         void jumpToVt(int vt, bool vt_auto);
-        void chVt(int vt);
     }
 }
 


### PR DESCRIPTION
Declared but never defined or called. Added in 32720096e3 and implementation
removed in 047069b5cd but the declaration stayed behind.