### PR TITLE
Support both [X11], [XDisplay], [Wayland] and [WaylandDisplay] config sections

### DIFF
--- a/src/common/ConfigReader.cpp
+++ b/src/common/ConfigReader.cpp
@@ -198,6 +198,12 @@ namespace SDDM {
             // get rid of comments first
             lineRef = lineRef.left(lineRef.indexOf(QLatin1Char('#'))).trimmed();
 
+            // In version 0.14.0, these sections were renamed
+            if (currentSection == QStringLiteral("XDisplay"))
+                currentSection = QStringLiteral("X11");
+            else if (currentSection == QStringLiteral("WaylandDisplay"))
+                currentSection = QStringLiteral("Wayland");
+
             // value assignment
             int separatorPosition = lineRef.indexOf(QLatin1Char('='));
             if (separatorPosition >= 0) {


### PR DESCRIPTION
In sddm 0.14.0, the [XDisplay] and [WaylandDisplay] sections were renamed.
This breaks existing configurations, so we need to fix that.
Reverting would break forwards compat., so just alias them.

Fixes #680

We've been using this patch downstream since 0.14.0, apparently it was never submitted.