### PR TITLE
Use PAM's username

### DIFF
--- a/src/helper/UserSession.cpp
+++ b/src/helper/UserSession.cpp
@@ -175,13 +175,13 @@ namespace SDDM {
         // fetch session's user's groups
         int n_user_groups = 0;
         gid_t *user_groups = NULL;
-        if (-1 == getgrouplist(username.constData(), pw.pw_gid,
+        if (-1 == getgrouplist(pw.pw_name, pw.pw_gid,
                                NULL, &n_user_groups)) {
             user_groups = new gid_t[n_user_groups];
-            if ((n_user_groups = getgrouplist(username.constData(),
+            if ((n_user_groups = getgrouplist(pw.pw_name,
                                               pw.pw_gid, user_groups,
                                               &n_user_groups)) == -1 ) {
-                qCritical() << "getgrouplist(" << username << ", " << pw.pw_gid
+                qCritical() << "getgrouplist(" << pw.pw_name << ", " << pw.pw_gid
                             << ") failed";
                 exit(Auth::HELPER_OTHER_ERROR);
             }


### PR DESCRIPTION
The provided username might differ from full username. This happens
for sssd with multiple domains where the username is suffixed with
@domain. However, the user can type only username without a suffix
and let sssd find the first username match according to
domain_resolution_order.

Fixes #1303

Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>