### PR TITLE
Enable QSurfaceFormat::ResetNotification on new Qt

### DIFF
--- a/src/greeter/GreeterApp.cpp
+++ b/src/greeter/GreeterApp.cpp
@@ -40,6 +40,9 @@
 #include <QDebug>
 #include <QTimer>
 #include <QTranslator>
+#include <QLibraryInfo>
+#include <QVersionNumber>
+#include <QSurfaceFormat>
 
 #include <iostream>
 
@@ -307,6 +310,12 @@ int main(int argc, char **argv)
         QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
     } else {
         qDebug() << "High-DPI autoscaling not Enabled";
+    }
+
+    if (QLibraryInfo::version() >= QVersionNumber(5, 13, 0)) {
+        auto format(QSurfaceFormat::defaultFormat());
+        format.setOption(QSurfaceFormat::ResetNotification);
+        QSurfaceFormat::setDefaultFormat(format);
     }
 
     QGuiApplication app(argc, argv);


### PR DESCRIPTION
This fixes graphical glitches on nvidia after VT switching.

It's opt-in as it requires code paths to handle glGetError differently.

The version comparison is because my early implementations missed a code
path. This was fixed in Qt5.12.2, but we may as well play safe.