### PR TITLE
Set QT_USE_PHYSICAL_DPI if hidpi is enabled

### DIFF
--- a/src/greeter/GreeterApp.cpp
+++ b/src/greeter/GreeterApp.cpp
@@ -328,6 +328,7 @@ int main(int argc, char **argv)
     if (hiDpiEnabled) {
         qDebug() << "High-DPI autoscaling Enabled";
         QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+        qputenv("QT_USE_PHYSICAL_DPI", "1");
     } else {
         qDebug() << "High-DPI autoscaling not Enabled";
     }


### PR DESCRIPTION
When the EnableHiDPI config option is set, Qt doesn't
automatically change the dpi of the screen. This requires
manual configuration leaving in the meantime too small fonts
for users with a hidpi monitor.

This commit sets the QT_USE_PHYSICAL_DPI environment variable
when the EnableHiDPI config option is set, which makes Qt
read the monitor edid data using xrandr and calculate the
required DPI to use automatically without user intervention
nor manual configuration.