### PR TITLE
Fix SDDM hanging when shutting down Plasma Wayland session

### DIFF
--- a/services/sddm.service.in
+++ b/services/sddm.service.in
@@ -10,6 +10,7 @@ StartLimitBurst=2
 [Service]
 ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/sddm
 Restart=always
+KillMode=mixed
 
 [Install]
 Alias=display-manager.service

--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -119,7 +119,6 @@ namespace SDDM {
     }
 
     Display::~Display() {
-        disconnect(m_auth, &Auth::finished, this, &Display::slotHelperFinished);
         stop();
     }
 
@@ -245,7 +244,9 @@ namespace SDDM {
         // stop the greeter
         m_greeter->stop();
 
+        m_auth->blockSignals(true);
         m_auth->stop();
+        m_auth->blockSignals(false);
 
         // stop socket server
         m_socketServer->stop();

--- a/src/daemon/Display.h
+++ b/src/daemon/Display.h
@@ -25,6 +25,7 @@
 #include <QObject>
 #include <QPointer>
 #include <QDir>
+#include <QTimer>
 
 #include "Auth.h"
 #include "Session.h"
@@ -103,6 +104,7 @@ namespace SDDM {
         SocketServer *m_socketServer { nullptr };
         QPointer<QLocalSocket> m_socket;
         Greeter *m_greeter { nullptr };
+        QTimer *m_stopTimer { nullptr };
 
     private slots:
         void slotRequestChanged();

--- a/src/helper/HelperApp.cpp
+++ b/src/helper/HelperApp.cpp
@@ -53,6 +53,7 @@ namespace SDDM {
             , m_socket(new QLocalSocket(this)) {
         qInstallMessageHandler(HelperMessageHandler);
         SignalHandler *s = new SignalHandler(this);
+        SignalHandler::initialize();
         QObject::connect(s, &SignalHandler::sigtermReceived, m_session, [this] {
             m_session->stop();
             QCoreApplication::instance()->exit(-1);

--- a/src/helper/HelperStartWayland.cpp
+++ b/src/helper/HelperStartWayland.cpp
@@ -39,6 +39,7 @@ int main(int argc, char** argv)
 {
     qInstallMessageHandler(WaylandHelperMessageHandler);
     SDDM::SignalHandler s;
+    SDDM::SignalHandler::initialize();
     QObject::connect(&s, &SDDM::SignalHandler::sigtermReceived, QCoreApplication::instance(), [] {
         QCoreApplication::instance()->exit(-1);
     });

--- a/src/helper/HelperStartX11User.cpp
+++ b/src/helper/HelperStartX11User.cpp
@@ -41,6 +41,7 @@ int main(int argc, char** argv)
 {
     qInstallMessageHandler(X11UserHelperMessageHandler);
     SDDM::SignalHandler s;
+    SDDM::SignalHandler::initialize();
     QObject::connect(&s, &SDDM::SignalHandler::sigtermReceived, QCoreApplication::instance(), [] {
         QCoreApplication::instance()->exit(-1);
     });


### PR DESCRIPTION
If the sddm-helper receives SIGTERM or the session process terminates
with non zero exit code, delaying restarting display.

The main issue with restarting display at shutdown is that sddm can hang
when trying to get display from Xorg. This is the main reason why shutdown
takes so long with plasma wayland session.

fixes #1476