### PR TITLE
Address privilege dropping

### DIFF
--- a/src/auth/Auth.cpp
+++ b/src/auth/Auth.cpp
@@ -69,7 +69,6 @@ namespace SDDM {
         bool autologin { false };
         bool greeter { false };
         QProcessEnvironment environment { };
-        qint64 sessionPid { -1 };
         qint64 id { 0 };
         static qint64 lastId;
     };
@@ -194,10 +193,8 @@ namespace SDDM {
             }
             case SESSION_STATUS: {
                 bool status;
-                qint64 pid; //not pid_t as we need to define the wire type
-                str >> status >> pid;
-                sessionPid = pid;
-                Q_EMIT auth->sessionStarted(status, pid);
+                str >> status;
+                Q_EMIT auth->sessionStarted(status);
                 str.reset();
                 str << SESSION_STATUS;
                 str.send();
@@ -299,10 +296,6 @@ namespace SDDM {
 
     AuthRequest *Auth::request() {
         return d->request;
-    }
-
-    qint64 Auth::sessionPid() const {
-        return d->sessionPid;
     }
 
     bool Auth::isActive() const {

--- a/src/auth/Auth.h
+++ b/src/auth/Auth.h
@@ -96,8 +96,6 @@ namespace SDDM {
         const QString &cookie() const;
         const QString &user() const;
         const QString &session() const;
-        qint64 sessionPid() const;
-
         AuthRequest *request();
         /**
          * True if an authentication or session is in progress
@@ -199,7 +197,7 @@ namespace SDDM {
         *
         * @param success true if succeeded
         */
-        void sessionStarted(bool success, qint64 pid);
+        void sessionStarted(bool success);
 
         /**
          * Emitted when the display server is ready.

--- a/src/common/VirtualTerminal.h
+++ b/src/common/VirtualTerminal.h
@@ -22,6 +22,7 @@
 
 namespace SDDM {
     namespace VirtualTerminal {
+        int fetchAvailableVt();
         int setUpNewVt();
         void jumpToVt(int vt, bool vt_auto);
     }

--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -364,7 +364,7 @@ namespace SDDM {
 
         // New VT
         if (session.xdgSessionType() != QLatin1String("x11") || m_displayServerType != X11DisplayServerType) {
-            m_lastSession.setVt(VirtualTerminal::setUpNewVt());
+            m_lastSession.setVt(VirtualTerminal::fetchAvailableVt());
         }
 
         // some information

--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -134,10 +134,6 @@ namespace SDDM {
         return m_displayServer;
     }
 
-    QString Display::displayId() const {
-        return m_displayServer->display();
-    }
-
     const int Display::terminalId() const {
         return m_terminalId;
     }

--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -364,11 +364,14 @@ namespace SDDM {
 
         // New VT
         if (session.xdgSessionType() != QLatin1String("x11") || m_displayServerType != X11DisplayServerType) {
-            m_lastSession.setVt(VirtualTerminal::fetchAvailableVt());
+            if (m_displayServerType == X11DisplayServerType)
+                m_lastSession.setVt(VirtualTerminal::setUpNewVt());
+            else
+                m_lastSession.setVt(VirtualTerminal::fetchAvailableVt());
         }
 
         // some information
-        qDebug() << "Session" << m_sessionName << "selected, command:" << session.exec();
+        qDebug() << "Session" << m_sessionName << "selected, command:" << session.exec() << "for VT" << m_lastSession.vt();
 
         QProcessEnvironment env;
         env.insert(session.additionalEnv());

--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -35,7 +35,6 @@
 #include <QFile>
 #include <QTimer>
 #include <QLocalSocket>
-#include <QByteArray>
 
 #include <pwd.h>
 #include <unistd.h>
@@ -49,10 +48,6 @@
 #include "VirtualTerminal.h"
 #include "WaylandDisplayServer.h"
 
-#if defined(Q_OS_LINUX)
-#include <utmp.h>
-#endif
-#include <utmpx.h>
 
 namespace SDDM {
     Display::Display(Seat *parent) : QObject(parent),
@@ -437,7 +432,6 @@ namespace SDDM {
             if (m_socket)
                 emit loginSucceeded(m_socket);
         } else if (m_socket) {
-            utmpLogin(QString::number(terminalId()),  name(), user, 0, false);
             qDebug() << "Authentication failure";
             emit loginFailed(m_socket);
         }
@@ -462,10 +456,6 @@ namespace SDDM {
     }
 
     void Display::slotHelperFinished(Auth::HelperExitStatus status) {
-        if (m_auth->sessionPid() > 0) {
-            utmpLogout(QString::number(terminalId()), name(), m_auth->sessionPid());
-        }
-
         // Don't restart greeter and display server unless sddm-helper exited
         // with an internal error or the user session finished successfully,
         // we want to avoid greeter from restarting when an authentication
@@ -490,104 +480,7 @@ namespace SDDM {
         }
     }
 
-    void Display::slotSessionStarted(bool success, qint64 pid) {
-        if (success) {
-            utmpLogin(QString::number(terminalId()), name(), m_auth->user(), pid, true);
-        }
+    void Display::slotSessionStarted(bool success) {
+        qDebug() << "Session started";
     }
-
-    void Display::utmpLogin(const QString &vt, const QString &displayName, const QString &user, qint64 pid, bool authSuccessful) {
-        struct utmpx entry;
-        struct timeval tv;
-
-        entry = { 0 };
-        entry.ut_type = USER_PROCESS;
-        entry.ut_pid = pid;
-
-        // ut_line: vt
-        if (!vt.isEmpty()) {
-            QString tty = QStringLiteral("tty");
-            tty.append(vt);
-            QByteArray ttyBa = tty.toLocal8Bit();
-            const char* ttyChar = ttyBa.constData();
-            strncpy(entry.ut_line, ttyChar, sizeof(entry.ut_line) - 1);
-        }
-
-        // ut_host: displayName
-        QByteArray displayBa = displayName.toLocal8Bit();
-        const char* displayChar = displayBa.constData();
-        strncpy(entry.ut_host, displayChar, sizeof(entry.ut_host) - 1);
-
-        // ut_user: user
-        QByteArray userBa = user.toLocal8Bit();
-        const char* userChar = userBa.constData();
-        strncpy(entry.ut_user, userChar, sizeof(entry.ut_user) -1);
-
-        gettimeofday(&tv, NULL);
-        entry.ut_tv.tv_sec = tv.tv_sec;
-        entry.ut_tv.tv_usec = tv.tv_usec;
-
-        // write to utmp
-        setutxent();
-        if (!pututxline (&entry))
-            qWarning() << "Failed to write utmpx: " << strerror(errno);
-        endutxent();
-
-#if !defined(Q_OS_FREEBSD)
-        // append to failed login database btmp
-        if (!authSuccessful) {
-#if defined(Q_OS_LINUX)
-            updwtmpx("/var/log/btmp", &entry);
-#endif
-        }
-
-        // append to wtmp
-        else {
-#if defined(Q_OS_LINUX)
-            updwtmpx("/var/log/wtmp", &entry);
-#endif
-        }
-#endif
-    }
-
-    void Display::utmpLogout(const QString &vt, const QString &displayName, qint64 pid) {
-        struct utmpx entry;
-        struct timeval tv;
-
-        entry = { 0 };
-        entry.ut_type = DEAD_PROCESS;
-        entry.ut_pid = pid;
-
-        // ut_line: vt
-        if (!vt.isEmpty()) {
-            QString tty = QStringLiteral("tty");
-            tty.append(vt);
-            QByteArray ttyBa = tty.toLocal8Bit();
-            const char* ttyChar = ttyBa.constData();
-            strncpy(entry.ut_line, ttyChar, sizeof(entry.ut_line) - 1);
-        }
-
-        // ut_host: displayName
-        QByteArray displayBa = displayName.toLocal8Bit();
-        const char* displayChar = displayBa.constData();
-        strncpy(entry.ut_host, displayChar, sizeof(entry.ut_host) - 1);
-
-        gettimeofday(&tv, NULL);
-        entry.ut_tv.tv_sec = tv.tv_sec;
-        entry.ut_tv.tv_usec = tv.tv_usec;
-
-        // write to utmp
-        setutxent();
-        if (!pututxline (&entry))
-            qWarning() << "Failed to write utmpx: " << strerror(errno);
-        endutxent();
-
-#if defined(Q_OS_LINUX)
-        // append to wtmp
-        updwtmpx("/var/log/wtmp", &entry);
-#elif defined(Q_OS_FREEBSD)
-        pututxline(&entry);
-#endif
-    }
-
 }

--- a/src/daemon/Display.h
+++ b/src/daemon/Display.h
@@ -54,7 +54,6 @@ namespace SDDM {
         DisplayServerType displayServerType() const;
         DisplayServer *displayServer() const;
 
-        QString displayId() const;
         const int terminalId() const;
 
         const QString &name() const;

--- a/src/daemon/Display.h
+++ b/src/daemon/Display.h
@@ -106,28 +106,10 @@ namespace SDDM {
         QLocalSocket *m_socket { nullptr };
         Greeter *m_greeter { nullptr };
 
-        /*!
-         \brief Write utmp/wtmp/btmp records when a user logs in
-         \param vt  Virtual terminal (tty7, tty8,...)
-         \param displayName  Display (:0, :1,...)
-         \param user  User logging in
-         \param pid  User process ID (e.g. PID of startkde)
-         \param authSuccessful  Was authentication successful
-        */
-        void utmpLogin(const QString &vt, const QString &displayName, const QString &user, qint64 pid, bool authSuccessful);
-
-        /*!
-         \brief Write utmp/wtmp records when a user logs out
-         \param vt  Virtual terminal (tty7, tty8,...)
-         \param displayName  Display (:0, :1,...)
-         \param pid  User process ID (e.g. PID of startkde)
-        */
-        void utmpLogout(const QString &vt, const QString &displayName, qint64 pid);
-
     private slots:
         void slotRequestChanged();
         void slotAuthenticationFinished(const QString &user, bool success);
-        void slotSessionStarted(bool success, qint64 pid);
+        void slotSessionStarted(bool success);
         void slotHelperFinished(Auth::HelperExitStatus status);
         void slotAuthInfo(const QString &message, Auth::Info info);
         void slotAuthError(const QString &message, Auth::Error error);

--- a/src/daemon/Seat.cpp
+++ b/src/daemon/Seat.cpp
@@ -77,7 +77,7 @@ namespace SDDM {
     }
 
     void Seat::removeDisplay(Display* display) {
-        qDebug() << "Removing display" << display->displayId() << "...";
+        qDebug() << "Removing display" << display << "...";
 
 
         // remove display from list

--- a/src/helper/CMakeLists.txt
+++ b/src/helper/CMakeLists.txt
@@ -15,10 +15,6 @@ set(HELPER_SOURCES
     Backend.cpp
     HelperApp.cpp
     UserSession.cpp
-    xorguserhelper.cpp
-    xorguserhelper.h
-    waylandhelper.cpp
-    waylandsocketwatcher.cpp
 )
 
 # Different implementations of the VT switching code
@@ -71,3 +67,15 @@ if(JOURNALD_FOUND)
 endif()
 
 install(TARGETS sddm-helper RUNTIME DESTINATION "${CMAKE_INSTALL_LIBEXECDIR}")
+
+add_executable(sddm-helper-start-wayland HelperStartWayland.cpp waylandsocketwatcher.cpp waylandhelper.cpp)
+target_link_libraries(sddm-helper-start-wayland Qt5::Core)
+install(TARGETS sddm-helper-start-wayland RUNTIME DESTINATION "${CMAKE_INSTALL_LIBEXECDIR}")
+
+add_executable(sddm-helper-start-x11user HelperStartX11User.cpp xorguserhelper.cpp
+                                                ${CMAKE_SOURCE_DIR}/src/common/ConfigReader.cpp
+                                                ${CMAKE_SOURCE_DIR}/src/common/Configuration.cpp
+                                                ${CMAKE_SOURCE_DIR}/src/common/XAuth.cpp
+                                                )
+target_link_libraries(sddm-helper-start-x11user Qt5::Core)
+install(TARGETS sddm-helper-start-x11user RUNTIME DESTINATION "${CMAKE_INSTALL_LIBEXECDIR}")

--- a/src/helper/CMakeLists.txt
+++ b/src/helper/CMakeLists.txt
@@ -62,10 +62,6 @@ else()
     target_link_libraries(sddm-helper crypt)
 endif()
 
-if(JOURNALD_FOUND)
-    target_link_libraries(sddm-helper ${JOURNALD_LIBRARIES})
-endif()
-
 install(TARGETS sddm-helper RUNTIME DESTINATION "${CMAKE_INSTALL_LIBEXECDIR}")
 
 add_executable(sddm-helper-start-wayland HelperStartWayland.cpp waylandsocketwatcher.cpp waylandhelper.cpp)
@@ -79,3 +75,9 @@ add_executable(sddm-helper-start-x11user HelperStartX11User.cpp xorguserhelper.c
                                                 )
 target_link_libraries(sddm-helper-start-x11user Qt5::Core)
 install(TARGETS sddm-helper-start-x11user RUNTIME DESTINATION "${CMAKE_INSTALL_LIBEXECDIR}")
+
+if(JOURNALD_FOUND)
+    target_link_libraries(sddm-helper ${JOURNALD_LIBRARIES})
+    target_link_libraries(sddm-helper-start-x11user ${JOURNALD_LIBRARIES})
+    target_link_libraries(sddm-helper-start-wayland ${JOURNALD_LIBRARIES})
+endif()

--- a/src/helper/HelperApp.cpp
+++ b/src/helper/HelperApp.cpp
@@ -144,6 +144,7 @@ namespace SDDM {
             return;
         }
 
+        Q_ASSERT(getuid() == 0);
         if (!m_backend->authenticate()) {
             authenticated(QString());
 
@@ -199,6 +200,8 @@ namespace SDDM {
     }
 
     void HelperApp::sessionFinished(int status) {
+        Q_ASSERT(getuid() == 0);
+
         m_backend->closeSession();
 
         // write logout to utmp/wtmp

--- a/src/helper/HelperApp.cpp
+++ b/src/helper/HelperApp.cpp
@@ -202,7 +202,6 @@ namespace SDDM {
             const QString vt = env.value(QStringLiteral("XDG_VTNR"));
             if (env.value(QStringLiteral("XDG_SESSION_CLASS")) != QLatin1String("greeter")) {
                 // cache pid for session end
-                m_session->setCachedProcessId(m_session->processId());
                 utmpLogin(vt, displayId, m_user, m_session->processId(), true);
             }
         }

--- a/src/helper/HelperApp.cpp
+++ b/src/helper/HelperApp.cpp
@@ -302,6 +302,7 @@ namespace SDDM {
     HelperApp::~HelperApp() {
         Q_ASSERT(getuid() == 0);
 
+        m_session->stop();
         m_backend->closeSession();
 
         // write logout to utmp/wtmp

--- a/src/helper/HelperApp.cpp
+++ b/src/helper/HelperApp.cpp
@@ -67,7 +67,7 @@ namespace SDDM {
     }
 
     void HelperApp::setUp() {
-        QStringList args = QCoreApplication::arguments();
+        const QStringList args = QCoreApplication::arguments();
         QString server;
         int pos;
 
@@ -147,9 +147,9 @@ namespace SDDM {
             authenticated(QString());
 
             // write failed login to btmp
-            QProcessEnvironment env = m_session->processEnvironment();
-            QString displayId = env.value(QStringLiteral("DISPLAY"));
-            QString vt = env.value(QStringLiteral("XDG_VTNR"));
+            const QProcessEnvironment env = m_session->processEnvironment();
+            const QString displayId = env.value(QStringLiteral("DISPLAY"));
+            const QString vt = env.value(QStringLiteral("XDG_VTNR"));
             utmpLogin(vt, displayId, m_user, 0, false);
 
             exit(Auth::HELPER_AUTH_ERROR);
@@ -161,9 +161,9 @@ namespace SDDM {
             authenticated(QString());
 
             // write failed login to btmp
-            QProcessEnvironment env = m_session->processEnvironment();
-            QString displayId = env.value(QStringLiteral("DISPLAY"));
-            QString vt = env.value(QStringLiteral("XDG_VTNR"));
+            const QProcessEnvironment env = m_session->processEnvironment();
+            const QString displayId = env.value(QStringLiteral("DISPLAY"));
+            const QString vt = env.value(QStringLiteral("XDG_VTNR"));
             utmpLogin(vt, displayId, m_user, 0, false);
 
             exit(Auth::HELPER_AUTH_ERROR);
@@ -197,9 +197,9 @@ namespace SDDM {
             sessionOpened(true);
 
             // write successful login to utmp/wtmp
-            QProcessEnvironment env = m_session->processEnvironment();
-            QString displayId = env.value(QStringLiteral("DISPLAY"));
-            QString vt = env.value(QStringLiteral("XDG_VTNR"));
+            const QProcessEnvironment env = m_session->processEnvironment();
+            const QString displayId = env.value(QStringLiteral("DISPLAY"));
+            const QString vt = env.value(QStringLiteral("XDG_VTNR"));
             if (env.value(QStringLiteral("XDG_SESSION_CLASS")) != QLatin1String("greeter")) {
                 // cache pid for session end
                 m_session->setCachedProcessId(m_session->processId());

--- a/src/helper/HelperApp.h
+++ b/src/helper/HelperApp.h
@@ -47,8 +47,8 @@ namespace SDDM {
         void info(const QString &message, Auth::Info type);
         void error(const QString &message, Auth::Error type);
         QProcessEnvironment authenticated(const QString &user);
-        void sessionOpened(bool success, qint64 pid);
         void displayServerStarted(const QString &displayName);
+        void sessionOpened(bool success);
 
     private slots:
         void setUp();
@@ -65,6 +65,23 @@ namespace SDDM {
         // TODO: get rid of this in a nice clean way along the way with moving to user session X server
         QString m_cookie { };
 
+        /*!
+         \brief Write utmp/wtmp/btmp records when a user logs in
+         \param vt  Virtual terminal (tty7, tty8,...)
+         \param displayName  Display (:0, :1,...)
+         \param user  User logging in
+         \param pid  User process ID (e.g. PID of startkde)
+         \param authSuccessful  Was authentication successful
+        */
+        void utmpLogin(const QString &vt, const QString &displayName, const QString &user, qint64 pid, bool authSuccessful);
+
+        /*!
+         \brief Write utmp/wtmp records when a user logs out
+         \param vt  Virtual terminal (tty7, tty8,...)
+         \param displayName  Display (:0, :1,...)
+         \param pid  User process ID (e.g. PID of startkde)
+        */
+        void utmpLogout(const QString &vt, const QString &displayName, qint64 pid);
     };
 }
 

--- a/src/helper/HelperStartWayland.cpp
+++ b/src/helper/HelperStartWayland.cpp
@@ -1,0 +1,55 @@
+/*
+ * Session process wrapper
+ * Copyright (C) 2021 Aleix Pol Gonzalez <aleixpol@kde.org>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+/**
+ * This application sole purpose is to launch a wayland compositor (first
+ * argument) and as soon as it's set up to launch a client (second argument)
+ */
+
+#include <QCoreApplication>
+#include <QTextStream>
+#include <QProcess>
+#include "waylandhelper.h"
+#include <unistd.h>
+
+int main(int argc, char** argv)
+{
+    Q_ASSERT(::getuid() != 0);
+    QCoreApplication app(argc, argv);
+    if (argc != 3) {
+        QTextStream(stderr) << "Wrong number of arguments\n";
+        return 1;
+    }
+
+    using namespace SDDM;
+    WaylandHelper helper;
+    QObject::connect(&app, &QCoreApplication::aboutToQuit, &helper, [&helper] {
+        qDebug("quitting helper-start-wayland");
+        helper.stop();
+    });
+    QObject::connect(&helper, &WaylandHelper::failed, &app, [&app] {
+        QTextStream(stderr) << "Failed to start wayland session" << Qt::endl;
+        app.exit(2);
+    });
+
+    helper.startCompositor(app.arguments()[1]);
+    helper.startGreeter(app.arguments()[2]);
+    return app.exec();
+}

--- a/src/helper/HelperStartWayland.cpp
+++ b/src/helper/HelperStartWayland.cpp
@@ -25,12 +25,16 @@
 
 #include <QCoreApplication>
 #include <QTextStream>
-#include <QProcess>
 #include "waylandhelper.h"
-#include <unistd.h>
+#include "MessageHandler.h"
+
+void WaylandHelperMessageHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg) {
+    SDDM::messageHandler(type, context, QStringLiteral("WaylandHelper: "), msg);
+}
 
 int main(int argc, char** argv)
 {
+    qInstallMessageHandler(WaylandHelperMessageHandler);
     Q_ASSERT(::getuid() != 0);
     QCoreApplication app(argc, argv);
     if (argc != 3) {

--- a/src/helper/HelperStartX11User.cpp
+++ b/src/helper/HelperStartX11User.cpp
@@ -1,0 +1,59 @@
+/*
+ * Session process wrapper
+ * Copyright (C) 2021 Aleix Pol Gonzalez <aleixpol@kde.org>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+/**
+ * This application sole purpose is to launch an X11 rootless compositor compositor (first
+ * argument) and as soon as it's set up to launch a client (second argument)
+ */
+
+#include <QCoreApplication>
+#include <QTextStream>
+#include <QProcess>
+#include "xorguserhelper.h"
+#include <unistd.h>
+
+int main(int argc, char** argv)
+{
+    Q_ASSERT(::getuid() != 0);
+    QCoreApplication app(argc, argv);
+    if (argc != 3) {
+        QTextStream(stderr) << "Wrong number of arguments\n";
+        return 33;
+    }
+
+    using namespace SDDM;
+    XOrgUserHelper helper;
+    QObject::connect(&app, &QCoreApplication::aboutToQuit, &helper, [&helper] {
+        qDebug("quitting helper-start-wayland");
+        helper.stop();
+    });
+    QObject::connect(&helper, &XOrgUserHelper::displayChanged, &app, [&helper, &app] {
+        auto args = QProcess::splitCommand(app.arguments()[2]);
+
+        QProcess *process = new QProcess(&app);
+        process->setProgram(args.takeFirst());
+        process->setArguments(args);
+        process->setProcessEnvironment(helper.sessionEnvironment());
+        process->start();
+    });
+
+    helper.start(app.arguments()[1]);
+    return app.exec();
+}

--- a/src/helper/HelperStartX11User.cpp
+++ b/src/helper/HelperStartX11User.cpp
@@ -60,6 +60,7 @@ int main(int argc, char** argv)
         process->setArguments(args);
         process->setProcessEnvironment(helper.sessionEnvironment());
         process->start();
+        QObject::connect(process, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished), &app, &QCoreApplication::quit);
     });
 
     helper.start(app.arguments()[1]);

--- a/src/helper/UserSession.cpp
+++ b/src/helper/UserSession.cpp
@@ -53,20 +53,22 @@ namespace SDDM {
 
         bool isWaylandGreeter = false;
         if (env.value(QStringLiteral("XDG_SESSION_TYPE")) == QLatin1String("x11")) {
+            QString command;
             if (env.value(QStringLiteral("XDG_SESSION_CLASS")) == QLatin1String("greeter")) {
-                if (m_displayServerCmd.isEmpty()) {
-                    qInfo() << "Starting X11 greeter session:" << m_path;
-                    auto args = QProcess::splitCommand(m_path);
-                    const auto program = args.takeFirst();
-                    QProcess::start(program, args);
-                } else {
-                    QProcess::start(QStringLiteral(LIBEXEC_INSTALL_DIR "/sddm-helper-start-x11user"), {m_displayServerCmd, m_path});
-                }
+                command = m_path;
             } else {
-                const QString cmd = QStringLiteral("%1 \"%2\"").arg(mainConfig.X11.SessionCommand.get()).arg(m_path);
-                qInfo() << "Starting X11 user session:" << cmd;
-                QProcess::start(mainConfig.X11.SessionCommand.get(), QStringList{m_path});
+                command = QStringLiteral("%1 \"%2\"").arg(mainConfig.X11.SessionCommand.get()).arg(m_path);
             }
+
+            qInfo() << "Starting X11 session:" << m_displayServerCmd << command;
+            if (m_displayServerCmd.isEmpty()) {
+                auto args = QProcess::splitCommand(command);
+                const auto program = args.takeFirst();
+                QProcess::start(program, args);
+            } else {
+                QProcess::start(QStringLiteral(LIBEXEC_INSTALL_DIR "/sddm-helper-start-x11user"), {m_displayServerCmd, command});
+            }
+
         } else if (env.value(QStringLiteral("XDG_SESSION_TYPE")) == QLatin1String("wayland")) {
             if (env.value(QStringLiteral("XDG_SESSION_CLASS")) == QLatin1String("greeter")) {
                 Q_ASSERT(!m_displayServerCmd.isEmpty());

--- a/src/helper/UserSession.cpp
+++ b/src/helper/UserSession.cpp
@@ -98,8 +98,15 @@ namespace SDDM {
     void UserSession::stop()
     {
         terminate();
-        if (!waitForFinished(5000))
+        const bool isGreeter = processEnvironment().value(QStringLiteral("XDG_SESSION_CLASS")) == QLatin1String("greeter");
+
+        // Wait longer for a session than a greeter
+        if (!waitForFinished(isGreeter ? 5000 : 60000)) {
             kill();
+            if (!waitForFinished(5000)) {
+                qWarning() << "Could not fully finish the process" << program();
+            }
+        }
 
         Q_EMIT finished(Auth::HELPER_OTHER_ERROR);
     }

--- a/src/helper/UserSession.cpp
+++ b/src/helper/UserSession.cpp
@@ -85,7 +85,9 @@ namespace SDDM {
             qCritical() << "Unable to run user session: unknown session type";
         }
 
-        if (waitForStarted()) {
+        const bool started = waitForStarted();
+        m_cachedProcessId = processId();
+        if (started) {
             return true;
         } else if (isWaylandGreeter) {
             // This is probably fine, we need the compositor to start first
@@ -322,10 +324,6 @@ namespace SDDM {
                 XAuth::addCookieToFile(display, file, cookie);
             }
         }
-    }
-
-    void UserSession::setCachedProcessId(qint64 pid) {
-        m_cachedProcessId = pid;
     }
 
     qint64 UserSession::cachedProcessId() {

--- a/src/helper/UserSession.cpp
+++ b/src/helper/UserSession.cpp
@@ -61,7 +61,8 @@ namespace SDDM {
         auto helper = qobject_cast<HelperApp*>(parent());
         QProcessEnvironment env = helper->session()->processEnvironment();
 
-        setup();
+        // WARNING- THESE ARE CURRENTLY RUN AS ROOT NOW!!!
+        // WE DEFINITELY DO NOT WANT THESE RUN AS ROOT
 
         if (!m_displayServerCmd.isEmpty()) {
             if (env.value(QStringLiteral("XDG_SESSION_TYPE")) == QLatin1String("wayland") && env.value(QStringLiteral("XDG_SESSION_CLASS")) == QLatin1String("greeter")) {
@@ -171,7 +172,7 @@ namespace SDDM {
         return m_process->processId();
     }
 
-    void UserSession::setup() {
+    void UserSession::setupChildProcess() {
         // Session type
         QString sessionType = processEnvironment().value(QStringLiteral("XDG_SESSION_TYPE"));
         QString sessionClass = processEnvironment().value(QStringLiteral("XDG_SESSION_CLASS"));
@@ -365,4 +366,13 @@ namespace SDDM {
             }
         }
     }
+
+    void UserSession::setCachedProcessId(qint64 pid) {
+        m_cachedProcessId = pid;
+    }
+
+    qint64 UserSession::cachedProcessId() {
+        return m_cachedProcessId;
+    }
+
 }

--- a/src/helper/UserSession.h
+++ b/src/helper/UserSession.h
@@ -29,7 +29,7 @@ namespace SDDM {
     class HelperApp;
     class XOrgUserHelper;
     class WaylandHelper;
-    class UserSession : public QObject
+    class UserSession : public QProcess
     {
         Q_OBJECT
     public:
@@ -38,8 +38,8 @@ namespace SDDM {
         bool start();
         void stop();
 
-        QProcessEnvironment processEnvironment() const;
-        void setProcessEnvironment(const QProcessEnvironment &env);
+//         QProcessEnvironment processEnvironment() const;
+//         void setProcessEnvironment(const QProcessEnvironment &env);
 
         QString displayServerCommand() const;
         void setDisplayServerCommand(const QString &command);
@@ -47,7 +47,7 @@ namespace SDDM {
         void setPath(const QString &path);
         QString path() const;
 
-        qint64 processId() const;
+//         qint64 processId() const;
 
         /*!
          \brief Sets m_cachedProcessId. Needed for getting the PID of a finished UserSession
@@ -68,13 +68,12 @@ namespace SDDM {
 
 
     protected:
-        void setupChildProcess();
+        void setupChildProcess() override;
 
     private:
         void setup();
 
         QString m_path { };
-        QProcess *m_process = nullptr;
         XOrgUserHelper *m_xorgUser = nullptr;
         WaylandHelper *m_wayland = nullptr;
         QString m_displayServerCmd;

--- a/src/helper/UserSession.h
+++ b/src/helper/UserSession.h
@@ -45,13 +45,6 @@ namespace SDDM {
         QString path() const;
 
         /*!
-         \brief Sets m_cachedProcessId. Needed for getting the PID of a finished UserSession
-                and calling HelperApp::utmpLogout
-         \param pid  The process ID
-        */
-        void setCachedProcessId(qint64 pid);
-
-        /*!
          \brief Gets m_cachedProcessId
          \return  The cached process ID
         */
@@ -70,6 +63,10 @@ namespace SDDM {
 
         QString m_path { };
         QString m_displayServerCmd;
+
+        /*!
+         Needed for getting the PID of a finished UserSession and calling HelperApp::utmpLogout
+        */
         qint64 m_cachedProcessId = -1;
     };
 }

--- a/src/helper/UserSession.h
+++ b/src/helper/UserSession.h
@@ -78,7 +78,7 @@ namespace SDDM {
         XOrgUserHelper *m_xorgUser = nullptr;
         WaylandHelper *m_wayland = nullptr;
         QString m_displayServerCmd;
-        qint64 m_cachedProcessId;
+        qint64 m_cachedProcessId = -1;
     };
 }
 

--- a/src/helper/UserSession.h
+++ b/src/helper/UserSession.h
@@ -49,8 +49,26 @@ namespace SDDM {
 
         qint64 processId() const;
 
+        /*!
+         \brief Sets m_cachedProcessId. Needed for getting the PID of a finished UserSession
+                and calling HelperApp::utmpLogout
+         \param pid  The process ID
+        */
+        void setCachedProcessId(qint64 pid);
+
+        /*!
+         \brief Gets m_cachedProcessId
+         \return  The cached process ID
+        */
+        qint64 cachedProcessId();
+
+
     Q_SIGNALS:
         void finished(int exitCode);
+
+
+    protected:
+        void setupChildProcess();
 
     private:
         void setup();
@@ -60,6 +78,7 @@ namespace SDDM {
         XOrgUserHelper *m_xorgUser = nullptr;
         WaylandHelper *m_wayland = nullptr;
         QString m_displayServerCmd;
+        qint64 m_cachedProcessId;
     };
 }
 

--- a/src/helper/UserSession.h
+++ b/src/helper/UserSession.h
@@ -38,16 +38,11 @@ namespace SDDM {
         bool start();
         void stop();
 
-//         QProcessEnvironment processEnvironment() const;
-//         void setProcessEnvironment(const QProcessEnvironment &env);
-
         QString displayServerCommand() const;
         void setDisplayServerCommand(const QString &command);
 
         void setPath(const QString &path);
         QString path() const;
-
-//         qint64 processId() const;
 
         /*!
          \brief Sets m_cachedProcessId. Needed for getting the PID of a finished UserSession
@@ -74,8 +69,6 @@ namespace SDDM {
         void setup();
 
         QString m_path { };
-        XOrgUserHelper *m_xorgUser = nullptr;
-        WaylandHelper *m_wayland = nullptr;
         QString m_displayServerCmd;
         qint64 m_cachedProcessId = -1;
     };

--- a/src/helper/waylandhelper.cpp
+++ b/src/helper/waylandhelper.cpp
@@ -71,10 +71,14 @@ void WaylandHelper::stop()
 bool WaylandHelper::startProcess(const QString &cmd, QProcess **p)
 {
     auto *process = new QProcess(this);
-    process->setInputChannelMode(QProcess::ForwardedInputChannel);
-    process->setProcessChannelMode(QProcess::ForwardedChannels);
     process->setProcessEnvironment(m_environment);
-
+    process->setInputChannelMode(QProcess::ForwardedInputChannel);
+    connect(process, &QProcess::readyReadStandardError, this, [process] {
+        qWarning() << process->readAllStandardError();
+    });
+    connect(process, &QProcess::readyReadStandardOutput, this, [process] {
+        qInfo() << process->readAllStandardOutput();
+    });
     qDebug() << "Starting Wayland process" << cmd << m_environment.value(QStringLiteral("USER"));
     connect(process, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished),
             process, [](int exitCode, QProcess::ExitStatus exitStatus) {
@@ -108,6 +112,12 @@ void WaylandHelper::startGreeter(const QString &cmd)
     process->setProgram(args.takeFirst());
     process->setArguments(args);
     process->setProcessEnvironment(m_environment);
+    connect(process, &QProcess::readyReadStandardError, this, [process] {
+        qWarning() << process->readAllStandardError();
+    });
+    connect(process, &QProcess::readyReadStandardOutput, this, [process] {
+        qInfo() << process->readAllStandardOutput();
+    });
     startGreeter(process);
 }
 

--- a/src/helper/waylandhelper.cpp
+++ b/src/helper/waylandhelper.cpp
@@ -34,7 +34,8 @@ namespace SDDM {
 
 WaylandHelper::WaylandHelper(QObject *parent)
     : QObject(parent)
-    , m_watcher(new WaylandSocketWatcher)
+    , m_environment(QProcessEnvironment::systemEnvironment())
+    , m_watcher(new WaylandSocketWatcher(this))
 {
 }
 
@@ -97,6 +98,17 @@ bool WaylandHelper::startProcess(const QString &cmd, QProcess **p)
 
     qDebug() << "started succesfully" << cmd;
     return true;
+}
+
+void WaylandHelper::startGreeter(const QString &cmd)
+{
+    auto args = QProcess::splitCommand(cmd);
+
+    QProcess *process = new QProcess(this);
+    process->setProgram(args.takeFirst());
+    process->setArguments(args);
+    process->setProcessEnvironment(m_environment);
+    startGreeter(process);
 }
 
 void WaylandHelper::startGreeter(QProcess *process)

--- a/src/helper/waylandhelper.h
+++ b/src/helper/waylandhelper.h
@@ -35,13 +35,15 @@ public:
     void setEnvironment(const QProcessEnvironment &env);
 
     bool startCompositor(const QString &cmd);
-    void startGreeter(QProcess *process);
+    void startGreeter(const QString &cmd);
     void stop();
 
 Q_SIGNALS:
     void failed();
 
 private:
+    void startGreeter(QProcess *process);
+
     QProcessEnvironment m_environment;
     QProcess *m_serverProcess = nullptr;
     WaylandSocketWatcher * const m_watcher;

--- a/src/helper/xorguserhelper.cpp
+++ b/src/helper/xorguserhelper.cpp
@@ -32,12 +32,13 @@ namespace SDDM {
 
 XOrgUserHelper::XOrgUserHelper(QObject *parent)
     : QObject(parent)
+    , m_environment(QProcessEnvironment::systemEnvironment())
 {
 }
 
 QProcessEnvironment XOrgUserHelper::sessionEnvironment() const
 {
-    auto env = QProcessEnvironment::systemEnvironment();
+    auto env = m_environment;
     env.insert(QStringLiteral("DISPLAY"), m_display);
     env.insert(QStringLiteral("XAUTHORITY"), m_xauth.authPath());
     env.insert(QStringLiteral("QT_QPA_PLATFORM"), QStringLiteral("xcb"));

--- a/src/helper/xorguserhelper.cpp
+++ b/src/helper/xorguserhelper.cpp
@@ -35,6 +35,15 @@ XOrgUserHelper::XOrgUserHelper(QObject *parent)
 {
 }
 
+QProcessEnvironment XOrgUserHelper::sessionEnvironment() const
+{
+    auto env = QProcessEnvironment::systemEnvironment();
+    env.insert(QStringLiteral("DISPLAY"), m_display);
+    env.insert(QStringLiteral("XAUTHORITY"), m_xauth.authPath());
+    env.insert(QStringLiteral("QT_QPA_PLATFORM"), QStringLiteral("xcb"));
+    return env;
+}
+
 QProcessEnvironment XOrgUserHelper::environment() const
 {
     return m_environment;
@@ -228,15 +237,10 @@ void XOrgUserHelper::startDisplayCommand()
 
 void XOrgUserHelper::displayFinished()
 {
-    auto env = QProcessEnvironment::systemEnvironment();
-    env.insert(QStringLiteral("DISPLAY"), m_display);
-    env.insert(QStringLiteral("XAUTHORITY"), m_xauth.authPath());
-    env.insert(QStringLiteral("QT_QPA_PLATFORM"), QStringLiteral("xcb"));
-
     auto cmd = mainConfig.X11.DisplayStopCommand.get();
     qInfo("Running display stop script: %s", qPrintable(cmd));
     QProcess *displayStopScript = nullptr;
-    if (startProcess(cmd, env, &displayStopScript)) {
+    if (startProcess(cmd, sessionEnvironment(), &displayStopScript)) {
         if (!displayStopScript->waitForFinished(5000))
             displayStopScript->kill();
         displayStopScript->deleteLater();

--- a/src/helper/xorguserhelper.cpp
+++ b/src/helper/xorguserhelper.cpp
@@ -105,10 +105,14 @@ bool XOrgUserHelper::startProcess(const QString &cmd,
     // Make sure to forward the input of this process into the Xorg
     // server, otherwise it will complain that only console users are allowed
     auto *process = new QProcess(this);
-    process->setInputChannelMode(QProcess::ForwardedInputChannel);
-    process->setProcessChannelMode(QProcess::ForwardedChannels);
     process->setProcessEnvironment(env);
-
+    process->setInputChannelMode(QProcess::ForwardedInputChannel);
+    connect(process, &QProcess::readyReadStandardError, this, [process] {
+        qWarning() << process->readAllStandardError();
+    });
+    connect(process, &QProcess::readyReadStandardOutput, this, [process] {
+        qInfo() << process->readAllStandardOutput();
+    });
     connect(process, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished),
             process, [](int exitCode, QProcess::ExitStatus exitStatus) {
         if (exitCode != 0 || exitStatus != QProcess::NormalExit)

--- a/src/helper/xorguserhelper.h
+++ b/src/helper/xorguserhelper.h
@@ -36,6 +36,9 @@ public:
     QProcessEnvironment environment() const;
     void setEnvironment(const QProcessEnvironment &env);
 
+    /// @returns the same as @m environment plus the variables we need here
+    QProcessEnvironment sessionEnvironment() const;
+
     QString display() const;
 
     QString xauthPath() const;


### PR DESCRIPTION
Our sddm-helper needs to stay a root process as it's in charge of dealing with PAM.  Alternatively the pam calls in PamBackend will fail.

To do so, we get helper processes to run xorg+greeter for x11-user and wayland-compositor+greeter for wayland. Obviously for general x11 don't need a helper as it runs as root.