### PR TITLE
Improve font config deserialization

### DIFF
--- a/src/greeter/GreeterApp.cpp
+++ b/src/greeter/GreeterApp.cpp
@@ -258,10 +258,13 @@ namespace SDDM {
         }
 
         // Set font
-        QVariant fontEntry = mainConfig.Theme.Font.get();
-        QFont font = fontEntry.value<QFont>();
-        if (!fontEntry.toString().isEmpty())
-            QGuiApplication::setFont(font);
+        const QString fontStr = mainConfig.Theme.Font.get();
+        if (!fontStr.isEmpty()) {
+            QFont font;
+            if (font.fromString(fontStr)) {
+                QGuiApplication::setFont(font);
+            }
+        }
 
         // Set session model on proxy
         m_proxy->setSessionModel(m_sessionModel);


### PR DESCRIPTION
Going from QString -> QVariant -> QFont isn't ideal and means that it tries
to create a QFont from a null/empty QString as well, resulting in a warning:
QFont::fromString: Invalid description '(empty)'
Just skip the QVariant step and call QFont::fromString directly.