### PR TITLE
sddm service is a part of graphical target

### DIFF
--- a/services/sddm.service.in
+++ b/services/sddm.service.in
@@ -3,6 +3,7 @@ Description=Simple Desktop Display Manager
 Documentation=man:sddm(1) man:sddm.conf(5)
 Conflicts=getty@tty1.service
 After=systemd-user-sessions.service getty@tty1.service plymouth-quit.service systemd-logind.service
+PartOf=graphical.target
 StartLimitIntervalSec=30
 StartLimitBurst=2
 


### PR DESCRIPTION
This allow to stop or restart sddm.service when graphical.target revices one of these signals.