### PR TITLE
Don't concatenate SessionLogFile to $HOME if absolute

### DIFF
--- a/src/helper/UserSession.cpp
+++ b/src/helper/UserSession.cpp
@@ -233,11 +233,18 @@ namespace SDDM {
         //we want to redirect after we setuid so that the log file is owned by the user
 
         // determine stderr log file based on session type
-        QString sessionLog = QStringLiteral("%1/%2")
+        QString sessionLog;
+        QString sessionLogRel(sessionType == QLatin1String("x11")
+         ? mainConfig.X11.SessionLogFile.get()
+         : mainConfig.Wayland.SessionLogFile.get());
+
+        if (sessionLogRel.startsWith(QStringLiteral("/"))) {
+            sessionLog = sessionLogRel;
+        } else {
+            sessionLog = QStringLiteral("%1/%2")
                 .arg(QString::fromLocal8Bit(pw.pw_dir))
-                .arg(sessionType == QLatin1String("x11")
-                     ? mainConfig.X11.SessionLogFile.get()
-                     : mainConfig.Wayland.SessionLogFile.get());
+                .arg(sessionLogRel);
+        }
 
         // create the path
         QFileInfo finfo(sessionLog);


### PR DESCRIPTION
This allows to set absolute paths as SessionLogFile ; they aren't appended to the user's home directory but just taken as is.