### PR TITLE
Only allocate VTs for seat0 [new branch]

### DIFF
--- a/src/daemon/Greeter.cpp
+++ b/src/daemon/Greeter.cpp
@@ -179,7 +179,8 @@ namespace SDDM {
             env.insert(QStringLiteral("XDG_SEAT"), m_display->seat()->name());
             env.insert(QStringLiteral("XDG_SEAT_PATH"), daemonApp->displayManager()->seatPath(m_display->seat()->name()));
             env.insert(QStringLiteral("XDG_SESSION_PATH"), daemonApp->displayManager()->sessionPath(QStringLiteral("Session%1").arg(daemonApp->newSessionId())));
-            env.insert(QStringLiteral("XDG_VTNR"), QString::number(m_display->terminalId()));
+            if (m_display->seat()->name() == QLatin1String("seat0"))
+                env.insert(QStringLiteral("XDG_VTNR"), QString::number(m_display->terminalId()));
             env.insert(QStringLiteral("XDG_SESSION_CLASS"), QStringLiteral("greeter"));
             env.insert(QStringLiteral("XDG_SESSION_TYPE"), m_display->sessionType());
             env.insert(QStringLiteral("QT_IM_MODULE"), mainConfig.InputMethod.get());

--- a/src/daemon/Seat.cpp
+++ b/src/daemon/Seat.cpp
@@ -55,19 +55,24 @@ namespace SDDM {
     void Seat::createDisplay(int terminalId) {
         //reload config if needed
         mainConfig.load();
-        
-        if (terminalId == -1) {
+
+        if (m_name == QLatin1String("seat0")) {
+            if (terminalId == -1) {
                 // find unused terminal
-            terminalId = findUnused(mainConfig.X11.MinimumVT.get(), [&](const int number) {
-                return m_terminalIds.contains(number);
-            });
+                terminalId = findUnused(mainConfig.X11.MinimumVT.get(), [&](const int number) {
+                    return m_terminalIds.contains(number);
+                });
+            }
+
+            // mark terminal as used
+            m_terminalIds << terminalId;
+
+            // log message
+            qDebug() << "Adding new display" << "on vt" << terminalId << "...";
         }
-
-        // mark terminal as used
-        m_terminalIds << terminalId;
-
-        // log message
-        qDebug() << "Adding new display" << "on vt" << terminalId << "...";
+        else {
+            qDebug() << "Adding new VT-less display...";
+        }
 
         // create a new display
         Display *display = new Display(terminalId, this);
@@ -117,7 +122,8 @@ namespace SDDM {
         // vt switch automatically (VT_AUTO).
         else {
             int disp = m_displays.last()->terminalId();
-            VirtualTerminal::jumpToVt(disp, true);
+            if (disp != -1)
+                VirtualTerminal::jumpToVt(disp, true);
         }
     }
 }


### PR DESCRIPTION
Currently only systemd-logind special seat named "seat0" can
handle VTs. Allocating a VT and setting XDG_VTNR for non-seat0
seats is currently pointless. Moreover, Xorg server 1.16 and
newer doesn't touch VTs if -seat option is passed with a
non-seat0 value, so there's no need to pass vt?? argument to
a non-seat0 Xorg server.

This fixes some leftovers from multi-seat support implemented by @davidedmundson.

Issue: #78