### PR TITLE
Move creation of cookie file before running X server

### DIFF
--- a/src/daemon/XorgDisplayServer.cpp
+++ b/src/daemon/XorgDisplayServer.cpp
@@ -117,6 +117,10 @@ namespace SDDM {
         // check flag
         if (m_started)
             return false;
+        
+        // generate auth file
+        addCookie(m_authPath);
+        changeOwner(m_authPath);
 
         // create process
         process = new QProcess(this);
@@ -216,10 +220,6 @@ namespace SDDM {
 
             emit started();
         }
-
-        // generate auth file
-        addCookie(m_authPath);
-        changeOwner(m_authPath);
 
         // set flag
         m_started = true;


### PR DESCRIPTION
I have no clue about what is written in the cookie.
I know that I was getting something like
(EE) failed to open authorization file "/var/run/sddm/{xxxxx}": no such file or directory
in /var/log/Xorg.0.log
It sounds to me that now the xserver run so fast that sddm has not created the cookie file in time
This pull request move the create of cookie before running the server