### PR TITLE
Switch to pam_tally2

### DIFF
--- a/services/sddm-autologin.pam
+++ b/services/sddm-autologin.pam
@@ -1,6 +1,6 @@
 #%PAM-1.0
 auth        required    pam_env.so
-auth        required    pam_tally.so file=/var/log/faillog onerr=succeed
+auth        required    pam_tally2.so file=/var/log/tallylog onerr=succeed
 auth        required    pam_shells.so
 auth        required    pam_nologin.so
 auth        required    pam_permit.so


### PR DESCRIPTION
Switch to pam_tally2 as pam_tally is deprecated since 9 years now.

Commit:
https://github.com/linux-pam/linux-pam/commit/660464aa88967f55ab3ec7d54cba20757d884634

Or see this blame:
https://github.com/linux-pam/linux-pam/blame/3db1c497e455fafabf30076670dd0164a8ce2aa6/modules/pam_tally/pam_tally.8.xml#L84

Or see man pam_tally for deprecation note.