### PR TITLE
Don't leak VT FDs in jumpToVt

### DIFF
--- a/src/daemon/VirtualTerminal.cpp
+++ b/src/daemon/VirtualTerminal.cpp
@@ -187,6 +187,8 @@ out:
                 qWarning("Couldn't finalize jump to VT %d: %s", vt, strerror(errno));
 
             close(activeVtFd);
+            if (fd != activeVtFd)
+                close(fd);
         }
     }
 }


### PR DESCRIPTION
SDDM did not close the FD referring to the virtual console.
By repeatedly logging in and out, it had to move to higher tty numbers as the
lower ones were occupied by sddm itself.
This is made worse by not using O_CLOEXEC, which means that the session started
by sddm inherits those open FDs.

Fixes issue #1078