### PR TITLE
Change "User name" to "Username"

### DIFF
--- a/components/common/TextConstants.qml
+++ b/components/common/TextConstants.qml
@@ -40,7 +40,7 @@ QtObject {
     readonly property string shutdown:          qsTr("Shutdown")
     readonly property string suspend:           qsTr("Suspend")
     readonly property string hibernate:         qsTr("Hibernate")
-    readonly property string userName:          qsTr("User name")
+    readonly property string userName:          qsTr("Username")
     readonly property string welcomeText:       qsTr("Welcome to %1")
 }
 


### PR DESCRIPTION
Currently  the strings are as follows:
```
    readonly property string prompt:            qsTr("Enter your username and password")
    readonly property string promptSelectUser:  qsTr("Select your user and enter password")
    readonly property string promptUser:        qsTr("Enter your username")
    readonly property string userName:          qsTr("User name")
```

The userName string is inconsistent with the rest as it has a space in it. 
This also stands out as elsewhere in the system "username" is usually a single word.