### PR TITLE
Prevent duplicate session name.

### DIFF
--- a/src/common/Session.cpp
+++ b/src/common/Session.cpp
@@ -169,7 +169,10 @@ namespace SDDM {
 
             if (line.startsWith(QLatin1String("Name="))) {
                 if (type == WaylandSession)
-                    m_displayName = QObject::tr("%1 (Wayland)").arg(line.mid(5));
+                    if (line.mid(5).endsWith(" (Wayland)"))
+                        m_displayName = QObject::tr("%1").arg(line.mid(5));
+                    else
+                        m_displayName = QObject::tr("%1 (Wayland)").arg(line.mid(5));
                 else
                     m_displayName = line.mid(5);
             }


### PR DESCRIPTION
Several desktop sessions (e.g. KDE Plasma) already include the string " (Wayland)" in the session name. When this happens, the session name displayed to the user is "Plasma (Wayland) (Wayland)". This change makes it so that only "Plasma (Wayland)" will be displayed.