### PR TITLE
Re-add fish /etc/profile sourcing

### DIFF
--- a/data/scripts/Xsession
+++ b/data/scripts/Xsession
@@ -39,6 +39,8 @@ case $SHELL in
     rm -f $xsess_tmp
     ;;
   */fish)
+    [ -f /etc/profile ] && . /etc/profile
+    [ -f $HOME/.profile ] && . $HOME/.profile
     xsess_tmp=`mktemp /tmp/xsess-env-XXXXXX`
     $SHELL --login -c "/bin/sh -c 'export -p' > $xsess_tmp"
     . $xsess_tmp

--- a/data/scripts/wayland-session
+++ b/data/scripts/wayland-session
@@ -43,6 +43,8 @@ case $SHELL in
     rm -f $wlsess_tmp
     ;;
   */fish)
+    [ -f /etc/profile ] && . /etc/profile
+    [ -f $HOME/.profile ] && . $HOME/.profile
     xsess_tmp=`mktemp /tmp/xsess-env-XXXXXX`
     $SHELL --login -c "/bin/sh -c 'export -p' > $xsess_tmp"
     . $xsess_tmp


### PR DESCRIPTION
Fixes https://github.com/sddm/sddm/issues/879
Also added sourcing of `~/.profile`, ubuntu adds `~/.local/bin` to PATH in this file, so this will be useful.