### PR TITLE
Delay for logind, and fallback to seat0

### DIFF
--- a/src/daemon/SeatManager.h
+++ b/src/daemon/SeatManager.h
@@ -49,6 +49,7 @@ namespace SDDM {
     private:
         QHash<QString, Seat *> m_seats; //these will exist only for graphical seats
         QHash<QString, LogindSeat*> m_systemSeats; //these will exist for all seats
+        void checkSeat(void);
     };
 }
 


### PR DESCRIPTION
There is systemd/logind race with when restarting
sddm that causes logind1 not to be available. Previously
this meant the seat0 was immediately created regardless
of the state of CanGraphical.

Fixing this, though we still want seat0 to be started
if none of the seats appear to be graphical. Presumably
there are some graphics on the machine, otherwise
why run sddm? Wait a bit, and create seat0 anyway. If
this fails the output from Xorg should tell us why. This
is generally a better strategy than what happens a good
amount of time now, where sddm is started and silent about
why the screen is blank.
