### PR TITLE
Set re-use session option by default

### DIFF
--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -91,7 +91,7 @@ namespace SDDM {
             Entry(RememberLastUser,    bool,        true,                                       _S("Remember the last successfully logged in user"));
             Entry(RememberLastSession, bool,        true,                                       _S("Remember the session of the last successfully logged in user"));
 
-            Entry(ReuseSession,        bool,        false,                                      _S("When logging in as the same user twice, restore the original session, rather than create a new one"));
+            Entry(ReuseSession,        bool,        true,                                       _S("When logging in as the same user twice, restore the original session, rather than create a new one"));
         );
 
         Section(Autologin,


### PR DESCRIPTION
I added Reuse session option a few years ago as often logging into a
graphical session twice is not what the user actually wants.

This is particularly important for Plasma which doesn't really support
multiple logins. This has got worse recently as systemd's defaults share
a DBus session across user sessions which makes two graphical logins
even more likely to explode.

Some distros have this set by default.

The option still remains for user, but it'll reduce my bug reports if
all distros have it on by default.