### PR TITLE
sddm.service: Limit restarts

### DIFF
--- a/services/sddm.service.in
+++ b/services/sddm.service.in
@@ -3,6 +3,8 @@ Description=Simple Desktop Display Manager
 Documentation=man:sddm(1) man:sddm.conf(5)
 Conflicts=getty@tty1.service
 After=systemd-user-sessions.service getty@tty1.service plymouth-quit.service systemd-logind.service
+StartLimitIntervalSec=30
+StartLimitBurst=2
 
 [Service]
 ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/sddm


### PR DESCRIPTION
Currently it's possible to have sddm in a crash loop. The systemd default
is to block restarts if there are more than 5 during 10s, but sddm is too
slow to start to trigger that.
Limit it to a max of two restarts during 30s to work reliably even on slow
systems with complex themes.

Reported on https://bugzilla.opensuse.org/show_bug.cgi?id=1142492