### PR TITLE
Allow one-click passwordless login (fix #751)

### DIFF
--- a/src/greeter/theme/Main.qml
+++ b/src/greeter/theme/Main.qml
@@ -87,11 +87,15 @@ Rectangle {
                 onLogin: sddm.login(model.name, password, sessionIndex);
 
                 MouseArea {
-                    anchors.fill: parent
-                    onClicked: {
+                    anchors.left: parent.left; anchors.top: parent.top
+                    width: parent.width; height: 185
+                    cursorShape: Qt.PointingHandCursor
+                    hoverEnabled: true
+                    onEntered: {
                         listView.currentIndex = index;
                         listView.focus = true;
                     }
+                    onClicked: sddm.login (model.name, password, sessionIndex)
                 }
             }
         }


### PR DESCRIPTION
Login acts by click on the user icon.
For passwordless login (https://github.com/sddm/sddm/issues/751):
1) the user must be a member of the "nopasswdlogin" group;
2) passwordless login must be allowed in /etc/pam.d/sddm.