### PR TITLE
Several VT switch fixes

### DIFF
--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -253,6 +253,8 @@ namespace SDDM {
         // stop the greeter
         m_greeter->stop();
 
+	m_auth->stop();
+
         // stop socket server
         m_socketServer->stop();
 

--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -62,14 +62,14 @@ namespace SDDM {
         m_socketServer(new SocketServer(this)),
         m_greeter(new Greeter(this)) {
 
-        // Allocate vt
-        m_terminalId = VirtualTerminal::setUpNewVt();
 
         // Save display server type
         const QString &displayServerType = mainConfig.DisplayServer.get().toLower();
-        if (displayServerType == QLatin1String("x11"))
+        if (displayServerType == QLatin1String("x11")) {
+            // Allocate vt
+            m_terminalId = VirtualTerminal::setUpNewVt();
             m_displayServerType = X11DisplayServerType;
-        else if (displayServerType == QStringLiteral("x11-user"))
+        } else if (displayServerType == QStringLiteral("x11-user"))
             m_displayServerType = X11UserDisplayServerType;
         else if (displayServerType == QStringLiteral("wayland"))
             m_displayServerType = WaylandDisplayServerType;
@@ -95,7 +95,9 @@ namespace SDDM {
         }
 
         // Print what VT we are using for more information
-        qDebug("Using VT %d", m_terminalId);
+        if (m_terminalId > 0) {
+            qDebug("Using VT %d", m_terminalId);
+        }
 
         // respond to authentication requests
         m_auth->setVerbose(true);

--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -30,7 +30,6 @@
 #include "SocketServer.h"
 #include "Greeter.h"
 #include "Utils.h"
-#include "SignalHandler.h"
 
 #include <QDebug>
 #include <QFile>

--- a/src/daemon/XorgDisplayServer.cpp
+++ b/src/daemon/XorgDisplayServer.cpp
@@ -23,7 +23,6 @@
 #include "Configuration.h"
 #include "DaemonApp.h"
 #include "Display.h"
-#include "SignalHandler.h"
 #include "Seat.h"
 
 #include <QDebug>

--- a/src/helper/UserSession.cpp
+++ b/src/helper/UserSession.cpp
@@ -116,7 +116,6 @@ namespace SDDM {
 
         if (m_process->waitForStarted()) {
             int vtNumber = processEnvironment().value(QStringLiteral("XDG_VTNR")).toInt();
-            VirtualTerminal::jumpToVt(vtNumber, true);
             return true;
         } else if (isWaylandGreeter) {
             // This is probably fine, we need the compositor to start first
@@ -217,7 +216,7 @@ namespace SDDM {
                 }
             }
 
-            VirtualTerminal::jumpToVt(vtNumber, false);
+            VirtualTerminal::jumpToVt(vtNumber, true);
         }
 
 #ifdef Q_OS_LINUX


### PR DESCRIPTION
    Avoid duplicated VT Switch in UserSession

----

    Avoid incorrect terminal switching
    
    When running with rootless Xorg or wayland we setup a new VT
    when we are about to launch the session.
    
    This avoids an incorrect switch and SDDM taking ownership of a VT we
    don't use.

---

    Stop any active session when closing the daemon, this just helps cleanup when running sudo systemctl restart sddm
