### PR TITLE
Add font option

### DIFF
--- a/data/man/sddm.conf.rst.in
+++ b/data/man/sddm.conf.rst.in
@@ -85,6 +85,10 @@ OPTIONS
 	Name of the cursor theme to be set before starting
 	the display server.
 
+`Font=`
+	Name of the font to be set before starting the
+	display server.
+
 `EnableAvatars=`
 	When enabled, home directories are searched for ".face.icon" images to
 	display as their avatars. This can be slow on some file systems.

--- a/data/man/sddm.conf.rst.in
+++ b/data/man/sddm.conf.rst.in
@@ -87,7 +87,7 @@ OPTIONS
 
 `Font=`
 	Name of the font to be set before starting the
-	display server.
+	display server. Please note that the theme can still override this option.
 
 `EnableAvatars=`
 	When enabled, home directories are searched for ".face.icon" images to

--- a/data/translations/ru.ts
+++ b/data/translations/ru.ts
@@ -5,14 +5,14 @@
     <name>PictureBox</name>
     <message>
         <source>Press to login</source>
-        <translation type="unfinished"></translation>
+        <translation>Нажмите для входа</translation>
     </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
         <source>%1 (Wayland)</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 (Wayland)</translation>
     </message>
 </context>
 <context>
@@ -23,7 +23,7 @@
     </message>
     <message>
         <source>Warning, Caps Lock is ON!</source>
-        <translation>Внимание: нажата клавиша Caps Lock</translation>
+        <translation>Внимание: нажата клавиша Caps Lock!</translation>
     </message>
     <message>
         <source>Layout</source>
@@ -68,6 +68,22 @@
     <message>
         <source>Select your user and enter password</source>
         <translation>Выберите пользователя и введите пароль</translation>
+    </message>
+    <message>
+        <source>Enter your username</source>
+        <translation>Введите имя пользователя</translation>
+    </message>
+    <message>
+        <source>Enter your password</source>
+        <translation>Введите пароль</translation>
+    </message>
+    <message>
+        <source>Suspend</source>
+        <translation>Ждущий режим</translation>
+    </message>
+    <message>
+        <source>Hibernate</source>
+        <translation>Спящий режим</translation>
     </message>
 </context>
 </TS>

--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -51,6 +51,7 @@ namespace SDDM {
             Entry(FacesDir,            QString,     _S(DATA_INSTALL_DIR "/faces"),              _S("Global directory for user avatars\n"
                                                                                                    "The files should be named <username>.face.icon"));
             Entry(CursorTheme,         QString,     QString(),                                  _S("Cursor theme used in the greeter"));
+            Entry(Font,                QString,     QString(),                                  _S("Font used in the greeter"));
             Entry(EnableAvatars,       bool,        true,                                       _S("Enable display of custom user avatars"));
             Entry(DisableAvatarsThreshold,int,      7,                                          _S("Number of users to use as threshold\n"
                                                                                                    "above which avatars are disabled\n"

--- a/src/greeter/GreeterApp.cpp
+++ b/src/greeter/GreeterApp.cpp
@@ -248,8 +248,9 @@ namespace SDDM {
         }
 
         // Set font
-        QString font = mainConfig.Theme.Font.get();
-        if (!font.isEmpty())
+        QVariant fontEntry = mainConfig.Theme.Font.get();
+        QFont font = fontEntry.value<QFont>();
+        if (!fontEntry.toString().isEmpty())
             QGuiApplication::setFont(font);
 
         // Set session model on proxy

--- a/src/greeter/GreeterApp.cpp
+++ b/src/greeter/GreeterApp.cpp
@@ -247,6 +247,11 @@ namespace SDDM {
                 m_keyboard->setNumLockState(false);
         }
 
+        // Set font
+        QString font = mainConfig.Theme.Font.get();
+        if (!font.isEmpty())
+            QGuiApplication::setFont(font);
+
         // Set session model on proxy
         m_proxy->setSessionModel(m_sessionModel);
 


### PR DESCRIPTION
Users may wish to further their SDDM theming efforts by using a custom font.

In order to facilitate this, this patch adds a config option which allows users to specify a font.

DEs can also use the option by adding code which would sync the user's font with SDDM.