### PR TITLE
helper/PamBackend: fix freeing memory in error path

### DIFF
--- a/src/helper/backend/PamBackend.cpp
+++ b/src/helper/backend/PamBackend.cpp
@@ -340,9 +340,9 @@ namespace SDDM {
             resp[i]->resp = (char *) malloc(response.length() + 1);
             // on error, get rid of everything
             if (!resp[i]->resp) {
-                for (int j = 0; j < n; j++) {
-                    free(resp[i]->resp);
-                    resp[i]->resp = nullptr;
+                for (int j = 0; j < i; j++) {
+                    free(resp[j]->resp);
+                    resp[j]->resp = nullptr;
                 }
                 free(*resp);
                 *resp = nullptr;


### PR DESCRIPTION
free the previously allocated blocks, not just the one
that failed to allocate over and over.
