### PR TITLE
Replace 'precedent' with 'precedence' in manpage

### DIFF
--- a/data/man/sddm.conf.rst.in
+++ b/data/man/sddm.conf.rst.in
@@ -14,7 +14,7 @@ sddm display manager configuration
 SYNOPSIS
 ========
 
-Configuration loads all files in the configuration directories followed by the configuration file in the order listed below with the latter having the most precedent. Changes should be made to the local configurations.
+Configuration loads all files in the configuration directories followed by the configuration file in the order listed below with the latter having highest precedence. Changes should be made to the local configurations.
 
 **@SYSTEM_CONFIG_DIR@**
 	System configuration directory


### PR DESCRIPTION
I think this change improves documentation readability; it's based on the usage of the word _precedence_ in other programming languages like [Java](https://introcs.cs.princeton.edu/java/11precedence/)

Please also note how contributors to [#906](https://github.com/sddm/sddm/issues/906) overlooked the word _precedent_, and instead, used the word precedence instinctively.

_Precedence_ is an uncountable noun so it doesn't need the definite article.