### PR TITLE
Don't abort on failure to start the display server

### DIFF
--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -102,15 +102,8 @@ namespace SDDM {
         return m_seat;
     }
 
-    void Display::start() {
-        // check flag
-        if (m_started)
-            return;
-
-        // start display server
-        if (!m_displayServer->start()) {
-            qFatal("Display server failed to start. Exiting");
-        }
+    bool Display::start() {
+        return m_started || m_displayServer->start();
     }
 
     bool Display::attemptAutologin() {

--- a/src/daemon/Display.h
+++ b/src/daemon/Display.h
@@ -54,7 +54,7 @@ namespace SDDM {
         Seat *seat() const;
 
     public slots:
-        void start();
+        bool start();
         void stop();
 
         void login(QLocalSocket *socket,

--- a/src/daemon/Seat.cpp
+++ b/src/daemon/Seat.cpp
@@ -52,7 +52,7 @@ namespace SDDM {
         return m_name;
     }
 
-    void Seat::createDisplay(int terminalId) {
+    bool Seat::createDisplay(int terminalId) {
         //reload config if needed
         mainConfig.load();
 
@@ -84,7 +84,12 @@ namespace SDDM {
         m_displays << display;
 
         // start the display
-        display->start();
+        if (!display->start()) {
+            qCritical() << "Could not start Display server on vt" << terminalId;
+            return false;
+        }
+
+        return true;
     }
 
     void Seat::removeDisplay(Display* display) {

--- a/src/daemon/Seat.h
+++ b/src/daemon/Seat.h
@@ -35,7 +35,7 @@ namespace SDDM {
         const QString &name() const;
 
     public slots:
-        void createDisplay(int terminalId = -1);
+        bool createDisplay(int terminalId = -1);
         void removeDisplay(SDDM::Display* display);
 
     private slots:


### PR DESCRIPTION
Currently sddm logs a fatal error if X fails to start, which triggers an
abort and thus a very unclean shutdown and even a core dump.
In the case of a broken X setup, this leads to frequent service restarts
triggered by systemd which don't help and just result in core dumps and
if this fails in the handling of new seats or switchToGreeter, it'll even
kill all other sessions, potentially leading to data loss.

Logging it as critical error is enough, at least it doesn't make it worse.