### PR TITLE
Perform initialization on the initialization list

### DIFF
--- a/src/daemon/DisplayManager.cpp
+++ b/src/daemon/DisplayManager.cpp
@@ -129,11 +129,8 @@ namespace SDDM {
         }
     }
 
-    DisplayManagerSeat::DisplayManagerSeat(const QString &name, QObject *parent) : QObject(parent) {
-        // set name and path
-        m_name = name;
-        m_path = DISPLAYMANAGER_SEAT_PATH + name.mid(4);
-
+    DisplayManagerSeat::DisplayManagerSeat(const QString &name, QObject *parent)
+        : QObject(parent), m_name(name), m_path(DISPLAYMANAGER_SEAT_PATH + name.mid(4)) {
         // create adaptor
         new SeatAdaptor(this);
 
@@ -171,10 +168,8 @@ namespace SDDM {
        return daemonApp->displayManager()->Sessions(this);
     }
 
-    DisplayManagerSession::DisplayManagerSession(const QString &name, const QString &seat, const QString &user, QObject *parent) : QObject(parent), m_name(name), m_seat(seat), m_user(user) {
-        // set path
-        m_path = DISPLAYMANAGER_SESSION_PATH + name.mid(7);
-
+    DisplayManagerSession::DisplayManagerSession(const QString &name, const QString &seat, const QString &user, QObject *parent)
+        : QObject(parent), m_name(name), m_path(DISPLAYMANAGER_SESSION_PATH + name.mid(7)), m_seat(seat), m_user(user) {
         // create adaptor
         new SessionAdaptor(this);
 

--- a/src/helper/backend/PamHandle.cpp
+++ b/src/helper/backend/PamHandle.cpp
@@ -178,9 +178,7 @@ namespace SDDM {
         return QString::fromLocal8Bit(pam_strerror(m_handle, m_result));
     }
 
-    PamHandle::PamHandle(PamBackend *parent) {
-        // create context
-        m_conv = { &PamHandle::converse, parent };
+    PamHandle::PamHandle(PamBackend *parent) : m_conv{&PamHandle::converse, parent} { // create context
     }
 
     PamHandle::~PamHandle() {


### PR DESCRIPTION
When an object of a class is created, the constructors of all member
variables are called consecutively in the order the variables are declared,
even if you don't explicitly write them to the initialization list.

Avoids double "initialization".