### PR TITLE
More on SDDM service turn off

### DIFF
--- a/src/greeter/CMakeLists.txt
+++ b/src/greeter/CMakeLists.txt
@@ -8,6 +8,7 @@ set(GREETER_SOURCES
     ${CMAKE_SOURCE_DIR}/src/common/Configuration.cpp
     ${CMAKE_SOURCE_DIR}/src/common/ConfigReader.cpp
     ${CMAKE_SOURCE_DIR}/src/common/Session.cpp
+    ${CMAKE_SOURCE_DIR}/src/common/SignalHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/common/SocketWriter.cpp
     ${CMAKE_SOURCE_DIR}/src/common/ThemeConfig.cpp
     ${CMAKE_SOURCE_DIR}/src/common/ThemeMetadata.cpp

--- a/src/greeter/GreeterApp.cpp
+++ b/src/greeter/GreeterApp.cpp
@@ -24,6 +24,7 @@
 #include "Constants.h"
 #include "ScreenModel.h"
 #include "SessionModel.h"
+#include "SignalHandler.h"
 #include "ThemeConfig.h"
 #include "ThemeMetadata.h"
 #include "UserModel.h"
@@ -270,6 +271,9 @@ namespace SDDM {
         // Set session model on proxy
         m_proxy->setSessionModel(m_sessionModel);
 
+        // If the socket ends, bail. There is not much we can do.
+        connect(m_proxy, &GreeterProxy::socketDisconnected, qGuiApp, &QCoreApplication::quit);
+
         // Create views
         const QList<QScreen *> screens = qGuiApp->primaryScreen()->virtualSiblings();
         for (QScreen *screen : screens)
@@ -348,6 +352,10 @@ int main(int argc, char **argv)
         qputenv("QT_IM_MODULE", SDDM::mainConfig.InputMethod.get().toLocal8Bit().constData());
 
     QGuiApplication app(argc, argv);
+    SDDM::SignalHandler s;
+    QObject::connect(&s, &SDDM::SignalHandler::sigtermReceived, &app, [] {
+        QCoreApplication::instance()->exit(-1);
+    });
 
     QCommandLineParser parser;
     parser.setApplicationDescription(TR("SDDM greeter"));

--- a/src/greeter/GreeterProxy.cpp
+++ b/src/greeter/GreeterProxy.cpp
@@ -138,6 +138,8 @@ namespace SDDM {
     void GreeterProxy::disconnected() {
         // log disconnection
         qDebug() << "Disconnected from the daemon.";
+
+        Q_EMIT socketDisconnected();
     }
 
     void GreeterProxy::error() {

--- a/src/greeter/GreeterProxy.h
+++ b/src/greeter/GreeterProxy.h
@@ -79,6 +79,7 @@ namespace SDDM {
         void canHibernateChanged(bool canHibernate);
         void canHybridSleepChanged(bool canHybridSleep);
 
+        void socketDisconnected();
         void loginFailed();
         void loginSucceeded();
 

--- a/src/helper/HelperStartWayland.cpp
+++ b/src/helper/HelperStartWayland.cpp
@@ -39,12 +39,12 @@ int main(int argc, char** argv)
 {
     qInstallMessageHandler(WaylandHelperMessageHandler);
     SDDM::SignalHandler s;
-    QObject::connect(&s, &SDDM::SignalHandler::sigtermReceived, QCoreApplication::instance(), [] {
+    QCoreApplication app(argc, argv);
+    QObject::connect(&s, &SDDM::SignalHandler::sigtermReceived, &app, [] {
         QCoreApplication::instance()->exit(-1);
     });
 
     Q_ASSERT(::getuid() != 0);
-    QCoreApplication app(argc, argv);
     if (argc != 3) {
         QTextStream(stderr) << "Wrong number of arguments\n";
         return 1;

--- a/src/helper/HelperStartX11User.cpp
+++ b/src/helper/HelperStartX11User.cpp
@@ -41,12 +41,12 @@ int main(int argc, char** argv)
 {
     qInstallMessageHandler(X11UserHelperMessageHandler);
     SDDM::SignalHandler s;
-    QObject::connect(&s, &SDDM::SignalHandler::sigtermReceived, QCoreApplication::instance(), [] {
+    QCoreApplication app(argc, argv);
+    QObject::connect(&s, &SDDM::SignalHandler::sigtermReceived, &app, [] {
         QCoreApplication::instance()->exit(-1);
     });
 
     Q_ASSERT(::getuid() != 0);
-    QCoreApplication app(argc, argv);
     if (argc != 3) {
         QTextStream(stderr) << "Wrong number of arguments\n";
         return 33;


### PR DESCRIPTION
* Address why SIGTERMs were not getting caught in some cases (x11-user, wayland greeters).
* Let the greeter know that it can go in ways that aren't "login successful". i.e. SIGTERM and socket close.