### PR TITLE
Move utmp logic to Display

### DIFF
--- a/src/auth/Auth.cpp
+++ b/src/auth/Auth.cpp
@@ -68,6 +68,7 @@ namespace SDDM {
         bool autologin { false };
         bool greeter { false };
         QProcessEnvironment environment { };
+        qint64 sessionPid { -1 };
         qint64 id { 0 };
         static qint64 lastId;
     };
@@ -192,8 +193,10 @@ namespace SDDM {
             }
             case SESSION_STATUS: {
                 bool status;
-                str >> status;
-                Q_EMIT auth->sessionStarted(status);
+                qint64 pid; //not pid_t as we need to define the wire type
+                str >> status >> pid;
+                sessionPid = pid;
+                Q_EMIT auth->sessionStarted(status, pid);
                 str.reset();
                 str << SESSION_STATUS;
                 str.send();
@@ -284,6 +287,10 @@ namespace SDDM {
 
     AuthRequest *Auth::request() {
         return d->request;
+    }
+
+    qint64 Auth::sessionPid() const {
+        return d->sessionPid;
     }
 
     bool Auth::isActive() const {

--- a/src/auth/Auth.h
+++ b/src/auth/Auth.h
@@ -93,6 +93,8 @@ namespace SDDM {
         const QString &cookie() const;
         const QString &user() const;
         const QString &session() const;
+        qint64 sessionPid() const;
+
         AuthRequest *request();
         /**
          * True if an authentication or session is in progress
@@ -182,7 +184,7 @@ namespace SDDM {
         *
         * @param success true if succeeded
         */
-        void sessionStarted(bool success);
+        void sessionStarted(bool success, qint64 pid);
 
         /**
         * Emitted when the helper quits, either after authentication or when the session ends.

--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -35,6 +35,7 @@
 #include <QFile>
 #include <QTimer>
 #include <QLocalSocket>
+#include <QByteArray>
 
 #include <pwd.h>
 #include <unistd.h>
@@ -46,6 +47,10 @@
 #include "Login1Manager.h"
 #include "Login1Session.h"
 
+#if defined(Q_OS_LINUX)
+#include <utmp.h>
+#endif
+#include <utmpx.h>
 
 namespace SDDM {
     Display::Display(const int terminalId, Seat *parent) : QObject(parent),
@@ -367,6 +372,7 @@ namespace SDDM {
             if (m_socket)
                 emit loginSucceeded(m_socket);
         } else if (m_socket) {
+            utmpLogin(QString::number(terminalId()),  name(), user, 0, false);
             qDebug() << "Authentication failure";
             emit loginFailed(m_socket);
         }
@@ -391,6 +397,10 @@ namespace SDDM {
     }
 
     void Display::slotHelperFinished(Auth::HelperExitStatus status) {
+        if (m_auth->sessionPid() > 0) {
+            utmpLogout(QString::number(terminalId()), name(), m_auth->sessionPid());
+        }
+
         // Don't restart greeter and display server unless sddm-helper exited
         // with an internal error or the user session finished successfully,
         // we want to avoid greeter from restarting when an authentication
@@ -411,7 +421,104 @@ namespace SDDM {
         }
     }
 
-    void Display::slotSessionStarted(bool success) {
-        qDebug() << "Session started";
+    void Display::slotSessionStarted(bool success, qint64 pid) {
+        if (success) {
+            utmpLogin(QString::number(terminalId()), name(), m_auth->user(), pid, true);
+        }
     }
+
+    void Display::utmpLogin(const QString &vt, const QString &displayName, const QString &user, qint64 pid, bool authSuccessful) {
+        struct utmpx entry;
+        struct timeval tv;
+
+        entry = { 0 };
+        entry.ut_type = USER_PROCESS;
+        entry.ut_pid = pid;
+
+        // ut_line: vt
+        if (!vt.isEmpty()) {
+            QString tty = QStringLiteral("tty");
+            tty.append(vt);
+            QByteArray ttyBa = tty.toLocal8Bit();
+            const char* ttyChar = ttyBa.constData();
+            strncpy(entry.ut_line, ttyChar, sizeof(entry.ut_line) - 1);
+        }
+
+        // ut_host: displayName
+        QByteArray displayBa = displayName.toLocal8Bit();
+        const char* displayChar = displayBa.constData();
+        strncpy(entry.ut_host, displayChar, sizeof(entry.ut_host) - 1);
+
+        // ut_user: user
+        QByteArray userBa = user.toLocal8Bit();
+        const char* userChar = userBa.constData();
+        strncpy(entry.ut_user, userChar, sizeof(entry.ut_user) -1);
+
+        gettimeofday(&tv, NULL);
+        entry.ut_tv.tv_sec = tv.tv_sec;
+        entry.ut_tv.tv_usec = tv.tv_usec;
+
+        // write to utmp
+        setutxent();
+        if (!pututxline (&entry))
+            qWarning() << "Failed to write utmpx: " << strerror(errno);
+        endutxent();
+
+#if !defined(Q_OS_FREEBSD)
+        // append to failed login database btmp
+        if (!authSuccessful) {
+#if defined(Q_OS_LINUX)
+            updwtmpx("/var/log/btmp", &entry);
+#endif
+        }
+
+        // append to wtmp
+        else {
+#if defined(Q_OS_LINUX)
+            updwtmpx("/var/log/wtmp", &entry);
+#endif
+        }
+#endif
+    }
+
+    void Display::utmpLogout(const QString &vt, const QString &displayName, qint64 pid) {
+        struct utmpx entry;
+        struct timeval tv;
+
+        entry = { 0 };
+        entry.ut_type = DEAD_PROCESS;
+        entry.ut_pid = pid;
+
+        // ut_line: vt
+        if (!vt.isEmpty()) {
+            QString tty = QStringLiteral("tty");
+            tty.append(vt);
+            QByteArray ttyBa = tty.toLocal8Bit();
+            const char* ttyChar = ttyBa.constData();
+            strncpy(entry.ut_line, ttyChar, sizeof(entry.ut_line) - 1);
+        }
+
+        // ut_host: displayName
+        QByteArray displayBa = displayName.toLocal8Bit();
+        const char* displayChar = displayBa.constData();
+        strncpy(entry.ut_host, displayChar, sizeof(entry.ut_host) - 1);
+
+        gettimeofday(&tv, NULL);
+        entry.ut_tv.tv_sec = tv.tv_sec;
+        entry.ut_tv.tv_usec = tv.tv_usec;
+
+        // write to utmp
+        setutxent();
+        if (!pututxline (&entry))
+            qWarning() << "Failed to write utmpx: " << strerror(errno);
+        endutxent();
+
+#if defined(Q_OS_LINUX)
+        // append to wtmp
+        updwtmpx("/var/log/wtmp", &entry);
+#elif defined(Q_OS_FREEBSD)
+        pututxline(&entry);
+#endif
+    }
+
 }

--- a/src/daemon/Display.h
+++ b/src/daemon/Display.h
@@ -94,10 +94,28 @@ namespace SDDM {
         QLocalSocket *m_socket { nullptr };
         Greeter *m_greeter { nullptr };
 
+        /*!
+         \brief Write utmp/wtmp/btmp records when a user logs in
+         \param vt  Virtual terminal (tty7, tty8,...)
+         \param displayName  Display (:0, :1,...)
+         \param user  User logging in
+         \param pid  User process ID (e.g. PID of startkde)
+         \param authSuccessful  Was authentication successful
+        */
+        void utmpLogin(const QString &vt, const QString &displayName, const QString &user, qint64 pid, bool authSuccessful);
+
+        /*!
+         \brief Write utmp/wtmp records when a user logs out
+         \param vt  Virtual terminal (tty7, tty8,...)
+         \param displayName  Display (:0, :1,...)
+         \param pid  User process ID (e.g. PID of startkde)
+        */
+        void utmpLogout(const QString &vt, const QString &displayName, qint64 pid);
+
     private slots:
         void slotRequestChanged();
         void slotAuthenticationFinished(const QString &user, bool success);
-        void slotSessionStarted(bool success);
+        void slotSessionStarted(bool success, qint64 pid);
         void slotHelperFinished(Auth::HelperExitStatus status);
         void slotAuthInfo(const QString &message, Auth::Info info);
         void slotAuthError(const QString &message, Auth::Error error);

--- a/src/helper/HelperApp.cpp
+++ b/src/helper/HelperApp.cpp
@@ -36,12 +36,6 @@
 #include <sys/socket.h>
 #include <sys/time.h>
 
-#if defined(Q_OS_LINUX)
-#include <utmp.h>
-#endif
-#include <utmpx.h>
-#include <QByteArray>
-
 namespace SDDM {
     HelperApp::HelperApp(int& argc, char** argv)
             : QCoreApplication(argc, argv)
@@ -122,26 +116,12 @@ namespace SDDM {
 
         if (!m_backend->start(m_user)) {
             authenticated(QString());
-
-            // write failed login to btmp
-            QProcessEnvironment env = m_session->processEnvironment();
-            QString displayId = env.value(QStringLiteral("DISPLAY"));
-            QString vt = env.value(QStringLiteral("XDG_VTNR"));
-            utmpLogin(vt, displayId, m_user, 0, false);
-
             exit(Auth::HELPER_AUTH_ERROR);
             return;
         }
 
         if (!m_backend->authenticate()) {
             authenticated(QString());
-
-            // write failed login to btmp
-            QProcessEnvironment env = m_session->processEnvironment();
-            QString displayId = env.value(QStringLiteral("DISPLAY"));
-            QString vt = env.value(QStringLiteral("XDG_VTNR"));
-            utmpLogin(vt, displayId, m_user, 0, false);
-
             exit(Auth::HELPER_AUTH_ERROR);
             return;
         }
@@ -159,22 +139,12 @@ namespace SDDM {
             m_session->setProcessEnvironment(env);
 
             if (!m_backend->openSession()) {
-                sessionOpened(false);
+                sessionOpened(false, -1);
                 exit(Auth::HELPER_SESSION_ERROR);
                 return;
             }
 
-            sessionOpened(true);
-
-            // write successful login to utmp/wtmp
-            QProcessEnvironment env = m_session->processEnvironment();
-            QString displayId = env.value(QStringLiteral("DISPLAY"));
-            QString vt = env.value(QStringLiteral("XDG_VTNR"));
-            if (env.value(QStringLiteral("XDG_SESSION_CLASS")) != QLatin1String("greeter")) {
-                // cache pid for session end
-                m_session->setCachedProcessId(m_session->processId());
-                utmpLogin(vt, displayId, m_user, m_session->processId(), true);
-            }
+            sessionOpened(true, m_session->processId());
         }
         else
             exit(Auth::HELPER_SUCCESS);
@@ -183,15 +153,6 @@ namespace SDDM {
 
     void HelperApp::sessionFinished(int status) {
         m_backend->closeSession();
-
-        // write logout to utmp/wtmp
-        qint64 pid = m_session->cachedProcessId();
-        QProcessEnvironment env = m_session->processEnvironment();
-        if (env.value(QStringLiteral("XDG_SESSION_CLASS")) != QLatin1String("greeter")) {
-            QString vt = env.value(QStringLiteral("XDG_VTNR"));
-            QString displayId = env.value(QStringLiteral("DISPLAY"));
-            utmpLogout(vt, displayId, pid);
-        }
 
         exit(status);
     }
@@ -243,10 +204,10 @@ namespace SDDM {
         return env;
     }
 
-    void HelperApp::sessionOpened(bool success) {
+    void HelperApp::sessionOpened(bool success, qint64 pid) {
         Msg m = Msg::MSG_UNKNOWN;
         SafeDataStream str(m_socket);
-        str << Msg::SESSION_STATUS << success;
+        str << Msg::SESSION_STATUS << success << pid;
         str.send();
         str.receive();
         str >> m;
@@ -269,100 +230,6 @@ namespace SDDM {
 
     HelperApp::~HelperApp() {
 
-    }
-
-    void HelperApp::utmpLogin(const QString &vt, const QString &displayName, const QString &user, qint64 pid, bool authSuccessful) {
-        struct utmpx entry;
-        struct timeval tv;
-
-        entry = { 0 };
-        entry.ut_type = USER_PROCESS;
-        entry.ut_pid = pid;
-
-        // ut_line: vt
-        if (!vt.isEmpty()) {
-            QString tty = QStringLiteral("tty");
-            tty.append(vt);
-            QByteArray ttyBa = tty.toLocal8Bit();
-            const char* ttyChar = ttyBa.constData();
-            strncpy(entry.ut_line, ttyChar, sizeof(entry.ut_line) - 1);
-        }
-
-        // ut_host: displayName
-        QByteArray displayBa = displayName.toLocal8Bit();
-        const char* displayChar = displayBa.constData();
-        strncpy(entry.ut_host, displayChar, sizeof(entry.ut_host) - 1);
-
-        // ut_user: user
-        QByteArray userBa = user.toLocal8Bit();
-        const char* userChar = userBa.constData();
-        strncpy(entry.ut_user, userChar, sizeof(entry.ut_user) -1);
-
-        gettimeofday(&tv, NULL);
-        entry.ut_tv.tv_sec = tv.tv_sec;
-        entry.ut_tv.tv_usec = tv.tv_usec;
-
-        // write to utmp
-        setutxent();
-        if (!pututxline (&entry))
-            qWarning() << "Failed to write utmpx: " << strerror(errno);
-        endutxent();
-
-#if !defined(Q_OS_FREEBSD)
-        // append to failed login database btmp
-        if (!authSuccessful) {
-#if defined(Q_OS_LINUX)
-            updwtmpx("/var/log/btmp", &entry);
-#endif
-        }
-
-        // append to wtmp
-        else {
-#if defined(Q_OS_LINUX)
-            updwtmpx("/var/log/wtmp", &entry);
-#endif
-        }
-#endif
-    }
-
-    void HelperApp::utmpLogout(const QString &vt, const QString &displayName, qint64 pid) {
-        struct utmpx entry;
-        struct timeval tv;
-
-        entry = { 0 };
-        entry.ut_type = DEAD_PROCESS;
-        entry.ut_pid = pid;
-
-        // ut_line: vt
-        if (!vt.isEmpty()) {
-            QString tty = QStringLiteral("tty");
-            tty.append(vt);
-            QByteArray ttyBa = tty.toLocal8Bit();
-            const char* ttyChar = ttyBa.constData();
-            strncpy(entry.ut_line, ttyChar, sizeof(entry.ut_line) - 1);
-        }
-
-        // ut_host: displayName
-        QByteArray displayBa = displayName.toLocal8Bit();
-        const char* displayChar = displayBa.constData();
-        strncpy(entry.ut_host, displayChar, sizeof(entry.ut_host) - 1);
-
-        gettimeofday(&tv, NULL);
-        entry.ut_tv.tv_sec = tv.tv_sec;
-        entry.ut_tv.tv_usec = tv.tv_usec;
-
-        // write to utmp
-        setutxent();
-        if (!pututxline (&entry))
-            qWarning() << "Failed to write utmpx: " << strerror(errno);
-        endutxent();
-
-#if defined(Q_OS_LINUX)
-        // append to wtmp
-        updwtmpx("/var/log/wtmp", &entry);
-#elif defined(Q_OS_FREEBSD)
-        pututxline(&entry);
-#endif
     }
 }
 

--- a/src/helper/HelperApp.h
+++ b/src/helper/HelperApp.h
@@ -47,7 +47,7 @@ namespace SDDM {
         void info(const QString &message, Auth::Info type);
         void error(const QString &message, Auth::Error type);
         QProcessEnvironment authenticated(const QString &user);
-        void sessionOpened(bool success);
+        void sessionOpened(bool success, qint64 pid);
 
     private slots:
         void setUp();
@@ -64,23 +64,6 @@ namespace SDDM {
         // TODO: get rid of this in a nice clean way along the way with moving to user session X server
         QString m_cookie { };
 
-        /*!
-         \brief Write utmp/wtmp/btmp records when a user logs in
-         \param vt  Virtual terminal (tty7, tty8,...)
-         \param displayName  Display (:0, :1,...)
-         \param user  User logging in
-         \param pid  User process ID (e.g. PID of startkde)
-         \param authSuccessful  Was authentication successful
-        */
-        void utmpLogin(const QString &vt, const QString &displayName, const QString &user, qint64 pid, bool authSuccessful);
-
-        /*!
-         \brief Write utmp/wtmp records when a user logs out
-         \param vt  Virtual terminal (tty7, tty8,...)
-         \param displayName  Display (:0, :1,...)
-         \param pid  User process ID (e.g. PID of startkde)
-        */
-        void utmpLogout(const QString &vt, const QString &displayName, qint64 pid);
     };
 }
 

--- a/src/helper/UserSession.cpp
+++ b/src/helper/UserSession.cpp
@@ -47,6 +47,8 @@ namespace SDDM {
     bool UserSession::start() {
         QProcessEnvironment env = qobject_cast<HelperApp*>(parent())->session()->processEnvironment();
 
+        setup();
+
         if (env.value(QStringLiteral("XDG_SESSION_CLASS")) == QLatin1String("greeter")) {
             QProcess::start(m_path);
         } else if (env.value(QStringLiteral("XDG_SESSION_TYPE")) == QLatin1String("x11")) {
@@ -72,7 +74,7 @@ namespace SDDM {
         return m_path;
     }
 
-    void UserSession::setupChildProcess() {
+    void UserSession::setup() {
         // Session type
         QString sessionType = processEnvironment().value(QStringLiteral("XDG_SESSION_TYPE"));
 
@@ -294,13 +296,4 @@ namespace SDDM {
             pclose(fp);
         }
     }
-
-    void UserSession::setCachedProcessId(qint64 pid) {
-        m_cachedProcessId = pid;
-    }
-
-    qint64 UserSession::cachedProcessId() {
-        return m_cachedProcessId;
-    }
-
 }

--- a/src/helper/UserSession.h
+++ b/src/helper/UserSession.h
@@ -40,25 +40,10 @@ namespace SDDM {
         void setPath(const QString &path);
         QString path() const;
 
-        /*!
-         \brief Sets m_cachedProcessId. Needed for getting the PID of a finished UserSession
-                and calling HelperApp::utmpLogout
-         \param pid  The process ID
-        */
-        void setCachedProcessId(qint64 pid);
-
-        /*!
-         \brief Gets m_cachedProcessId
-         \return  The cached process ID
-        */
-        qint64 cachedProcessId();
-
-    protected:
-        void setupChildProcess();
+        void setup();
 
     private:
         QString m_path { };
-        qint64 m_cachedProcessId;
     };
 }
 


### PR DESCRIPTION
By moving this in display we don't need sddm-helper to perform anything
as root after the initial setup.

This allows us to drop the priveleges in UserSession before forking.

This should unblock #1230 as well as give us a path to simplify the
paths where the helper is running the display manager.