### PR TITLE
Initialise Greeter::m_display from the start

### DIFF
--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -223,7 +223,6 @@ namespace SDDM {
         }
 
         // set greeter params
-        m_greeter->setDisplay(this);
         if (qobject_cast<XorgDisplayServer *>(m_displayServer))
             m_greeter->setAuthPath(qobject_cast<XorgDisplayServer *>(m_displayServer)->authPath());
         m_greeter->setSocket(m_socketServer->socketAddress());

--- a/src/daemon/Greeter.cpp
+++ b/src/daemon/Greeter.cpp
@@ -34,7 +34,10 @@
 #include <QtCore/QProcess>
 
 namespace SDDM {
-    Greeter::Greeter(QObject *parent) : QObject(parent) {
+    Greeter::Greeter(Display *parent)
+        : QObject(parent)
+        , m_display(parent)
+    {
         m_metadata = new ThemeMetadata(QString());
         m_themeConfig = new ThemeConfig(QString());
     }
@@ -44,10 +47,6 @@ namespace SDDM {
 
         delete m_metadata;
         delete m_themeConfig;
-    }
-
-    void Greeter::setDisplay(Display *display) {
-        m_display = display;
     }
 
     void Greeter::setAuthPath(const QString &authPath) {
@@ -110,6 +109,7 @@ namespace SDDM {
         if (!style.isEmpty())
             args << QLatin1String("-style") << style;
 
+        Q_ASSERT(m_display);
         if (daemonApp->testing()) {
             // create process
             m_process = new QProcess(this);

--- a/src/daemon/Greeter.h
+++ b/src/daemon/Greeter.h
@@ -35,10 +35,9 @@ namespace SDDM {
         Q_OBJECT
         Q_DISABLE_COPY(Greeter)
     public:
-        explicit Greeter(QObject *parent = 0);
+        explicit Greeter(Display *parent = 0);
         ~Greeter();
 
-        void setDisplay(Display *display);
         void setAuthPath(const QString &authPath);
         void setSocket(const QString &socket);
         void setTheme(const QString &theme);
@@ -64,7 +63,7 @@ namespace SDDM {
     private:
         bool m_started { false };
 
-        Display *m_display { nullptr };
+        Display * const m_display { nullptr };
         QString m_authPath;
         QString m_socket;
         QString m_themePath;


### PR DESCRIPTION
No need to call a setter as the display is always the parent. This
fixes a crash on autologin when there is no display server.