### PR TITLE
Add support for xcursor size configuration

### DIFF
--- a/data/man/sddm.conf.rst.in
+++ b/data/man/sddm.conf.rst.in
@@ -94,6 +94,9 @@ OPTIONS
 	Name of the cursor theme to be set before starting
 	the display server.
 
+`CursorSize=`
+	Cursor size to be set before starting the display server.
+
 `Font=`
 	Name of the font to be set before starting the
 	display server. Please note that the theme can still override this option.

--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -55,6 +55,7 @@ namespace SDDM {
             Entry(FacesDir,            QString,     _S(DATA_INSTALL_DIR "/faces"),              _S("Global directory for user avatars\n"
                                                                                                    "The files should be named <username>.face.icon"));
             Entry(CursorTheme,         QString,     QString(),                                  _S("Cursor theme used in the greeter"));
+            Entry(CursorSize,          QString,     QString(),                                  _S("Cursor size used in the greeter"));
             Entry(Font,                QString,     QString(),                                  _S("Font used in the greeter"));
             Entry(EnableAvatars,       bool,        true,                                       _S("Enable display of custom user avatars"));
             Entry(DisableAvatarsThreshold,int,      7,                                          _S("Number of users to use as threshold\n"

--- a/src/daemon/Greeter.cpp
+++ b/src/daemon/Greeter.cpp
@@ -91,6 +91,9 @@ namespace SDDM {
         QString xcursorTheme = mainConfig.Theme.CursorTheme.get();
         if (m_themeConfig->contains(QLatin1String("cursorTheme")))
             xcursorTheme = m_themeConfig->value(QLatin1String("cursorTheme")).toString();
+        QString xcursorSize = mainConfig.Theme.CursorSize.get();
+        if (m_themeConfig->contains(QLatin1String("cursorSize")))
+            xcursorSize = m_themeConfig->value(QLatin1String("cursorSize")).toString();
         QString platformTheme;
         if (m_themeConfig->contains(QLatin1String("platformTheme")))
             platformTheme = m_themeConfig->value(QLatin1String("platformTheme")).toString();
@@ -131,6 +134,8 @@ namespace SDDM {
                 env.insert(QStringLiteral("DISPLAY"), m_display->name());
                 env.insert(QStringLiteral("XAUTHORITY"), m_authPath);
                 env.insert(QStringLiteral("XCURSOR_THEME"), xcursorTheme);
+                if (!xcursorSize.isEmpty())
+                    env.insert(QStringLiteral("XCURSOR_SIZE"), xcursorSize);
                 m_process->setProcessEnvironment(env);
             }
             // Greeter command
@@ -187,6 +192,8 @@ namespace SDDM {
 
             env.insert(QStringLiteral("PATH"), mainConfig.Users.DefaultPath.get());
             env.insert(QStringLiteral("XCURSOR_THEME"), xcursorTheme);
+            if (!xcursorSize.isEmpty())
+                env.insert(QStringLiteral("XCURSOR_SIZE"), xcursorSize);
             env.insert(QStringLiteral("XDG_SEAT"), m_display->seat()->name());
             env.insert(QStringLiteral("XDG_SEAT_PATH"), daemonApp->displayManager()->seatPath(m_display->seat()->name()));
             env.insert(QStringLiteral("XDG_SESSION_PATH"), daemonApp->displayManager()->sessionPath(QStringLiteral("Session%1").arg(daemonApp->newSessionId())));


### PR DESCRIPTION
Users of HiDPI screens may wish to set custom cursor size instead of the one automatically selected by default.