### PR TITLE
Make theme.conf values have a data type comparison for INT and BOOL

### DIFF
--- a/src/common/ThemeConfig.cpp
+++ b/src/common/ThemeConfig.cpp
@@ -24,6 +24,8 @@
 #include <QDebug>
 #include <QSettings>
 #include <QStringList>
+#include <QRegularExpression>
+#include <QRegularExpressionMatch>
 
 namespace SDDM {
     ThemeConfig::ThemeConfig(const QString &path) {
@@ -46,11 +48,44 @@ namespace SDDM {
 
         // read default keys
         for (const QString &key: settings.allKeys()) {
-            insert(key, settings.value(key));
+
+            // check if the keys value is written as a number
+            QRegularExpression re(QStringLiteral("\\A(?:\\d+)\\z"));
+            QRegularExpressionMatch check = re.match(settings.value(key).toString());
+            if (check.hasMatch()) {
+                // convert the value accordingly to integer
+                insert(key, settings.value(key).toInt());
+
+            // check if the keys value is written as a boolean
+            } else if (settings.value(key).toString().toLower() == (QStringLiteral("true")) ||
+                       settings.value(key).toString().toLower() == (QStringLiteral("false"))) {
+                // convert the value accordingly to boolean
+                insert(key, settings.value(key).toBool());
+
+            // pass on as is
+            } else if (!userSettings.value(key).toString().isEmpty()) {
+                insert(key, settings.value(key));
+            }
         }
+
         // read user set themes overwriting defaults if they exist
         for (const QString &key: userSettings.allKeys()) {
-            if (!userSettings.value(key).toString().isEmpty()) {
+
+            // check if the keys value is written as a number
+            QRegularExpression re(QStringLiteral("\\A(?:\\d+)\\z"));
+            QRegularExpressionMatch check = re.match(userSettings.value(key).toString());
+            if (check.hasMatch()) {
+                // convert the value accordingly to integer
+                insert(key, userSettings.value(key).toInt());
+
+                // check if the keys value is written as a boolean
+            } else if (userSettings.value(key).toString().toLower() == (QStringLiteral("true")) ||
+                userSettings.value(key).toString().toLower() == (QStringLiteral("false"))) {
+                // convert the value accordingly to boolean
+                insert(key, userSettings.value(key).toBool());
+
+            // pass on as is
+            } else if (!userSettings.value(key).toString().isEmpty()) {
                 insert(key, userSettings.value(key));
             }
         }


### PR DESCRIPTION
Fixes #1097

The INI format of `theme.conf` determines its contents as plain text which does not include data types. Key values are therefore **passed on by Qt as strings by default** if not told different.
A theme may include keys designed specifically as integer or boolean though and may want to compare these to their data type.
The added checks will convert the key values depending on whether or not they are of such design or else just pass them on as plain text resulting in a string.

The following example shows how values would be passed to QML theme files after merging this change.
```
# theme.conf
[General]
forceSomething=TRUE      // BOOL TRUE
forceSomething="false"   // BOOL FALSE
forceSomething=0         // INT & FALSE
raiseMargin=372          // INT & TRUE
raiseMargin="83"         // INT & TRUE
printText=Foo            // STRING & TRUE
printText="Foo"          // STRING & TRUE
printText=2Foo3          // STRING & TRUE
```
This is a **breaking change**. There are themes comparing keys to true as a string, as a workaround for the former implementation, which passed on any key value as plain text.
```
anchors.marginTop: config.forceSomething == "true" ? config.raiseMargin : 0
```
Themes impelementing such comparisons will behave different after merging this change.