### PR TITLE
Implement system-wide DefaultSession

### DIFF
--- a/data/man/sddm.conf.rst.in
+++ b/data/man/sddm.conf.rst.in
@@ -76,6 +76,12 @@ OPTIONS
 	`/run/netns/mynet`.  Default value is empty.  (The value is ignored if
 	the operating system is not Linux.)
 
+`DefaultSession=`
+	Defines the session file name that will get selected by default.
+	In case `RememberLastSession` is enabled and there is a last session
+	available, that last session will be selected, ignoring this option.
+	Default value is empty.
+
 [Theme] section:
 
 `ThemeDir=`

--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -48,6 +48,7 @@ namespace SDDM {
         Entry(InputMethod,         QString,     QStringLiteral("qtvirtualkeyboard"),                   _S("Input method module"));
         Entry(Namespaces,          QStringList, QStringList(),                                  _S("Comma-separated list of Linux namespaces for user session to enter"));
         Entry(GreeterEnvironment,  QStringList, QStringList(),                                  _S("Comma-separated list of environment variables to be set"));
+        Entry(DefaultSession,      QString,     QString(),                                      _S("System-wide default session file name"));
         //  Name   Entries (but it's a regular class again)
         Section(Theme,
             Entry(ThemeDir,            QString,     _S(DATA_INSTALL_DIR "/themes"),             _S("Theme directory path"));

--- a/src/greeter/SessionModel.h
+++ b/src/greeter/SessionModel.h
@@ -59,6 +59,7 @@ namespace SDDM {
         SessionModelPrivate *d { nullptr };
 
         void populate(Session::Type type, const QStringList &dirPaths);
+        void selectDefaultSession();
     };
 }
 


### PR DESCRIPTION
Close #326

I define the option to accept only the session file name rather than a absolute path, because this configuration is usually written by human, there's no reason to repeat `SessionDir` twice, and this option doesn't need to distinguish between X11 and Wayland.