### PR TITLE
Cleanup sessions on exit

### DIFF
--- a/src/helper/HelperApp.cpp
+++ b/src/helper/HelperApp.cpp
@@ -37,6 +37,7 @@
 
 #if defined(Q_OS_LINUX)
 #include <utmp.h>
+#include <sys/prctl.h>
 #endif
 #include <utmpx.h>
 #include <QByteArray>
@@ -50,6 +51,9 @@ namespace SDDM {
         qInstallMessageHandler(HelperMessageHandler);
 
         QTimer::singleShot(0, this, SLOT(setUp()));
+#if defined(Q_OS_LINUX)
+        prctl(PR_SET_CHILD_SUBREAPER);
+#endif
     }
 
     void HelperApp::setUp() {


### PR DESCRIPTION
On exit we currently don't do any cleanup. This leaves stray processes
running. Some aren't even the responsibility of the session, such as
anything spawned in the Xsessions.d directory.

In the event of a hard reset (systemctl --restart sddm) we currently
don't even send a SIGTERM to the session leader.

By registering as a subreaper we can have the kernel automatically clean
up anything when sddm-helper is quit gracefully or unexpectedly.