### PR TITLE
Prefer Wayland sessions over X11 ones

### DIFF
--- a/src/common/Session.cpp
+++ b/src/common/Session.cpp
@@ -131,13 +131,13 @@ namespace SDDM {
         m_desktopNames.clear();
 
         switch (type) {
-        case X11Session:
-            m_dir = QDir(mainConfig.X11.SessionDir.get());
-            m_xdgSessionType = QStringLiteral("x11");
-            break;
         case WaylandSession:
             m_dir = QDir(mainConfig.Wayland.SessionDir.get());
             m_xdgSessionType = QStringLiteral("wayland");
+            break;
+        case X11Session:
+            m_dir = QDir(mainConfig.X11.SessionDir.get());
+            m_xdgSessionType = QStringLiteral("x11");
             break;
         default:
             m_xdgSessionType.clear();

--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -115,10 +115,10 @@ namespace SDDM {
         if (autologinSession.isEmpty()) {
             autologinSession = stateConfig.Last.Session.get();
         }
-        if (findSessionEntry(mainConfig.X11.SessionDir.get(), autologinSession)) {
-            sessionType = Session::X11Session;
-        } else if (findSessionEntry(mainConfig.Wayland.SessionDir.get(), autologinSession)) {
+        if (findSessionEntry(mainConfig.Wayland.SessionDir.get(), autologinSession)) {
             sessionType = Session::WaylandSession;
+        } else if (findSessionEntry(mainConfig.X11.SessionDir.get(), autologinSession)) {
+            sessionType = Session::X11Session;
         } else {
             qCritical() << "Unable to find autologin session entry" << autologinSession;
             return false;

--- a/src/greeter/SessionModel.cpp
+++ b/src/greeter/SessionModel.cpp
@@ -41,8 +41,8 @@ namespace SDDM {
     SessionModel::SessionModel(QObject *parent) : QAbstractListModel(parent), d(new SessionModelPrivate()) {
         // initial population
         beginResetModel();
-        populate(Session::X11Session, mainConfig.X11.SessionDir.get());
         populate(Session::WaylandSession, mainConfig.Wayland.SessionDir.get());
+        populate(Session::X11Session, mainConfig.X11.SessionDir.get());
         endResetModel();
 
         // refresh everytime a file is changed, added or removed
@@ -50,12 +50,12 @@ namespace SDDM {
         connect(watcher, &QFileSystemWatcher::directoryChanged, [this](const QString &path) {
             beginResetModel();
             d->sessions.clear();
-            populate(Session::X11Session, mainConfig.X11.SessionDir.get());
             populate(Session::WaylandSession, mainConfig.Wayland.SessionDir.get());
+            populate(Session::X11Session, mainConfig.X11.SessionDir.get());
             endResetModel();
         });
-        watcher->addPath(mainConfig.X11.SessionDir.get());
         watcher->addPath(mainConfig.Wayland.SessionDir.get());
+        watcher->addPath(mainConfig.X11.SessionDir.get());
     }
 
     SessionModel::~SessionModel() {


### PR DESCRIPTION
As a general goal and preference, we want to make the change
to Wayland as the default and X11 as the fallback.

This change codifies that preference.

Reference: https://fedoraproject.org/wiki/Changes/WaylandByDefaultForPlasma