### PR TITLE
fix supplemental group initialization (pam_group.so)

### DIFF
--- a/src/helper/Backend.cpp
+++ b/src/helper/Backend.cpp
@@ -29,6 +29,7 @@
 #include <QtCore/QProcessEnvironment>
 
 #include <pwd.h>
+#include <grp.h>
 
 namespace SDDM {
     Backend::Backend(HelperApp* parent)
@@ -78,5 +79,9 @@ namespace SDDM {
 
     bool Backend::closeSession() {
         return true;
+    }
+
+    bool Backend::setupSupplementalGroups(struct passwd *pw) {
+        return !initgroups(pw->pw_name, pw->pw_gid);
     }
 }

--- a/src/helper/Backend.h
+++ b/src/helper/Backend.h
@@ -22,6 +22,7 @@
 #define BACKEND_H
 
 #include <QtCore/QObject>
+#include <pwd.h>
 
 namespace SDDM {
     class HelperApp;
@@ -37,6 +38,8 @@ namespace SDDM {
 
         void setAutologin(bool on = true);
         void setGreeter(bool on = true);
+
+        virtual bool setupSupplementalGroups(struct passwd *pw);
 
     public slots:
         virtual bool start(const QString &user = QString()) = 0;

--- a/src/helper/HelperApp.cpp
+++ b/src/helper/HelperApp.cpp
@@ -253,6 +253,10 @@ namespace SDDM {
         return m_session;
     }
 
+    Backend *HelperApp::backend() {
+        return m_backend;
+    }
+
     const QString& HelperApp::user() const {
         return m_user;
     }

--- a/src/helper/HelperApp.h
+++ b/src/helper/HelperApp.h
@@ -39,6 +39,7 @@ namespace SDDM {
         virtual ~HelperApp();
 
         UserSession *session();
+        Backend *backend();
         const QString &user() const;
         const QString &cookie() const;
 

--- a/src/helper/UserSession.cpp
+++ b/src/helper/UserSession.cpp
@@ -150,67 +150,10 @@ namespace SDDM {
             qCritical() << "setgid(" << pw.pw_gid << ") failed for user: " << username;
             exit(Auth::HELPER_OTHER_ERROR);
         }
-
-#ifdef USE_PAM
-
-        // fetch ambient groups from PAM's environment;
-        // these are set by modules such as pam_groups.so
-        int n_pam_groups = getgroups(0, NULL);
-        gid_t *pam_groups = NULL;
-        if (n_pam_groups > 0) {
-            pam_groups = new gid_t[n_pam_groups];
-            if ((n_pam_groups = getgroups(n_pam_groups, pam_groups)) == -1) {
-                qCritical() << "getgroups() failed to fetch supplemental"
-                            << "PAM groups for user:" << username;
-                exit(Auth::HELPER_OTHER_ERROR);
-            }
-        } else {
-            n_pam_groups = 0;
-        }
-
-        // fetch session's user's groups
-        int n_user_groups = 0;
-        gid_t *user_groups = NULL;
-        if (-1 == getgrouplist(username.constData(), pw.pw_gid,
-                               NULL, &n_user_groups)) {
-            user_groups = new gid_t[n_user_groups];
-            if ((n_user_groups = getgrouplist(username.constData(),
-                                              pw.pw_gid, user_groups,
-                                              &n_user_groups)) == -1 ) {
-                qCritical() << "getgrouplist(" << username << ", " << pw.pw_gid
-                            << ") failed";
-                exit(Auth::HELPER_OTHER_ERROR);
-            }
-        }
-
-        // set groups to concatenation of PAM's ambient
-        // groups and the session's user's groups
-        int n_groups = n_pam_groups + n_user_groups;
-        if (n_groups > 0) {
-            gid_t *groups = new gid_t[n_groups];
-            memcpy(groups, pam_groups, (n_pam_groups * sizeof(gid_t)));
-            memcpy((groups + n_pam_groups), user_groups,
-                   (n_user_groups * sizeof(gid_t)));
-
-            // setgroups(2) handles duplicate groups
-            if (setgroups(n_groups, groups) != 0) {
-                qCritical() << "setgroups() failed for user: " << username;
-                exit (Auth::HELPER_OTHER_ERROR);
-            }
-            delete[] groups;
-        }
-        delete[] pam_groups;
-        delete[] user_groups;
-
-#else
-
         if (initgroups(pw.pw_name, pw.pw_gid) != 0) {
             qCritical() << "initgroups(" << pw.pw_name << ", " << pw.pw_gid << ") failed for user: " << username;
             exit(Auth::HELPER_OTHER_ERROR);
         }
-
-#endif /* USE_PAM */
-
         if (setuid(pw.pw_uid) != 0) {
             qCritical() << "setuid(" << pw.pw_uid << ") failed for user: " << username;
             exit(Auth::HELPER_OTHER_ERROR);

--- a/src/helper/backend/PamBackend.h
+++ b/src/helper/backend/PamBackend.h
@@ -28,6 +28,7 @@
 #include <QtCore/QObject>
 
 #include <security/pam_appl.h>
+#include <pwd.h>
 
 namespace SDDM {
     class PamHandle;
@@ -61,6 +62,7 @@ namespace SDDM {
         explicit PamBackend(HelperApp *parent);
         virtual ~PamBackend();
         int converse(int n, const struct pam_message **msg, struct pam_response **resp);
+        virtual bool setupSupplementalGroups(struct passwd *pw);
 
     public slots:
         virtual bool start(const QString &user = QString());


### PR DESCRIPTION
This MR reverts and attempts to re-implement #834.
It also serves as a fix for #1159, #414, and #416.

The original implementation in `1bc813d0` turned out to be broken and leads to privilege escalation in some setups, as it pulls in all supplemental groups at initialization (PAM+user+root) instead of just the user's groups (user+PAM).

This version moves the supplemental group initialization step from `UserSession` to `Backend`, and makes it accessible to `UserSession` via `HelperApp` so that `PamBackend` is able to inject its additional supplemental groups for modules like `pam_group.so` via `pam_setcred`.

As presented in #1159, the correct PAM initialization sequence seems to be as follows, and at least LightDM seems to do it this way [3]:

* `pam_start` (as root w/ root's sup groups)
* `pam_authenticate`
* `initgroups` (now root w/ user's sup groups)
* `pam_setcred` (now root w/ user's sup groups + other credentials)
* `pam_open_session`
* `setuid`/`setgid` (now user w/ user's sup groups + other user credentials)
* exec the user's session

SDDM's existing initialization model doesn't really seem compatible with this:
`PamBackend` calls `pam_setcred(PAM_ESTABLISH_CRED)` shortly before `pam_open_session`at the beginning of `PamBackend::openSession`, but the `initgroups`/`setgid`/`setuid` step happens after that in `UserSession::setupChildProcess` via `Backend::openSession` via `PamBackend::openSession`.

I couldn't find a good way to reorder the supplemental group initialization before `pam_setcred(PAM_ESTABLISH_CRED)` that doesn't require a bunch of `#ifdef`s or major refactoring. As a result, this MR instead calls `pam_setcred(PAM_REINITIALIZE_CRED)` after the supplemental group initialization in the new `Backend::setupSupplementalGroups` to force PAM to redo the initialization step and add its groups to the user's.

The re-initialization approach seems to work, at least during my testing on an archlinux box with standard PAM config and an opensuse system using NFS homes and `pam_sssd.so`. I also took a look at `pam_sm_setcred` in  all upstream PAM modules [0] and pam_sssd [2], and couldn't find any obvious case in which calling `PAM_REINITIALIZE_CRED` would break things if `PAM_ESTABLISH_CRED` worked. However, this could possibly cause side-effects or breakage for more esoteric pam modules.

I'm not too familiar with PAM or C++, so I'd appreciate your comments. Some suggestions on how to rework the control flow to avoid `PAM_REINITIALIZE_CRED` would be nice, too.

Please note that the original patch proposed by @mbucas in #1159 has been implemented here [1].

[0] https://github.com/linux-pam/linux-pam/search?l=C&q=pam_sm_setcred
[1] https://github.com/jktr/sddm/tree/fix/supplemental-groups-v1
[2] https://github.com/SSSD/sssd/blob/45efba71befd96c8e9fe0a51fc300cafa93bd703/src/sss_client/pam_sss.c#L2736
[3] https://github.com/CanonicalLtd/lightdm/blob/ff1c38c0616b3df66a5002ed7f531d53f218dfab/src/session-child.c#L512-L529