### PR TITLE
WaylandHelper: support non-default display names

### DIFF
--- a/src/helper/waylandhelper.cpp
+++ b/src/helper/waylandhelper.cpp
@@ -119,7 +119,6 @@ void WaylandHelper::startGreeter(const QString &cmd)
     m_greeterProcess = new QProcess(this);
     m_greeterProcess->setProgram(args.takeFirst());
     m_greeterProcess->setArguments(args);
-    m_greeterProcess->setProcessEnvironment(m_environment);
     connect(m_greeterProcess, &QProcess::readyReadStandardError, this, [this] {
         qWarning() << m_greeterProcess->readAllStandardError();
     });
@@ -132,6 +131,8 @@ void WaylandHelper::startGreeter(const QString &cmd)
         QCoreApplication::instance()->quit();
     });
     if (m_watcher->status() == WaylandSocketWatcher::Started) {
+        m_environment.insert(QStringLiteral("WAYLAND_DISPLAY"), m_watcher->socketName());
+        m_greeterProcess->setProcessEnvironment(m_environment);
         m_greeterProcess->start();
     } else if (m_watcher->status() == WaylandSocketWatcher::Failed) {
         Q_EMIT failed();
@@ -139,6 +140,8 @@ void WaylandHelper::startGreeter(const QString &cmd)
         connect(m_watcher, &WaylandSocketWatcher::failed, this, &WaylandHelper::failed);
         connect(m_watcher, &WaylandSocketWatcher::started, this, [this] {
             m_watcher->stop();
+            m_environment.insert(QStringLiteral("WAYLAND_DISPLAY"), m_watcher->socketName());
+            m_greeterProcess->setProcessEnvironment(m_environment);
             m_greeterProcess->start();
         });
     }

--- a/src/helper/waylandsocketwatcher.h
+++ b/src/helper/waylandsocketwatcher.h
@@ -41,7 +41,7 @@ public:
     explicit WaylandSocketWatcher(QObject *parent = nullptr);
 
     Status status() const;
-    QString socketPath() const;
+    QString socketName() const;
 
     void start();
     void stop();
@@ -54,7 +54,7 @@ Q_SIGNALS:
 private:
     Status m_status = Stopped;
     QDir m_runtimeDir;
-    QString m_socketPath;
+    QString m_socketName;
     QTimer m_timer;
     QPointer<QFileSystemWatcher> m_watcher;
 };


### PR DESCRIPTION
Weston v10[1] and some wlroots-based compositors[2],[3] decided to stop using `wayland-0`.
Extend WaylandSocketWatcher to look for any socket matching the `wayland-?` pattern and pass the `WAYLAND_DISPLAY` to the greeter.

[1]: https://gitlab.freedesktop.org/wayland/weston/-/merge_requests/486
[2]: https://github.com/swaywm/sway/commit/65a751a21f61b30808b7e703257c6ca3b71f50eb
[3]: https://github.com/WayfireWM/wayfire/commit/4ee4f3f259be00fd9a3c26960e8fce91ec526290


***
Tested with: sway v1.7 (`wayland-1`), weston v10 (`wayland-1`), weston v8 (`wayland-0`).