### PR TITLE
Initialize member variable in the constructor

### DIFF
--- a/src/common/Session.cpp
+++ b/src/common/Session.cpp
@@ -31,6 +31,7 @@ namespace SDDM {
     Session::Session()
         : m_valid(false)
         , m_type(UnknownSession)
+        , m_vt(0)
         , m_isHidden(false)
         , m_isNoDisplay(false)
     {


### PR DESCRIPTION
A member variable should always be initialized.