### PR TITLE
Revert "Don't leak VT FDs in jumpToVt (#1079)"

### DIFF
--- a/src/daemon/VirtualTerminal.cpp
+++ b/src/daemon/VirtualTerminal.cpp
@@ -187,8 +187,6 @@ out:
                 qWarning("Couldn't finalize jump to VT %d: %s", vt, strerror(errno));
 
             close(activeVtFd);
-            if (fd != activeVtFd)
-                close(fd);
         }
     }
 }


### PR DESCRIPTION
This reverts commit b9dd8d9927e0c33539e731fde6a617448d38cbfb.

openQA had a (single) failure which was caused by a race condition:

sddm[1281]: Jumping to VT 2
sddm[1281]: VT mode didn't need to be fixed
sddm-greeter[2552]: Message received from daemon: LoginSucceeded
susetest systemd[1]: Started Getty on tty2.
[...]
sddm-helper[2558]: Starting: "/usr/share/sddm/scripts/wayland-session dbus-run-session /usr/bin/startplasmacompositor"
sddm-helper[2568]: Failed to take control of the tty: Operation not permitted

As can be seen, sddm jumps to the selected VT, which triggers getty to start.
Then sddm-helper starts the user session, which fails to take control of the
tty as it's already opened by another process.