### PR TITLE
Improve the SignalHandler

### DIFF
--- a/src/common/SignalHandler.cpp
+++ b/src/common/SignalHandler.cpp
@@ -28,19 +28,11 @@
 #include <sys/socket.h>
 
 namespace SDDM {
-    int sighupFd[2];
     int sigintFd[2];
     int sigtermFd[2];
-    int sigusr1Fd[2];
     int sigcustomFd[2];
 
     SignalHandler::SignalHandler(QObject *parent) : QObject(parent) {
-        if (::socketpair(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0, sighupFd))
-            qCritical() << "Failed to create socket pair for SIGHUP handling.";
-
-        snhup = new QSocketNotifier(sighupFd[1], QSocketNotifier::Read, this);
-        connect(snhup, &QSocketNotifier::activated, this, &SignalHandler::handleSighup);
-
         if (::socketpair(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0, sigintFd))
             qCritical() << "Failed to create socket pair for SIGINT handling.";
 
@@ -53,12 +45,6 @@ namespace SDDM {
         snterm = new QSocketNotifier(sigtermFd[1], QSocketNotifier::Read, this);
         connect(snterm, &QSocketNotifier::activated, this, &SignalHandler::handleSigterm);
 
-        if (::socketpair(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0, sigusr1Fd))
-            qCritical() << "Failed to create socket pair for SIGUSR1 handling.";
-
-        snusr1 = new QSocketNotifier(sigusr1Fd[1], QSocketNotifier::Read, this);
-        connect(snusr1, &QSocketNotifier::activated, this, &SignalHandler::handleSigusr1);
-
         if (::socketpair(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0, sigcustomFd))
             qCritical() << "Failed to create socket pair for custom signals handling.";
 
@@ -67,16 +53,6 @@ namespace SDDM {
     }
 
     void SignalHandler::initialize() {
-        struct sigaction sighup = { };
-        sighup.sa_handler = SignalHandler::hupSignalHandler;
-        sigemptyset(&sighup.sa_mask);
-        sighup.sa_flags = SA_RESTART;
-
-        if (sigaction(SIGHUP, &sighup, 0) > 0) {
-            qCritical() << "Failed to setup SIGHUP handler.";
-            return;
-        }
-
         struct sigaction sigint = { };
         sigint.sa_handler = SignalHandler::intSignalHandler;
         sigemptyset(&sigint.sa_mask);
@@ -98,18 +74,6 @@ namespace SDDM {
         }
     }
 
-    void SignalHandler::initializeSigusr1() {
-        struct sigaction sigusr1 = { };
-        sigusr1.sa_handler = SignalHandler::usr1SignalHandler;
-        sigemptyset(&sigusr1.sa_mask);
-        sigusr1.sa_flags = SA_RESTART;
-
-        if (sigaction(SIGUSR1, &sigusr1, 0) > 0) {
-            qCritical() << "Failed to set up SIGUSR1 handler.";
-            return;
-        }
-    }
-
     void SignalHandler::addCustomSignal(int signal)
     {
         struct sigaction sigcustom = { };
@@ -119,27 +83,6 @@ namespace SDDM {
 
         if (sigaction(signal, &sigcustom, 0) > 0) {
             qCritical() << "Failed to set up " << strsignal(signal) << " handler.";
-            return;
-        }
-    }
-
-
-    void SignalHandler::ignoreSigusr1() {
-        struct sigaction sigusr1 = { };
-        sigusr1.sa_handler = SIG_IGN;
-        sigemptyset(&sigusr1.sa_mask);
-        sigusr1.sa_flags = SA_RESTART;
-
-        if (sigaction(SIGUSR1, &sigusr1, 0) > 0) {
-            qCritical() << "Failed to set up SIGUSR1 handler.";
-            return;
-        }
-    }
-
-    void SignalHandler::hupSignalHandler(int) {
-        char a = 1;
-        if (::write(sighupFd[0], &a, sizeof(a)) == -1) {
-            qCritical() << "Error writing to the SIGHUP handler";
             return;
         }
     }
@@ -160,40 +103,11 @@ namespace SDDM {
         }
     }
 
-    void SignalHandler::usr1SignalHandler(int) {
-        char a = 1;
-        if (::write(sigusr1Fd[0], &a, sizeof(a)) == -1) {
-            qCritical() << "Error writing to the SIGUSR1 handler";
-            return;
-        }
-    }
     void SignalHandler::customSignalHandler(int signal) {
         if (::write(sigcustomFd[0], &signal, sizeof(signal)) == -1) {
             qCritical() << "Error writing to the " << strsignal(signal) << " handler";
             return;
         }
-    }
-
-    void SignalHandler::handleSighup() {
-        // disable notifier
-        snhup->setEnabled(false);
-
-        // read from socket
-        char a;
-        if (::read(sighupFd[1], &a, sizeof(a)) == -1) {
-            // something went wrong!
-            qCritical() << "Error reading from the socket";
-            return;
-        }
-
-        // log event
-        qWarning() << "Signal received: SIGHUP";
-
-        // emit signal
-        emit sighupReceived();
-
-        // enable notifier
-        snhup->setEnabled(true);
     }
 
     void SignalHandler::handleSigint() {
@@ -238,28 +152,6 @@ namespace SDDM {
 
         // enable notifier
         snterm->setEnabled(true);
-    }
-
-    void SignalHandler::handleSigusr1() {
-        // disable notifier
-        snusr1->setEnabled(false);
-
-        // read from socket
-        char a;
-        if (::read(sigusr1Fd[1], &a, sizeof(a)) == -1) {
-            // something went wrong!
-            qCritical() << "Error reading from the socket";
-            return;
-        }
-
-        // log event
-        qWarning() << "Signal received: SIGUSR1";
-
-        // emit signal
-        emit sigusr1Received();
-
-        // enable notifier
-        snusr1->setEnabled(true);
     }
 
     void SignalHandler::handleSigCustom() {

--- a/src/common/SignalHandler.h
+++ b/src/common/SignalHandler.h
@@ -32,12 +32,8 @@ namespace SDDM {
         SignalHandler(QObject *parent = 0);
 
         static void initialize();
-        static void initializeSigusr1();
-        static void ignoreSigusr1();
-        static void hupSignalHandler(int unused);
         static void intSignalHandler(int unused);
         static void termSignalHandler(int unused);
-        static void usr1SignalHandler(int unused);
         static void customSignalHandler(int unused);
 
         void addCustomSignal(int signal);
@@ -46,21 +42,16 @@ namespace SDDM {
         void sighupReceived();
         void sigintReceived();
         void sigtermReceived();
-        void sigusr1Received();
         void customSignalReceived(int signal);
 
     private slots:
-        void handleSighup();
         void handleSigint();
         void handleSigterm();
-        void handleSigusr1();
         void handleSigCustom();
 
     private:
-        QSocketNotifier *snhup { nullptr };
         QSocketNotifier *snint { nullptr };
         QSocketNotifier *snterm { nullptr };
-        QSocketNotifier *snusr1 { nullptr };
         QSocketNotifier *sncustom { nullptr };
     };
 }

--- a/src/common/SignalHandler.h
+++ b/src/common/SignalHandler.h
@@ -31,11 +31,6 @@ namespace SDDM {
     public:
         SignalHandler(QObject *parent = 0);
 
-        static void initialize();
-        static void intSignalHandler(int unused);
-        static void termSignalHandler(int unused);
-        static void customSignalHandler(int unused);
-
         void addCustomSignal(int signal);
 
     signals:
@@ -50,6 +45,11 @@ namespace SDDM {
         void handleSigCustom();
 
     private:
+        static void initialize();
+        static void intSignalHandler(int unused);
+        static void termSignalHandler(int unused);
+        static void customSignalHandler(int unused);
+
         QSocketNotifier *snint { nullptr };
         QSocketNotifier *snterm { nullptr };
         QSocketNotifier *sncustom { nullptr };

--- a/src/daemon/DaemonApp.cpp
+++ b/src/daemon/DaemonApp.cpp
@@ -81,9 +81,6 @@ namespace SDDM {
         // create signal handler
         m_signalHandler = new SignalHandler(this);
 
-        // initialize signal signalHandler
-        SignalHandler::initialize();
-
         // quit when SIGINT, SIGTERM received
         connect(m_signalHandler, &SignalHandler::sigintReceived, this, &DaemonApp::quit);
         connect(m_signalHandler, &SignalHandler::sigtermReceived, this, &DaemonApp::quit);


### PR DESCRIPTION
* Do not require initialize to be called.
* Remove unused code.

We could simplify it further by having all signals go through the one socket.

Fixes #1507 