### PR TITLE
Fix session logs

### DIFF
--- a/src/helper/UserSession.cpp
+++ b/src/helper/UserSession.cpp
@@ -46,7 +46,6 @@ namespace SDDM {
         , m_process(new QProcess(this))
         , m_xorgUser(new XOrgUserHelper(this))
     {
-        m_process->setProcessChannelMode(QProcess::ForwardedChannels);
         connect(m_process, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished), this, &UserSession::finished);
         connect(m_xorgUser, &XOrgUserHelper::displayChanged, this, [this, parent](const QString &display) {
             auto env = processEnvironment();
@@ -346,6 +345,9 @@ namespace SDDM {
             QDir().mkpath(finfo.absolutePath());
 
             m_process->setStandardErrorFile(sessionLog);
+            m_process->setStandardOutputFile(QProcess::nullDevice());
+        } else {
+            m_process->setProcessChannelMode(QProcess::ForwardedChannels);
         }
 
         // set X authority for X11 sessions only


### PR DESCRIPTION
Mixing processChannelMode with setting error files does not work
reliably and our logs regressed again.

This patch only forwards when we are running the greeter.
It also groups the code together so it's more readable and hopefully
will stay working.

setStandardOutput file to nullptr was added as docs imply this is more
efficient.