### PR TITLE
Search XDG Base Directories for session files

### DIFF
--- a/data/man/sddm.conf.rst.in
+++ b/data/man/sddm.conf.rst.in
@@ -127,8 +127,8 @@ OPTIONS
 	Default value is "/usr/bin/xauth".
 
 `SessionDir=`
-	Path of the directory containing session files.
-	Default value is "/usr/share/xsessions".
+	Comma-separated list of directories containing session files.
+	Default value is "/usr/local/share/xsessions,/usr/share/xsessions".
 
 `SessionCommand=`
 	Path of script to execute when starting the user session. This script
@@ -174,8 +174,8 @@ OPTIONS
         Default value is "weston --shell=fullscreen-shell.so".
 
 `SessionDir=`
-	Path of the directory containing session files.
-	Default value is "/usr/share/wayland-sessions".
+	Comma-separated list of directories containing session files.
+	Default value is "/usr/local/share/wayland-sessions,/usr/share/wayland-sessions".
 
 `SessionCommand=`
 	Path of script to execute when starting the user session. This script

--- a/src/common/ConfigReader.h
+++ b/src/common/ConfigReader.h
@@ -51,8 +51,8 @@
         __VA_ARGS__ \
     }
 // entry wrapper
-#define Entry(name, type, default, description) \
-    SDDM::ConfigEntry<type> name { this, QStringLiteral(#name), (default), (description) }
+#define Entry(name, type, default, description, ...) \
+    SDDM::ConfigEntry<type> name { this, QStringLiteral(#name), default, description, __VA_ARGS__ }
 // section wrapper
 #define Section(name, ...) \
     class name : public SDDM::ConfigSection { \

--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -69,7 +69,8 @@ namespace SDDM {
             Entry(ServerArguments,     QString,     _S("-nolisten tcp"),                        _S("Arguments passed to the X server invocation"));
             Entry(XephyrPath,          QString,     _S("/usr/bin/Xephyr"),                      _S("Path to Xephyr binary"));
             Entry(XauthPath,           QString,     _S("/usr/bin/xauth"),                       _S("Path to xauth binary"));
-            Entry(SessionDir,          QString,     _S("/usr/share/xsessions"),                 _S("Directory containing available X sessions"));
+            Entry(SessionDir,          QStringList, {_S("/usr/local/share/xsessions"),
+                                                     _S("/usr/share/xsessions")},               _S("Comma-separated list of directories containing available X sessions"));
             Entry(SessionCommand,      QString,     _S(SESSION_COMMAND),                        _S("Path to a script to execute when starting the desktop session"));
 	    Entry(SessionLogFile,      QString,     _S(".local/share/sddm/xorg-session.log"),   _S("Path to the user session log file"));
 	    Entry(UserAuthFile,        QString,     _S(".Xauthority"),                          _S("Path to the Xauthority file"));
@@ -80,7 +81,8 @@ namespace SDDM {
 
         Section(Wayland,
             Entry(CompositorCommand,   QString,     _S("weston --shell=fullscreen-shell.so"),   _S("Path of the Wayland compositor to execute when starting the greeter"));
-            Entry(SessionDir,          QString,     _S("/usr/share/wayland-sessions"),          _S("Directory containing available Wayland sessions"));
+            Entry(SessionDir,          QStringList, {_S("/usr/local/share/wayland-sessions"),
+                                                     _S("/usr/share/wayland-sessions")},        _S("Comma-separated list of directories containing available Wayland sessions"));
             Entry(SessionCommand,      QString,     _S(WAYLAND_SESSION_COMMAND),                _S("Path to a script to execute when starting the desktop session"));
 	    Entry(SessionLogFile,      QString,     _S(".local/share/sddm/wayland-session.log"),_S("Path to the user session log file"));
             Entry(EnableHiDPI,         bool,        false,                                      _S("Enable Qt's automatic high-DPI scaling"));

--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -345,12 +345,8 @@ namespace SDDM {
         return QString();
     }
 
-    bool Display::findSessionEntry(const QDir &dir, const QString &name) const {
-        // Given an absolute path: Check that it matches dir
+    bool Display::findSessionEntry(const QStringList &dirPaths, const QString &name) const {
         const QFileInfo fileInfo(name);
-        if (fileInfo.isAbsolute() && fileInfo.absolutePath() != dir.absolutePath())
-            return false;
-
         QString fileName = name;
 
         // append extension
@@ -358,7 +354,17 @@ namespace SDDM {
         if (!fileName.endsWith(extension))
             fileName += extension;
 
-        return dir.exists(fileName);
+        for (const auto &path: dirPaths) {
+            QDir dir = path;
+
+            // Given an absolute path: Check that it matches dir
+            if (fileInfo.isAbsolute() && fileInfo.absolutePath() != dir.absolutePath())
+                continue;
+
+            if (dir.exists(fileName))
+                return true;
+        }
+        return false;
     }
 
     void Display::startAuth(const QString &user, const QString &password, const Session &session) {

--- a/src/daemon/Display.h
+++ b/src/daemon/Display.h
@@ -84,7 +84,7 @@ namespace SDDM {
 
     private:
         QString findGreeterTheme() const;
-        bool findSessionEntry(const QDir &dir, const QString &name) const;
+        bool findSessionEntry(const QStringList &dirPaths, const QString &name) const;
 
         void startAuth(const QString &user, const QString &password,
                        const Session &session);

--- a/src/greeter/SessionModel.cpp
+++ b/src/greeter/SessionModel.cpp
@@ -64,8 +64,8 @@ namespace SDDM {
             populate(Session::X11Session, mainConfig.X11.SessionDir.get());
             endResetModel();
         });
-        watcher->addPath(mainConfig.Wayland.SessionDir.get());
-        watcher->addPath(mainConfig.X11.SessionDir.get());
+        watcher->addPaths(mainConfig.Wayland.SessionDir.get());
+        watcher->addPaths(mainConfig.X11.SessionDir.get());
     }
 
     SessionModel::~SessionModel() {
@@ -124,17 +124,17 @@ namespace SDDM {
         return QVariant();
     }
 
-    void SessionModel::populate(Session::Type type, const QString &path) {
+    void SessionModel::populate(Session::Type type, const QStringList &dirPaths) {
         // read session files
-        QDir dir(path);
-        dir.setNameFilters(QStringList() << QStringLiteral("*.desktop"));
-        dir.setFilter(QDir::Files);
+        QStringList sessions;
+        for (QDir dir: dirPaths) {
+            dir.setNameFilters(QStringList() << QStringLiteral("*.desktop"));
+            dir.setFilter(QDir::Files);
+            sessions += dir.entryList();
+        }
         // read session
-        const auto sessions = dir.entryList();
-        for(const QString &session : sessions) {
-            if (!dir.exists(session))
-                continue;
-
+        sessions.removeDuplicates();
+        for (auto& session : qAsConst(sessions)) {
             Session *si = new Session(type, session);
             bool execAllowed = true;
             QFileInfo fi(si->tryExec());

--- a/src/greeter/SessionModel.h
+++ b/src/greeter/SessionModel.h
@@ -58,7 +58,7 @@ namespace SDDM {
     private:
         SessionModelPrivate *d { nullptr };
 
-        void populate(Session::Type type, const QString &path);
+        void populate(Session::Type type, const QStringList &dirPaths);
     };
 }
 


### PR DESCRIPTION
`SessionDir` config entries are now a lists with default values:
"/usr/local/share/xsessions,/usr/share/xsessions" for [X11] section and
"/usr/local/share/wayland-sessions,/usr/share/wayland-sessions" for
[Wayland] section.

Tries to comply with the following specs clauses (XDG_DATA_DIRS env var is not implemented):
>  If multiple files have the same desktop file ID, the first one in the $XDG_DATA_DIRS precedence order is used. 

https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html

>  If $XDG_DATA_DIRS is either not set or empty, a value equal to /usr/local/share/:/usr/share/ should be used. 

https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html

It's especially important as others Display Managers (GDM, Ly, etc.) are already comply, so we should be able to use session files uniformly.