### PR TITLE
Set XCURSOR_SIZE in XorgDisplayServer::start

### DIFF
--- a/src/daemon/XorgDisplayServer.cpp
+++ b/src/daemon/XorgDisplayServer.cpp
@@ -96,6 +96,9 @@ namespace SDDM {
         // set process environment
         QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
         env.insert(QStringLiteral("XCURSOR_THEME"), mainConfig.Theme.CursorTheme.get());
+        QString xcursorSize = mainConfig.Theme.CursorSize.get();
+        if (!xcursorSize.isEmpty())
+            env.insert(QStringLiteral("XCURSOR_SIZE"), xcursorSize);
         process->setProcessEnvironment(env);
 
         //create pipe for communicating with X server


### PR DESCRIPTION
This fully fixes #569 and #1353, and perhaps even  #965. Although an option to specify a cursor size was given in #1446, this only sets XCURSOR_SIZE in the Greeter; it should also be set during initialisation of the X server to prevent sudden changes in cursor size.