### PR TITLE
Fixed Caps Lock is 大写锁定 instead of 大小写锁定

### DIFF
--- a/data/translations/zh_CN.ts
+++ b/data/translations/zh_CN.ts
@@ -23,7 +23,7 @@
     <name>TextConstants</name>
     <message>
         <source>Warning, Caps Lock is ON!</source>
-        <translation>警告，大小写锁定已开启！</translation>
+        <translation>警告，大写锁定已开启！</translation>
     </message>
     <message>
         <source>Layout</source>


### PR DESCRIPTION
大写锁定 means locking to capitcal case.
大小写锁定 means locking to capital/small case, which contains ambigues.
