### PR TITLE
Fix Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,16 @@
+dist: xenial
+addons:
+  apt:
+    packages:
+      - extra-cmake-modules
+      - libpam0g-dev
+      - libxcb1-dev
+      - libxcb-xkb-dev
+      - libdrm-dev
+      - libgl-dev
+      - libsystemd-dev
+      - python-docutils
+
 language: cpp
 
 compiler:
@@ -10,22 +23,15 @@ env:
   - PAM=0
   - PAM=1
 
-arch:
-  packages:
-    - pam
-    - python-docutils
-    - qt5-declarative
-    - qt5-tools
-    - extra-cmake-modules
-    - clang
-    - git
-  script:
-    - if [ "$PAM" == "0" ]; then cmake -DBUILD_MAN_PAGES=ON -DENABLE_PAM:BOOL=OFF .; fi
-    - if [ "$PAM" == "1" ]; then cmake -DBUILD_MAN_PAGES=ON -DENABLE_PAM:BOOL=ON .; fi
-    - make
-
+before_script:
+  - sudo add-apt-repository -y ppa:beineri/opt-qt58-xenial
+  - sudo apt-get update -q
+  - sudo apt-get install -y qt58declarative qt58tools
 script:
-  - "curl -s https://raw.githubusercontent.com/mikkeloscar/arch-travis/master/arch-travis.sh | bash"
+  - source /opt/qt58/bin/qt58-env.sh
+  - if [ "$PAM" == "0" ]; then cmake -DBUILD_MAN_PAGES=ON -DENABLE_PAM:BOOL=OFF .; fi
+  - if [ "$PAM" == "1" ]; then cmake -DBUILD_MAN_PAGES=ON -DENABLE_PAM:BOOL=ON .; fi
+  - make -j $(nproc)
 
 notifications:
   email: false


### PR DESCRIPTION
We used arch-travis to build using Arch Linux in a Docker container,
but looks like it doesn't pass environment variables to the
container and this breaks the build.

Meanwhile Travis adopted Ubuntu xenial, so we can use that which
is also faster and doesn't need sudo.

Install Qt 5.8 because it's the minimum requirement, but in the
future we will be able to update to a more recent version.