### PR TITLE
wayland-session: Ensure $SHELL remains correctly set

### DIFF
--- a/data/scripts/wayland-session
+++ b/data/scripts/wayland-session
@@ -6,6 +6,10 @@
 # Copyright (C) 2001-2005 Oswald Buddenhagen <ossi@kde.org>
 
 # Note that the respective logout scripts are not sourced.
+
+# Backup the user shell setting into SDDM specific variable
+SDDM_USER_SHELL=$SHELL
+
 case $SHELL in
   */bash)
     [ -z "$BASH" ] && exec $SHELL $0 "$@"
@@ -49,5 +53,8 @@ case $SHELL in
     [ -f $HOME/.profile ] && . $HOME/.profile
     ;;
 esac
+
+# Restore user shell setting that may have been clobbered by setting environment
+export SHELL=$SDDM_USER_SHELL
 
 exec $@


### PR DESCRIPTION
In some circumstances, the effort of setting the environment
correctly can wind up clobbering the user-specified shell. To
work around this issue, capture the shell setting in a variable
and set it back at the end of environment and profile setup.

Fixes #1351 