### PR TITLE
Add a ForceUsers option to display users which are not in passwd

### DIFF
--- a/data/man/sddm.conf.rst.in
+++ b/data/man/sddm.conf.rst.in
@@ -209,6 +209,11 @@ OPTIONS
 	user interface.
 	Default value is @UID_MAX@
 
+`ForceUsers=`
+	Comma-separated list of Users or user IDs that should show up in the user
+	list even if they are not local users.
+	Default value is empty.
+
 `HideUsers=`
 	Comma-separated list of Users that shouldn't show up in the user list.
 	Default value is empty.

--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -90,6 +90,7 @@ namespace SDDM {
             Entry(DefaultPath,         QString,     _S("/usr/local/bin:/usr/bin:/bin"),         _S("Default $PATH for logged in users"));
             Entry(MinimumUid,          int,         UID_MIN,                                    _S("Minimum user id for displayed users"));
             Entry(MaximumUid,          int,         UID_MAX,                                    _S("Maximum user id for displayed users"));
+            Entry(ForceUsers,          QStringList, QStringList(),                              _S("Comma-separated list of users that should be listed in any case"));
             Entry(HideUsers,           QStringList, QStringList(),                              _S("Comma-separated list of users that should not be listed"));
             Entry(HideShells,          QStringList, QStringList(),                              _S("Comma-separated list of shells.\n"
                                                                                                    "Users with these shells as their default won't be listed"));

--- a/src/greeter/UserModel.cpp
+++ b/src/greeter/UserModel.cpp
@@ -72,9 +72,24 @@ namespace SDDM {
         const QString iconURI = QStringLiteral("file://%1").arg(
                 QFile::exists(themeDefaultFace) ? themeDefaultFace : defaultFace);
 
-        bool lastUserFound = false;
-
         struct passwd *current_pw;
+
+        for (auto forced_user : mainConfig.Users.ForceUsers.get()) {
+            bool is_uid = false;
+            int uid = forced_user.toInt(&is_uid);
+            if (is_uid)
+                current_pw = getpwuid(uid);
+            else
+                current_pw = getpwnam(forced_user.toLocal8Bit().data());
+
+            if (current_pw == nullptr)
+                continue;
+
+            UserPtr user { new User(current_pw, iconURI) };
+            d->users << user;
+        }
+
+        bool lastUserFound = false;
         setpwent();
         while ((current_pw = getpwent()) != nullptr) {
 

--- a/src/greeter/UserModel.cpp
+++ b/src/greeter/UserModel.cpp
@@ -35,7 +35,7 @@ namespace SDDM {
     public:
         User(const struct passwd *data, const QString icon) :
             name(QString::fromLocal8Bit(data->pw_name)),
-            realName(QString::fromLocal8Bit(data->pw_gecos).split(QLatin1Char(',')).first()),
+            realName(QString::fromLocal8Bit(data->pw_gecos)),
             homeDir(QString::fromLocal8Bit(data->pw_dir)),
             uid(data->pw_uid),
             gid(data->pw_gid),


### PR DESCRIPTION
The ForceUsers option accepts comma-separated UIDs or Usernames which are resolved using getpwnam/getpwuid. This way, accounts from external authentication providers like LDAP, AD etc. can be forced to be shown.

In addition, this removes the previous behavior of dropping anything after a comma sign from the gecos field. I was not able to find out why this was implemented in the first place - can anyone comment on that? In my case, the displayName LDAP field is formatted like "Surname, First names".