### PR TITLE
Fix sessions being started as the wrong type on autologin

### DIFF
--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -245,6 +245,11 @@ namespace SDDM {
     }
 
     bool Display::findSessionEntry(const QDir &dir, const QString &name) const {
+        // Given an absolute path: Check that it matches dir
+        const QFileInfo fileInfo(name);
+        if (fileInfo.isAbsolute() && fileInfo.absolutePath() != dir.absolutePath())
+            return false;
+
         QString fileName = name;
 
         // append extension


### PR DESCRIPTION
For autologin, the last session is used, which contains a full path.
Display::findSessionEntry didn't handle that correctly, which led to
X11 sessions getting started as Wayland ones (or the other way around
before 994fa67).

Fixes #1348