### PR TITLE
Only use the base name for $DESKTOP_SESSION

### DIFF
--- a/src/common/Session.cpp
+++ b/src/common/Session.cpp
@@ -89,7 +89,7 @@ namespace SDDM {
 
     QString Session::desktopSession() const
     {
-        return fileName().replace(s_entryExtention, QString());
+        return QFileInfo(m_fileName).completeBaseName();
     }
 
     QString Session::desktopNames() const


### PR DESCRIPTION
Other DMs don't use the path.

Fixes #852

WIP because untested.