### PR TITLE
Allow addition env vars to be defined in session files

### DIFF
--- a/src/common/Session.h
+++ b/src/common/Session.h
@@ -23,6 +23,7 @@
 #include <QDataStream>
 #include <QDir>
 #include <QSharedPointer>
+#include <QProcessEnvironment>
 
 namespace SDDM {
     class SessionModel;
@@ -59,11 +60,14 @@ namespace SDDM {
         bool isHidden() const;
         bool isNoDisplay() const;
 
+        QProcessEnvironment additionalEnv() const;
+
         void setTo(Type type, const QString &name);
 
         Session &operator=(const Session &other);
 
     private:
+        QProcessEnvironment parseEnv(const QString &list);
         bool m_valid;
         Type m_type;
         QDir m_dir;
@@ -75,6 +79,7 @@ namespace SDDM {
         QString m_tryExec;
         QString m_xdgSessionType;
         QString m_desktopNames;
+        QProcessEnvironment m_additionalEnv;
         bool m_isHidden;
         bool m_isNoDisplay;
 

--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -313,6 +313,7 @@ namespace SDDM {
         qDebug() << "Session" << m_sessionName << "selected, command:" << session.exec();
 
         QProcessEnvironment env;
+        env.insert(session.additionalEnv());
 
         if (seat()->name() == QLatin1String("seat0")) {
             // Use the greeter VT, for wayland sessions the helper overwrites this


### PR DESCRIPTION
We have a continual problem with developers using Plasma in custom
prefixes. We need to set mulitple additional envs and it is a constant
pain point.

Setting XDG_DATA_DIRS and alike in a script in the Exec line of the
desktop file doesn't work properly, as this is after systemd and dbus
have already been started during pam_logind. It requires a lot of bodging.

Things will work much better if we can set the env before pam_logind is
run.

Using pam_env or profile.d doesn't really work correctly as that then affects all the
sessions. 

This additional hint is not intended to be used for anything other than dev setups.

From a security point it should be safe, as you need root for xsession/xwayalnd files, and if you can edit them, you could just edit the Exec line.