### PR TITLE
Remove title bar under Weston (and possibly others)

### DIFF
--- a/src/greeter/GreeterApp.cpp
+++ b/src/greeter/GreeterApp.cpp
@@ -149,6 +149,7 @@ namespace SDDM {
         view->setResizeMode(QQuickView::SizeRootObjectToView);
         //view->setGeometry(QRect(QPoint(0, 0), screen->geometry().size()));
         view->setGeometry(screen->geometry());
+        view->setFlags(Qt::FramelessWindowHint);
         m_views.append(view);
 
         // remove the view when the screen is removed, but we


### PR DESCRIPTION
I couldn't run sddm using Weston's fullscreen-shell.so (black screen, is it only me or is it a known bug?) Changing the compositor command line to just "weston" works, but it draws a title bar, and since Weston only supports client-side decorations it's apparently sddm's task to do this. Not sure if it breaks something under X11 (seems like it shouldn't). I'm new to sddm, let alone to C++. It's working for me, so I'm making this PR in case this it's actually the way to go.