### PR TITLE
Drop foreach/Q_FOREACH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ find_package(ECM 1.4.0 REQUIRED NO_MODULE)
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake;${CMAKE_MODULE_PATH};${ECM_MODULE_PATH}")
 
 # Definitions
-add_definitions(-Wall -std=c++11 -DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_FROM_BYTEARRAY)
+add_definitions(-Wall -std=c++11 -DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_FROM_BYTEARRAY -DQT_NO_FOREACH)
 
 # Default build type
 if(NOT CMAKE_BUILD_TYPE)

--- a/src/auth/AuthMessages.h
+++ b/src/auth/AuthMessages.h
@@ -187,7 +187,7 @@ namespace SDDM {
     inline QDataStream& operator<<(QDataStream &s, const Request &m) {
         qint32 length = m.prompts.length();
         s << length;
-        Q_FOREACH(Prompt p, m.prompts) {
+        for(const Prompt &p : qAsConst(m.prompts)) {
             s << p;
         }
         return s;

--- a/src/auth/AuthRequest.cpp
+++ b/src/auth/AuthRequest.cpp
@@ -38,7 +38,7 @@ namespace SDDM {
             : QObject(parent) { }
 
     void AuthRequest::Private::responseChanged() {
-        Q_FOREACH(AuthPrompt *qap, prompts) {
+        for(const AuthPrompt *qap : qAsConst(prompts)) {
             if (qap->response().isEmpty())
                 return;
         }
@@ -54,7 +54,7 @@ namespace SDDM {
         QList<AuthPrompt*> promptsCopy(d->prompts);
         d->prompts.clear();
         if (request != nullptr) {
-            Q_FOREACH (const Prompt& p, request->prompts) {
+            for (const Prompt& p : qAsConst(request->prompts)) {
                 AuthPrompt *qap = new AuthPrompt(&p, this);
                 d->prompts << qap;
                 if (finishAutomatically())
@@ -96,7 +96,7 @@ namespace SDDM {
 
     Request AuthRequest::request() const {
         Request r;
-        Q_FOREACH (const AuthPrompt* qap, d->prompts) {
+        for (const AuthPrompt* qap : qAsConst(d->prompts)) {
             Prompt p;
             p.hidden = qap->hidden();
             p.message = qap->message();

--- a/src/common/ConfigReader.cpp
+++ b/src/common/ConfigReader.cpp
@@ -33,7 +33,8 @@ QTextStream &operator>>(QTextStream &str, QStringList &list)  {
 
     QString line = str.readLine();
 
-    Q_FOREACH (const QStringRef &s, line.splitRef(QLatin1Char(','))) {
+    const auto strings = line.splitRef(QLatin1Char(','));
+    for (const QStringRef &s : strings) {
         QStringRef trimmed = s.trimmed();
         if (!trimmed.isEmpty())
             list.append(trimmed.toString());
@@ -154,7 +155,8 @@ namespace SDDM {
             QDir dir(m_sysConfigDir);
             if (dir.exists()) {
                 latestModificationTime = std::max(latestModificationTime,  QFileInfo(m_sysConfigDir).lastModified());
-                foreach (const QFileInfo &file, dir.entryInfoList(QDir::Files | QDir::NoDotAndDotDot, QDir::LocaleAware)) {
+                const auto dirFiles = dir.entryInfoList(QDir::Files | QDir::NoDotAndDotDot, QDir::LocaleAware);
+                for (const QFileInfo &file : dirFiles) {
                     files << (file.absoluteFilePath());
                     latestModificationTime = std::max(latestModificationTime, file.lastModified());
                 }
@@ -165,7 +167,8 @@ namespace SDDM {
             QDir dir(m_configDir);
             if (dir.exists()) {
                 latestModificationTime = std::max(latestModificationTime,  QFileInfo(m_configDir).lastModified());
-                foreach (const QFileInfo &file, dir.entryInfoList(QDir::Files | QDir::NoDotAndDotDot, QDir::LocaleAware)) {
+                const auto dirFiles = dir.entryInfoList(QDir::Files | QDir::NoDotAndDotDot, QDir::LocaleAware);
+                for (const QFileInfo &file : dirFiles) {
                     files << (file.absoluteFilePath());
                     latestModificationTime = std::max(latestModificationTime, file.lastModified());
                 }
@@ -179,7 +182,7 @@ namespace SDDM {
         }
         m_fileModificationTime = latestModificationTime;
 
-        foreach (const QString &filepath, files) {
+        for (const QString &filepath : qAsConst(files)) {
             loadInternal(filepath);
         }
     }

--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -293,7 +293,8 @@ namespace SDDM {
             auto reply = manager.ListSessions();
             reply.waitForFinished();
 
-            foreach(const SessionInfo &s, reply.value()) {
+            const auto info = reply.value();
+            for(const SessionInfo &s : reply.value()) {
                 if (s.userName == user) {
                     OrgFreedesktopLogin1SessionInterface session(Logind::serviceName(), s.sessionPath.path(), QDBusConnection::systemBus());
                     if (session.service() == QLatin1String("sddm") && session.state() == QLatin1String("online")) {

--- a/src/daemon/SeatManager.cpp
+++ b/src/daemon/SeatManager.cpp
@@ -107,7 +107,8 @@ namespace SDDM {
         QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(reply);
         connect(watcher, &QDBusPendingCallWatcher::finished, this, [=]() {
             watcher->deleteLater();
-            foreach(const NamedSeatPath &seat, reply.value()) {
+            const auto seats = reply.value();
+            for(const NamedSeatPath &seat : seats) {
                 logindSeatAdded(seat.name, seat.path);
             }
         });

--- a/src/greeter/GreeterApp.cpp
+++ b/src/greeter/GreeterApp.cpp
@@ -205,7 +205,8 @@ namespace SDDM {
                 return;
 
             QString errors;
-            Q_FOREACH(const QQmlError &e, view->errors()) {
+            const auto errorList = view->errors();
+            for(const QQmlError &e : errorList) {
                 qWarning() << e;
                 errors += QLatin1String("\n") + e.toString();
             }
@@ -266,8 +267,8 @@ namespace SDDM {
         m_proxy->setSessionModel(m_sessionModel);
 
         // Create views
-        QList<QScreen *> screens = qGuiApp->primaryScreen()->virtualSiblings();
-        Q_FOREACH (QScreen *screen, screens)
+        const QList<QScreen *> screens = qGuiApp->primaryScreen()->virtualSiblings();
+        for (QScreen *screen : screens)
             addViewForScreen(screen);
 
         // Handle screens
@@ -279,7 +280,7 @@ namespace SDDM {
 
     void GreeterApp::activatePrimary() {
         // activate and give focus to the window assigned to the primary screen
-        Q_FOREACH (QQuickView *view, m_views) {
+        for (QQuickView *view : qAsConst(m_views)) {
             if (view->screen() == QGuiApplication::primaryScreen()) {
                 view->requestActivate();
                 break;

--- a/src/greeter/SessionModel.cpp
+++ b/src/greeter/SessionModel.cpp
@@ -118,7 +118,8 @@ namespace SDDM {
         dir.setNameFilters(QStringList() << QStringLiteral("*.desktop"));
         dir.setFilter(QDir::Files);
         // read session
-        foreach(const QString &session, dir.entryList()) {
+        const auto sessions = dir.entryList();
+        for(const QString &session : sessions) {
             if (!dir.exists(session))
                 continue;
 
@@ -132,8 +133,8 @@ namespace SDDM {
                 execAllowed = false;
                 QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
                 QString envPath = env.value(QStringLiteral("PATH"));
-                QStringList pathList = envPath.split(QLatin1Char(':'));
-                foreach(const QString &path, pathList) {
+                const QStringList pathList = envPath.split(QLatin1Char(':'));
+                for(const QString &path : pathList) {
                     QDir pathDir(path);
                     fi.setFile(pathDir, si->tryExec());
                     if (fi.exists() && fi.isExecutable()) {

--- a/src/helper/backend/PamHandle.cpp
+++ b/src/helper/backend/PamHandle.cpp
@@ -24,7 +24,8 @@
 
 namespace SDDM {
     bool PamHandle::putEnv(const QProcessEnvironment& env) {
-        foreach (const QString& s, env.toStringList()) {
+        const auto envs = env.toStringList();
+        for (const QString& s : envs) {
             m_result = pam_putenv(m_handle, qPrintable(s));
             if (m_result != PAM_SUCCESS) {
                 qWarning() << "[PAM] putEnv:" << pam_strerror(m_handle, m_result);

--- a/src/helper/backend/PasswdBackend.cpp
+++ b/src/helper/backend/PasswdBackend.cpp
@@ -56,7 +56,7 @@ namespace SDDM {
         r.prompts << Prompt(AuthPrompt::LOGIN_PASSWORD, QStringLiteral("Password"), true);
 
         Request response = m_app->request(r);
-        Q_FOREACH(const Prompt &p, response.prompts) {
+        for(const Prompt &p : qAsConst(response.prompts)) {
             switch (p.type) {
                 case AuthPrompt::LOGIN_USER:
                     m_user = QString::fromUtf8(p.response);


### PR DESCRIPTION
Use C++11 range for. Making the container const or using qAsConst() to cast
to const, so that container detachments are avoided.
Enforce it by adding QT_NO_FOREACH to the compilation definitions.

Rationale:
* Since Qt 5.7, the use of this macro is discouraged. It will be removed
  in a future version of Qt.
* It only works efficiently on (some) Qt containers; it performs
  prohibitively expensive on all std containers, QVarLengthArray, and
  doesn’t work at all for C arrays.
* Even where it works as advertised, it typically costs ~100 bytes of text
  size more per loop than the C++11 ranged for-loop.
* Its unconditionally taking a copy of the container makes it hard to
  reason about the loop.

Reference: https://www.kdab.com/goodbye-q_foreach/