### PR TITLE
Avoid creating a new TTY when using rootful X starting an X session

### DIFF
--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -369,7 +369,9 @@ namespace SDDM {
         m_sessionName = session.fileName();
 
         // New VT
-        m_lastSession.setVt(VirtualTerminal::setUpNewVt());
+        if (session.xdgSessionType() != QLatin1String("x11") || m_displayServerType != X11DisplayServerType) {
+            m_lastSession.setVt(VirtualTerminal::setUpNewVt());
+        }
 
         // some information
         qDebug() << "Session" << m_sessionName << "selected, command:" << session.exec();


### PR DESCRIPTION
This is problematic as even though we stay on the TTY we tell logind a
different session is in use. This leads to the session being considered
inactive which causes lots of issues.