### PR TITLE
Fix container anti pattern uses

### DIFF
--- a/src/common/ConfigReader.cpp
+++ b/src/common/ConfigReader.cpp
@@ -241,16 +241,18 @@ namespace SDDM {
         if (section) {
             if (entry && !entry->matchesDefault())
                 remainingEntries.insert(section, entry);
-            else
-                for (const ConfigEntryBase *b : section->entries().values())
+            else {
+                for (const ConfigEntryBase *b : qAsConst(section->entries()))
                     if (!b->matchesDefault())
                         remainingEntries.insert(section, b);
+            }
         }
         else {
-            for (const ConfigSection *s : m_sections)
-                for (const ConfigEntryBase *b : s->entries().values())
+            for (const ConfigSection *s : qAsConst(m_sections)) {
+                for (const ConfigEntryBase *b : qAsConst(s->entries()))
                     if (!b->matchesDefault())
                         remainingEntries.insert(s, b);
+            }
         }
 
         // initialize the current section - General, usually


### PR DESCRIPTION
Temporary containers are being created needlessly. Just iterate the
containers directly instead.
Also made the containers const to avoid possible C++11 range-for container
detachments.