### PR TITLE
Fix warning from SDDM::generateName()

### DIFF
--- a/src/daemon/Utils.h
+++ b/src/daemon/Utils.h
@@ -26,11 +26,11 @@
 namespace SDDM {
 
 inline QString generateName(int length) {
-    QString digits = QStringLiteral("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ");
+    const QString digits = QStringLiteral("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ");
 
     // reserve space for name
     QString name;
-    name.reserve(length);
+    name.resize(length);
 
     // create random device
     std::random_device rd;


### PR DESCRIPTION
Properly constructs the created string by allocating the space to fill instead of just reserving. Addresses the following warning:

>   Using QCharRef with an index pointing outside the valid range of a QString. The corresponding behavior is deprecated, and will be changed in a future version of Qt.