### PR TITLE
Redesign Xauth handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,9 @@ add_feature_info("PAM" PAM_FOUND "PAM support")
 include(CheckFunctionExists)
 check_function_exists(getspnam HAVE_GETSPNAM)
 
+# XAU
+pkg_check_modules(LIBXAU REQUIRED "xau")
+
 # XCB
 find_package(XCB REQUIRED)
 

--- a/data/man/sddm.conf.rst.in
+++ b/data/man/sddm.conf.rst.in
@@ -124,10 +124,6 @@ OPTIONS
 	Path of the Xephyr.
 	Default value is "/usr/bin/Xephyr".
 
-`XauthPath=`
-	Path of the Xauth.
-	Default value is "/usr/bin/xauth".
-
 `SessionDir=`
 	Comma-separated list of directories containing session files.
 	Default value is "/usr/local/share/xsessions,/usr/share/xsessions".
@@ -141,10 +137,6 @@ OPTIONS
 `SessionLogFile=`
         Path to the user session log file, relative to the home directory.
         Default value is ".local/share/sddm/xorg-session.log".
-
-`UserAuthFile=`
-        Path to the Xauthority file, relative to the home directory.
-        Default value is ".Xauthority".
 
 `DisplayCommand=`
 	Path of script to execute when starting the display server.
@@ -168,6 +160,11 @@ OPTIONS
 	Enables Qt's automatic HiDPI scaling.
 	Can be either "true" or "false".
 	Default value is "false".
+
+The `XauthPath=` option is no longer necessary, libxau is used instead.
+
+The `UserAuthFile=` option was removed, the file is always created as
+`/tmp/xauth_XXXXX`. This is necessary for to the use of `FamilyWild` entries.
 
 [Wayland] section:
 

--- a/data/man/sddm.rst.in
+++ b/data/man/sddm.rst.in
@@ -34,6 +34,10 @@ Distributions without pam and systemd will need to put the **sddm** user
 into the **video** group, otherwise errors regarding GL and drm devices
 might be experienced.
 
+For X11 sessions, the cookie for X authorization is written into a
+temporary file `/tmp/xauth_XXXXXX`, owned and only accessible by the
+user.
+
 OPTIONS
 =======
 

--- a/src/auth/Auth.cpp
+++ b/src/auth/Auth.cpp
@@ -65,7 +65,7 @@ namespace SDDM {
         QString displayServerCmd;
         QString sessionPath { };
         QString user { };
-        QString cookie { };
+        QByteArray cookie { };
         bool autologin { false };
         bool greeter { false };
         QProcessEnvironment environment { };
@@ -279,7 +279,7 @@ namespace SDDM {
         return d->greeter;
     }
 
-    const QString& Auth::cookie() const {
+    const QByteArray& Auth::cookie() const {
         return d->cookie;
     }
 
@@ -311,7 +311,7 @@ namespace SDDM {
         d->environment.insert(key, value);
     }
 
-    void Auth::setCookie(const QString& cookie) {
+    void Auth::setCookie(const QByteArray& cookie) {
         if (cookie != d->cookie) {
             d->cookie = cookie;
             Q_EMIT cookieChanged();

--- a/src/auth/Auth.h
+++ b/src/auth/Auth.h
@@ -54,7 +54,7 @@ namespace SDDM {
         Q_PROPERTY(bool autologin READ autologin WRITE setAutologin NOTIFY autologinChanged)
         Q_PROPERTY(bool greeter READ isGreeter WRITE setGreeter NOTIFY greeterChanged)
         Q_PROPERTY(bool verbose READ verbose WRITE setVerbose NOTIFY verboseChanged)
-        Q_PROPERTY(QString cookie READ cookie WRITE setCookie NOTIFY cookieChanged)
+        Q_PROPERTY(QByteArray cookie READ cookie WRITE setCookie NOTIFY cookieChanged)
         Q_PROPERTY(QString user READ user WRITE setUser NOTIFY userChanged)
         Q_PROPERTY(QString session READ session WRITE setSession NOTIFY sessionChanged)
         Q_PROPERTY(AuthRequest* request READ request NOTIFY requestChanged)
@@ -95,7 +95,7 @@ namespace SDDM {
         bool autologin() const;
         bool isGreeter() const;
         bool verbose() const;
-        const QString &cookie() const;
+        const QByteArray &cookie() const;
         const QString &user() const;
         const QString &session() const;
         AuthRequest *request();
@@ -160,7 +160,7 @@ namespace SDDM {
          * Set the display server cookie, to be inserted into the user's $XAUTHORITY
          * @param cookie cookie data
          */
-        void setCookie(const QString &cookie);
+        void setCookie(const QByteArray &cookie);
 
     public Q_SLOTS:
         /**

--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -68,12 +68,10 @@ namespace SDDM {
             Entry(ServerPath,          QString,     _S("/usr/bin/X"),                           _S("Path to X server binary"));
             Entry(ServerArguments,     QString,     _S("-nolisten tcp"),                        _S("Arguments passed to the X server invocation"));
             Entry(XephyrPath,          QString,     _S("/usr/bin/Xephyr"),                      _S("Path to Xephyr binary"));
-            Entry(XauthPath,           QString,     _S("/usr/bin/xauth"),                       _S("Path to xauth binary"));
             Entry(SessionDir,          QStringList, {_S("/usr/local/share/xsessions"),
                                                      _S("/usr/share/xsessions")},               _S("Comma-separated list of directories containing available X sessions"));
             Entry(SessionCommand,      QString,     _S(SESSION_COMMAND),                        _S("Path to a script to execute when starting the desktop session"));
-	    Entry(SessionLogFile,      QString,     _S(".local/share/sddm/xorg-session.log"),   _S("Path to the user session log file"));
-	    Entry(UserAuthFile,        QString,     _S(".Xauthority"),                          _S("Path to the Xauthority file"));
+            Entry(SessionLogFile,      QString,     _S(".local/share/sddm/xorg-session.log"),   _S("Path to the user session log file"));
             Entry(DisplayCommand,      QString,     _S(DATA_INSTALL_DIR "/scripts/Xsetup"),     _S("Path to a script to execute when starting the display server"));
             Entry(DisplayStopCommand,  QString,     _S(DATA_INSTALL_DIR "/scripts/Xstop"),      _S("Path to a script to execute when stopping the display server"));
             Entry(EnableHiDPI,         bool,        false,                                      _S("Enable Qt's automatic high-DPI scaling"));
@@ -84,7 +82,7 @@ namespace SDDM {
             Entry(SessionDir,          QStringList, {_S("/usr/local/share/wayland-sessions"),
                                                      _S("/usr/share/wayland-sessions")},        _S("Comma-separated list of directories containing available Wayland sessions"));
             Entry(SessionCommand,      QString,     _S(WAYLAND_SESSION_COMMAND),                _S("Path to a script to execute when starting the desktop session"));
-	    Entry(SessionLogFile,      QString,     _S(".local/share/sddm/wayland-session.log"),_S("Path to the user session log file"));
+            Entry(SessionLogFile,      QString,     _S(".local/share/sddm/wayland-session.log"),_S("Path to the user session log file"));
             Entry(EnableHiDPI,         bool,        false,                                      _S("Enable Qt's automatic high-DPI scaling"));
         );
 

--- a/src/common/XAuth.h
+++ b/src/common/XAuth.h
@@ -34,20 +34,20 @@ public:
     void setAuthDirectory(const QString &path);
 
     QString authPath() const;
-    QString cookie() const;
+    QByteArray cookie() const;
 
     void setup();
     bool addCookie(const QString &display);
 
-    static bool addCookieToFile(const QString &display,
-                                const QString &fileName,
-                                const QString &cookie);
+    static bool writeCookieToFile(const QString &display,
+                                  const QString &fileName,
+                                  QByteArray cookie);
 
 private:
     bool m_setup = false;
     QString m_authDir;
     QString m_authPath;
-    QString m_cookie;
+    QByteArray m_cookie;
 };
 
 } // namespace SDDM

--- a/src/common/XAuth.h
+++ b/src/common/XAuth.h
@@ -22,6 +22,7 @@
 #define SDDM_XAUTH_H
 
 #include <QString>
+#include <QTemporaryFile>
 
 namespace SDDM {
 
@@ -46,7 +47,7 @@ public:
 private:
     bool m_setup = false;
     QString m_authDir;
-    QString m_authPath;
+    QTemporaryFile m_authFile;
     QByteArray m_cookie;
 };
 

--- a/src/daemon/CMakeLists.txt
+++ b/src/daemon/CMakeLists.txt
@@ -2,6 +2,7 @@ include_directories(
     "${CMAKE_SOURCE_DIR}/src/common"
     "${CMAKE_SOURCE_DIR}/src/auth"
     "${CMAKE_BINARY_DIR}/src/common"
+    ${LIBXAU_INCLUDE_DIRS}
     "${LIBXCB_INCLUDE_DIR}"
 )
 
@@ -65,6 +66,7 @@ target_link_libraries(sddm
                       Qt5::DBus
                       Qt5::Network
                       Qt5::Qml
+                      ${LIBXAU_LIBRARIES}
                       ${LIBXCB_LIBRARIES})
 if(PAM_FOUND)
     target_link_libraries(sddm ${PAM_LIBRARIES})

--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -270,9 +270,6 @@ namespace SDDM {
             }
         }
 
-        // set greeter params
-        if (qobject_cast<XorgDisplayServer *>(m_displayServer))
-            m_greeter->setAuthPath(qobject_cast<XorgDisplayServer *>(m_displayServer)->authPath());
         m_greeter->setSocket(m_socketServer->socketAddress());
         m_greeter->setTheme(findGreeterTheme());
 

--- a/src/daemon/Greeter.h
+++ b/src/daemon/Greeter.h
@@ -38,7 +38,6 @@ namespace SDDM {
         explicit Greeter(Display *parent = 0);
         ~Greeter();
 
-        void setAuthPath(const QString &authPath);
         void setSocket(const QString &socket);
         void setTheme(const QString &theme);
 
@@ -70,7 +69,6 @@ namespace SDDM {
         bool m_started { false };
 
         Display * const m_display { nullptr };
-        QString m_authPath;
         QString m_socket;
         QString m_themePath;
         QString m_displayServerCmd;

--- a/src/daemon/XorgDisplayServer.cpp
+++ b/src/daemon/XorgDisplayServer.cpp
@@ -61,7 +61,7 @@ namespace SDDM {
         return QStringLiteral("x11");
     }
 
-    QString XorgDisplayServer::cookie() const {
+    const QByteArray XorgDisplayServer::cookie() const {
         return m_xauth.cookie();
     }
 

--- a/src/daemon/XorgDisplayServer.cpp
+++ b/src/daemon/XorgDisplayServer.cpp
@@ -251,9 +251,6 @@ namespace SDDM {
         displayStopScript->deleteLater();
         displayStopScript = nullptr;
 
-        // remove authority file
-        QFile::remove(m_xauth.authPath());
-
         // emit signal
         emit stopped();
     }

--- a/src/daemon/XorgDisplayServer.h
+++ b/src/daemon/XorgDisplayServer.h
@@ -39,7 +39,7 @@ namespace SDDM {
 
         QString sessionType() const;
 
-        QString cookie() const;
+        const QByteArray cookie() const;
 
     public slots:
         bool start();

--- a/src/helper/Backend.cpp
+++ b/src/helper/Backend.cpp
@@ -73,13 +73,6 @@ namespace SDDM {
             env.insert(QStringLiteral("SHELL"), QString::fromLocal8Bit(pw->pw_shell));
             env.insert(QStringLiteral("USER"), QString::fromLocal8Bit(pw->pw_name));
             env.insert(QStringLiteral("LOGNAME"), QString::fromLocal8Bit(pw->pw_name));
-            if (env.contains(QStringLiteral("DISPLAY")) && !env.contains(QStringLiteral("XAUTHORITY"))) {
-                // determine Xauthority path
-                QString value = QStringLiteral("%1/%2")
-                        .arg(QString::fromLocal8Bit(pw->pw_dir))
-                        .arg(mainConfig.X11.UserAuthFile.get());
-                env.insert(QStringLiteral("XAUTHORITY"), value);
-            }
 #if defined(Q_OS_FREEBSD)
         /* get additional environment variables via setclassenvironment();
             this needs to be done here instead of in UserSession::setupChildProcess

--- a/src/helper/CMakeLists.txt
+++ b/src/helper/CMakeLists.txt
@@ -3,6 +3,7 @@ include(CheckLibraryExists)
 include_directories(
     "${CMAKE_SOURCE_DIR}/src/common"
     "${CMAKE_SOURCE_DIR}/src/auth"
+    ${LIBXAU_INCLUDE_DIRS}
 )
 include_directories("${CMAKE_BINARY_DIR}/src/common")
 
@@ -37,7 +38,11 @@ else()
 endif()
 
 add_executable(sddm-helper ${HELPER_SOURCES})
-target_link_libraries(sddm-helper Qt5::Network Qt5::DBus Qt5::Qml)
+target_link_libraries(sddm-helper
+                      Qt5::Network
+                      Qt5::DBus
+                      Qt5::Qml
+                      ${LIBXAU_LIBRARIES})
 if("${CMAKE_SYSTEM_NAME}" STREQUAL "FreeBSD")
     # On FreeBSD (possibly other BSDs as well), we want to use
     # setusercontext() to set up the login configuration from login.conf
@@ -68,7 +73,8 @@ add_executable(sddm-helper-start-x11user HelperStartX11User.cpp xorguserhelper.c
                                                 ${CMAKE_SOURCE_DIR}/src/common/XAuth.cpp
                                                 ${CMAKE_SOURCE_DIR}/src/common/SignalHandler.cpp
                                                 )
-target_link_libraries(sddm-helper-start-x11user Qt5::Core)
+target_link_libraries(sddm-helper-start-x11user Qt5::Core
+                                                ${LIBXAU_LIBRARIES})
 install(TARGETS sddm-helper-start-x11user RUNTIME DESTINATION "${CMAKE_INSTALL_LIBEXECDIR}")
 
 if(JOURNALD_FOUND)

--- a/src/helper/HelperApp.cpp
+++ b/src/helper/HelperApp.cpp
@@ -249,7 +249,7 @@ namespace SDDM {
         str >> m >> env >> m_cookie;
         if (m != AUTHENTICATED) {
             env = QProcessEnvironment();
-            m_cookie = QString();
+            m_cookie = {};
             qCritical() << "Received a wrong opcode instead of AUTHENTICATED:" << m;
         }
         return env;
@@ -288,7 +288,7 @@ namespace SDDM {
         return m_user;
     }
 
-    const QString& HelperApp::cookie() const {
+    const QByteArray& HelperApp::cookie() const {
         return m_cookie;
     }
 

--- a/src/helper/HelperApp.h
+++ b/src/helper/HelperApp.h
@@ -40,7 +40,7 @@ namespace SDDM {
 
         UserSession *session();
         const QString &user() const;
-        const QString &cookie() const;
+        const QByteArray &cookie() const;
 
     public slots:
         Request request(const Request &request);
@@ -63,7 +63,7 @@ namespace SDDM {
         QLocalSocket *m_socket { nullptr };
         QString m_user { };
         // TODO: get rid of this in a nice clean way along the way with moving to user session X server
-        QString m_cookie { };
+        QByteArray m_cookie { };
 
         /*!
          \brief Write utmp/wtmp/btmp records when a user logs in

--- a/src/helper/UserSession.h
+++ b/src/helper/UserSession.h
@@ -24,6 +24,7 @@
 
 #include <QtCore/QObject>
 #include <QtCore/QProcess>
+#include <QtCore/QTemporaryFile>
 
 namespace SDDM {
     class HelperApp;
@@ -62,6 +63,7 @@ namespace SDDM {
         void setup();
 
         QString m_path { };
+        QTemporaryFile m_xauthFile;
         QString m_displayServerCmd;
 
         /*!

--- a/src/helper/xorguserhelper.cpp
+++ b/src/helper/xorguserhelper.cpp
@@ -236,9 +236,6 @@ void XOrgUserHelper::displayFinished()
             displayStopScript->kill();
         displayStopScript->deleteLater();
     }
-
-    // Remove xauthority file
-    QFile::remove(m_xauth.authPath());
 }
 
 } // namespace SDDM


### PR DESCRIPTION
This commit moves Xauthority handling over to libXau.
Advantage is that this allows use of FamilyWild, is faster, more reliable
and easier to read. However, we lose the ability to merge the new cookie into
an existing Xauthority file, so support for using a non-temporary file is
dropped. Even if merging was implemented manually, use of FamilyWild would
"infect" such a file and break it for DMs which don't write it.