### PR TITLE
Address issues when sessions log out

### DIFF
--- a/src/helper/HelperApp.cpp
+++ b/src/helper/HelperApp.cpp
@@ -53,8 +53,7 @@ namespace SDDM {
             , m_socket(new QLocalSocket(this)) {
         qInstallMessageHandler(HelperMessageHandler);
         SignalHandler *s = new SignalHandler(this);
-        QObject::connect(s, &SignalHandler::sigtermReceived, m_session, [this] {
-            m_session->stop();
+        QObject::connect(s, &SignalHandler::sigtermReceived, m_session, [] {
             QCoreApplication::instance()->exit(-1);
         });
 

--- a/src/helper/waylandhelper.cpp
+++ b/src/helper/waylandhelper.cpp
@@ -57,7 +57,7 @@ bool WaylandHelper::startCompositor(const QString &cmd)
 
 void stopProcess(QProcess *process)
 {
-    if (process) {
+    if (process && process->state() != QProcess::NotRunning) {
         qInfo() << "Stopping..." << process->program();
         process->terminate();
         if (!process->waitForFinished(5000))
@@ -124,7 +124,11 @@ void WaylandHelper::startGreeter(const QString &cmd)
     connect(m_greeterProcess, &QProcess::readyReadStandardOutput, this, [this] {
         qInfo() << m_greeterProcess->readAllStandardOutput();
     });
-
+    connect(m_greeterProcess, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished),
+            m_greeterProcess, [](int exitCode, QProcess::ExitStatus exitStatus) {
+        qDebug() << "wayland greeter finished" << exitCode << exitStatus;
+        QCoreApplication::instance()->quit();
+    });
     if (m_watcher->status() == WaylandSocketWatcher::Started) {
         m_greeterProcess->start();
     } else if (m_watcher->status() == WaylandSocketWatcher::Failed) {


### PR DESCRIPTION
* Make sure both processes on the wayland helper end.
* Do not close the session without the rest
* Only offer the active vt if it's available. < needs proper testing on autologin only devices

Fixes #1520, https://bugzilla.redhat.com/show_bug.cgi?id=2057419