### PR TITLE
Also spawn a separate tty when greeting

### DIFF
--- a/src/daemon/Greeter.cpp
+++ b/src/daemon/Greeter.cpp
@@ -315,6 +315,11 @@ namespace SDDM {
         }
     }
 
+    bool Greeter::isRunning() const {
+        return (m_process && m_process->state() == QProcess::Running)
+            || (m_auth->isActive());
+    }
+
     void Greeter::onReadyReadStandardError()
     {
         if (m_process) {

--- a/src/daemon/Greeter.h
+++ b/src/daemon/Greeter.h
@@ -44,6 +44,7 @@ namespace SDDM {
 
         QString displayServerCommand() const;
         void setDisplayServerCommand(const QString &cmd);
+        bool isRunning() const;
 
     public slots:
         bool start();


### PR DESCRIPTION
This way we don't need to manage the state of the greeter that closely,
e.g. when auth fails and such, as there's cases where we will need to
have both the greeter and the actual session loaded side by side.