### PR TITLE
VirtualTerminal: do not ignore EINTR when activating

### DIFF
--- a/src/auth/Auth.cpp
+++ b/src/auth/Auth.cpp
@@ -260,6 +260,7 @@ namespace SDDM {
     }
 
     Auth::~Auth() {
+        stop();
         delete d;
     }
 


### PR DESCRIPTION
EINTR can be called at any time when a signal is received but here we
still need to follow through with both ioctl() calls.

This change is inspired by how xserver does more or less the same thing.