### PR TITLE
Implement substitution of passwd fields in session log file path

### DIFF
--- a/data/man/sddm.conf.rst.in
+++ b/data/man/sddm.conf.rst.in
@@ -126,7 +126,7 @@ OPTIONS
 
 `SessionLogFile=`
         Path to the user session log file, relative to the home directory.
-        Default value is ".local/share/sddm/xorg-session.log".
+        Default value is "%{HOME}%/.local/share/sddm/xorg-session.log".
 
 `UserAuthFile=`
         Path to the Xauthority file, relative to the home directory.

--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -66,8 +66,8 @@ namespace SDDM {
             Entry(XauthPath,           QString,     _S("/usr/bin/xauth"),                       _S("Path to xauth binary"));
             Entry(SessionDir,          QString,     _S("/usr/share/xsessions"),                 _S("Directory containing available X sessions"));
             Entry(SessionCommand,      QString,     _S(SESSION_COMMAND),                        _S("Path to a script to execute when starting the desktop session"));
-	    Entry(SessionLogFile,      QString,     _S(".local/share/sddm/xorg-session.log"),   _S("Path to the user session log file"));
-	    Entry(UserAuthFile,        QString,     _S(".Xauthority"),                          _S("Path to the Xauthority file"));
+            Entry(SessionLogFile,      QString,     _S("%{HOME}%/.local/share/sddm/xorg-session.log"),   _S("Path to the user session log file"));
+            Entry(UserAuthFile,        QString,     _S(".Xauthority"),                          _S("Path to the Xauthority file"));
             Entry(DisplayCommand,      QString,     _S(DATA_INSTALL_DIR "/scripts/Xsetup"),     _S("Path to a script to execute when starting the display server"));
             Entry(DisplayStopCommand,  QString,     _S(DATA_INSTALL_DIR "/scripts/Xstop"),      _S("Path to a script to execute when stopping the display server"));
             Entry(MinimumVT,           int,         MINIMUM_VT,                                 _S("The lowest virtual terminal number that will be used."));
@@ -77,7 +77,7 @@ namespace SDDM {
         Section(Wayland,
             Entry(SessionDir,          QString,     _S("/usr/share/wayland-sessions"),          _S("Directory containing available Wayland sessions"));
             Entry(SessionCommand,      QString,     _S(WAYLAND_SESSION_COMMAND),                _S("Path to a script to execute when starting the desktop session"));
-	    Entry(SessionLogFile,      QString,     _S(".local/share/sddm/wayland-session.log"),_S("Path to the user session log file"));
+            Entry(SessionLogFile,      QString,     _S("%{HOME}%/.local/share/sddm/wayland-session.log"),_S("Path to the user session log file"));
             Entry(EnableHiDPI,         bool,        false,                                      _S("Enable Qt's automatic high-DPI scaling"));
         );
 

--- a/src/helper/UserSession.cpp
+++ b/src/helper/UserSession.cpp
@@ -226,11 +226,14 @@ namespace SDDM {
         //we want to redirect after we setuid so that the log file is owned by the user
 
         // determine stderr log file based on session type
-        QString sessionLog = QStringLiteral("%1/%2")
-                .arg(homeDir)
-                .arg(sessionType == QLatin1String("x11")
+        QString sessionLog = (sessionType == QLatin1String("x11")
                      ? mainConfig.X11.SessionLogFile.get()
-                     : mainConfig.Wayland.SessionLogFile.get());
+                     : mainConfig.Wayland.SessionLogFile.get())
+        .replace(QStringLiteral("%{USER}%"), QString::fromLocal8Bit(pw.pw_name))
+        .replace(QStringLiteral("%{UID}%"), QString::number(pw.pw_uid))
+        .replace(QStringLiteral("%{GID}%"), QString::number(pw.pw_gid))
+        .replace(QStringLiteral("%{GECOS}%"), QString::fromLocal8Bit(pw.pw_gecos))
+        .replace(QStringLiteral("%{HOME}%"), QString::fromLocal8Bit(pw.pw_dir));
 
         // create the path
         QFileInfo finfo(sessionLog);


### PR DESCRIPTION
This allows the path in sessionLog to have substitution variables from the user's passwd entry: user, uid, gid, gecos and home.

This also allows setting the SessionLogFile to a path outside the user's home, but the defaults will remain unchanged:
`%{HOME}%/.local/share/sddm/xorg-session.log`
`%{HOME}%/.local/share/sddm/wayland-session.log`