### PR TITLE
PowerManager: enable use of kexec with systemd-logind

### DIFF
--- a/data/interfaces/org.freedesktop.login1.Manager.xml
+++ b/data/interfaces/org.freedesktop.login1.Manager.xml
@@ -2,6 +2,14 @@
 "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
 <node>
  <interface name="org.freedesktop.login1.Manager">
+  <property name="EnableWallMessages" type="b" access="readwrite">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+   <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
+  </property>
+  <property name="WallMessage" type="s" access="readwrite">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+   <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
+  </property>
   <property name="NAutoVTs" type="u" access="read">
    <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
   </property>
@@ -12,6 +20,21 @@
    <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
   </property>
   <property name="KillUserProcesses" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="RebootParameter" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="RebootToFirmwareSetup" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="RebootToBootLoaderMenu" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="RebootToBootLoaderEntry" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="BootLoaderEntries" type="as" access="read">
    <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
   </property>
   <property name="IdleHint" type="b" access="read">
@@ -27,6 +50,9 @@
   <property name="InhibitDelayMaxUSec" type="t" access="read">
    <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
   </property>
+  <property name="UserStopDelayUSec" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
   <property name="HandlePowerKey" type="s" access="read">
    <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
   </property>
@@ -37,6 +63,15 @@
    <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
   </property>
   <property name="HandleLidSwitch" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="HandleLidSwitchExternalPower" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="HandleLidSwitchDocked" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="HoldoffTimeoutUSec" type="t" access="read">
    <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
   </property>
   <property name="IdleAction" type="s" access="read">
@@ -51,60 +86,120 @@
   <property name="PreparingForSleep" type="b" access="read">
    <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
   </property>
+  <property name="ScheduledShutdown" type="(st)" access="read">
+   <annotation name="org.qtproject.QtDBus.QtTypeName" value="ScheduledShutdownInfoList"/>
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="Docked" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="LidClosed" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="OnExternalPower" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="RemoveIPC" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="RuntimeDirectorySize" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="RuntimeDirectoryInodesMax" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="InhibitorsMax" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="NCurrentInhibitors" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="SessionsMax" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="NCurrentSessions" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
   <method name="GetSession">
-   <arg type="s" direction="in"/>
-   <arg type="o" direction="out"/>
+   <arg type="s" name="session_id" direction="in"/>
+   <arg type="o" name="object_path" direction="out"/>
   </method>
   <method name="GetSessionByPID">
-   <arg type="u" direction="in"/>
-   <arg type="o" direction="out"/>
+   <arg type="u" name="pid" direction="in"/>
+   <arg type="o" name="object_path" direction="out"/>
   </method>
   <method name="GetUser">
-   <arg type="u" direction="in"/>
-   <arg type="o" direction="out"/>
+   <arg type="u" name="uid" direction="in"/>
+   <arg type="o" name="object_path" direction="out"/>
   </method>
   <method name="GetUserByPID">
-   <arg type="u" direction="in"/>
-   <arg type="o" direction="out"/>
+   <arg type="u" name="pid" direction="in"/>
+   <arg type="o" name="object_path" direction="out"/>
   </method>
   <method name="GetSeat">
-   <arg type="s" direction="in"/>
-   <arg type="o" direction="out"/>
+   <arg type="s" name="seat_id" direction="in"/>
+   <arg type="o" name="object_path" direction="out"/>
   </method>
   <method name="ListSessions">
-   <arg type="a(susso)" direction="out"/>
    <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="SessionInfoList"/>
+   <arg type="a(susso)" name="sessions" direction="out"/>
   </method>
   <method name="ListUsers">
-   <arg type="a(uso)" direction="out"/>
    <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="UserInfoList"/>
+   <arg type="a(uso)" name="users" direction="out"/>
   </method>
   <method name="ListSeats">
-   <arg type="a(so)" direction="out"/>
    <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="NamedSeatPathList"/>
+   <arg type="a(so)" name="seats" direction="out"/>
   </method>
   <method name="ListInhibitors">
-   <arg type="a(ssssuu)" direction="out"/>
    <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="InhibitorList"/>
+   <arg type="a(ssssuu)" name="inhibitors" direction="out"/>
+  </method>
+  <method name="CreateSession">
+   <arg type="u" name="uid" direction="in"/>
+   <arg type="u" name="pid" direction="in"/>
+   <arg type="s" name="service" direction="in"/>
+   <arg type="s" name="type" direction="in"/>
+   <arg type="s" name="_class" direction="in"/>
+   <arg type="s" name="desktop" direction="in"/>
+   <arg type="s" name="seat_id" direction="in"/>
+   <arg type="u" name="vtnr" direction="in"/>
+   <arg type="s" name="tty" direction="in"/>
+   <arg type="s" name="display" direction="in"/>
+   <arg type="b" name="remote" direction="in"/>
+   <arg type="s" name="remote_user" direction="in"/>
+   <arg type="s" name="remote_host" direction="in"/>
+   <annotation name="org.qtproject.QtDBus.QtTypeName.In13" value="CreateSessionPropertiesInfoList"/>
+   <arg type="a(sv)" name="properties" direction="in"/>
+   <arg type="s" name="session_id" direction="out"/>
+   <arg type="o" name="object_path" direction="out"/>
+   <arg type="s" name="runtime_path" direction="out"/>
+   <arg type="h" name="fifo_fd" direction="out"/>
+   <arg type="u" name="uid" direction="out"/>
+   <arg type="s" name="seat_id" direction="out"/>
+   <arg type="u" name="vtnr" direction="out"/>
+   <arg type="b" name="existing" direction="out"/>
+   <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
   </method>
   <method name="ReleaseSession">
-   <arg type="s" direction="in"/>
+   <arg type="s" name="session_id" direction="in"/>
    <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
   </method>
   <method name="ActivateSession">
-   <arg type="s" direction="in"/>
+   <arg type="s" name="session_id" direction="in"/>
   </method>
   <method name="ActivateSessionOnSeat">
-   <arg type="s" direction="in"/>
-   <arg type="s" direction="in"/>
+   <arg type="s" name="session_id" direction="in"/>
+   <arg type="s" name="seat_id" direction="in"/>
   </method>
   <method name="LockSession">
-   <arg type="s" direction="in"/>
    <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
+   <arg type="s" name="session_id" direction="in"/>
   </method>
   <method name="UnlockSession">
-   <arg type="s" direction="in"/>
    <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
+   <arg type="s" name="session_id" direction="in"/>
   </method>
   <method name="LockSessions">
    <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
@@ -113,108 +208,175 @@
    <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
   </method>
   <method name="KillSession">
-   <arg type="s" direction="in"/>
-   <arg type="s" direction="in"/>
-   <arg type="i" direction="in"/>
    <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
+   <arg type="s" name="session_id" direction="in"/>
+   <arg type="s" name="who" direction="in"/>
+   <arg type="i" name="signal_number" direction="in"/>
   </method>
   <method name="KillUser">
-   <arg type="u" direction="in"/>
-   <arg type="i" direction="in"/>
    <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
+   <arg type="u" name="uid" direction="in"/>
+   <arg type="i" name="signal_number" direction="in"/>
   </method>
   <method name="TerminateSession">
-   <arg type="s" direction="in"/>
    <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
+   <arg type="s" name="session_id" direction="in"/>
   </method>
   <method name="TerminateUser">
-   <arg type="u" direction="in"/>
    <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
+   <arg type="u" name="uid" direction="in"/>
   </method>
   <method name="TerminateSeat">
-   <arg type="s" direction="in"/>
    <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
+   <arg type="s" name="seat_id" direction="in"/>
   </method>
   <method name="SetUserLinger">
-   <arg type="u" direction="in"/>
-   <arg type="b" direction="in"/>
-   <arg type="b" direction="in"/>
+   <arg type="u" name="uid" direction="in"/>
+   <arg type="b" name="enable" direction="in"/>
+   <arg type="b" name="interactive" direction="in"/>
   </method>
   <method name="AttachDevice">
-   <arg type="s" direction="in"/>
-   <arg type="s" direction="in"/>
-   <arg type="b" direction="in"/>
+   <arg type="s" name="seat_id" direction="in"/>
+   <arg type="s" name="sysfs_path" direction="in"/>
+   <arg type="b" name="interactive" direction="in"/>
   </method>
   <method name="FlushDevices">
-   <arg type="b" direction="in"/>
+   <arg type="b" name="interactive" direction="in"/>
   </method>
   <method name="PowerOff">
-   <arg type="b" direction="in"/>
+   <arg type="b" name="interactive" direction="in"/>
+  </method>
+  <method name="PowerOffWithFlags">
+   <arg type="t" name="flags" direction="in"/>
   </method>
   <method name="Reboot">
-   <arg type="b" direction="in"/>
+   <arg type="b" name="interactive" direction="in"/>
+  </method>
+  <method name="RebootWithFlags">
+   <arg type="t" name="flags" direction="in"/>
+  </method>
+  <method name="Halt">
+   <arg type="b" name="interactive" direction="in"/>
+  </method>
+  <method name="HaltWithFlags">
+   <arg type="t" name="flags" direction="in"/>
   </method>
   <method name="Suspend">
-   <arg type="b" direction="in"/>
+   <arg type="b" name="interactive" direction="in"/>
+  </method>
+  <method name="SuspendWithFlags">
+   <arg type="t" name="flags" direction="in"/>
   </method>
   <method name="Hibernate">
-   <arg type="b" direction="in"/>
+   <arg type="b" name="interactive" direction="in"/>
+  </method>
+  <method name="HibernateWithFlags">
+   <arg type="t" name="flags" direction="in"/>
   </method>
   <method name="HybridSleep">
-   <arg type="b" direction="in"/>
+   <arg type="b" name="interactive" direction="in"/>
+  </method>
+  <method name="HybridSleepWithFlags">
+   <arg type="t" name="flags" direction="in"/>
+  </method>
+  <method name="SuspendThenHibernate">
+   <arg type="b" name="interactive" direction="in"/>
+  </method>
+  <method name="SuspendThenHibernateWithFlags">
+   <arg type="t" name="flags" direction="in"/>
   </method>
   <method name="CanPowerOff">
-   <arg type="s" direction="out"/>
+   <arg type="s" name="result" direction="out"/>
   </method>
   <method name="CanReboot">
-   <arg type="s" direction="out"/>
+   <arg type="s" name="result" direction="out"/>
+  </method>
+  <method name="CanHalt">
+   <arg type="s" name="result" direction="out"/>
   </method>
   <method name="CanSuspend">
-   <arg type="s" direction="out"/>
+   <arg type="s" name="result" direction="out"/>
   </method>
   <method name="CanHibernate">
-   <arg type="s" direction="out"/>
+   <arg type="s" name="result" direction="out"/>
   </method>
   <method name="CanHybridSleep">
-   <arg type="s" direction="out"/>
+   <arg type="s" name="result" direction="out"/>
+  </method>
+  <method name="CanSuspendThenHibernate">
+   <arg type="s" name="result" direction="out"/>
+  </method>
+  <method name="ScheduleShutdown">
+   <arg type="s" name="type" direction="in"/>
+   <arg type="t" name="usec" direction="in"/>
+  </method>
+  <method name="CancelScheduledShutdown">
+   <arg type="b" name="cancelled" direction="out"/>
   </method>
   <method name="Inhibit">
-   <arg type="s" direction="in"/>
-   <arg type="s" direction="in"/>
-   <arg type="s" direction="in"/>
-   <arg type="s" direction="in"/>
-   <arg type="h" direction="out"/>
+   <arg type="s" name="what" direction="in"/>
+   <arg type="s" name="who" direction="in"/>
+   <arg type="s" name="why" direction="in"/>
+   <arg type="s" name="mode" direction="in"/>
+   <arg type="h" name="pipe_fd" direction="out"/>
+  </method>
+  <method name="CanRebootParameter">
+   <arg type="s" name="result" direction="out"/>
+  </method>
+  <method name="SetRebootParameter">
+   <arg type="s" name="parameter" direction="in"/>
+  </method>
+  <method name="CanRebootToFirmwareSetup">
+   <arg type="s" name="result" direction="out"/>
+  </method>
+  <method name="SetRebootToFirmwareSetup">
+   <arg type="b" name="enable" direction="in"/>
+  </method>
+  <method name="CanRebootToBootLoaderMenu">
+   <arg type="s" name="result" direction="out"/>
+  </method>
+  <method name="SetRebootToBootLoaderMenu">
+   <arg type="t" name="timeout" direction="in"/>
+  </method>
+  <method name="CanRebootToBootLoaderEntry">
+   <arg type="s" name="result" direction="out"/>
+  </method>
+  <method name="SetRebootToBootLoaderEntry">
+   <arg type="s" name="boot_loader_entry" direction="in"/>
+  </method>
+  <method name="SetWallMessage">
+   <arg type="s" name="wall_message" direction="in"/>
+   <arg type="b" name="enable" direction="in"/>
   </method>
   <signal name="SessionNew">
-   <arg type="s"/>
-   <arg type="o"/>
+   <arg type="s" name="session_id"/>
+   <arg type="o" name="object_path"/>
   </signal>
   <signal name="SessionRemoved">
-   <arg type="s"/>
-   <arg type="o"/>
+   <arg type="s" name="session_id"/>
+   <arg type="o" name="object_path"/>
   </signal>
   <signal name="UserNew">
-   <arg type="u"/>
-   <arg type="o"/>
+   <arg type="u" name="uid"/>
+   <arg type="o" name="object_path"/>
   </signal>
   <signal name="UserRemoved">
-   <arg type="u"/>
-   <arg type="o"/>
+   <arg type="u" name="uid"/>
+   <arg type="o" name="object_path"/>
   </signal>
   <signal name="SeatNew">
-   <arg type="s"/>
-   <arg type="o"/>
+   <arg type="s" name="seat_id"/>
+   <arg type="o" name="object_path"/>
   </signal>
   <signal name="SeatRemoved">
-   <arg type="s"/>
-   <arg type="o"/>
+   <arg type="s" name="seat_id"/>
+   <arg type="o" name="object_path"/>
   </signal>
   <signal name="PrepareForShutdown">
-   <arg type="b"/>
+   <arg type="b" name="start"/>
   </signal>
   <signal name="PrepareForSleep">
-   <arg type="b"/>
+   <arg type="b" name="start"/>
   </signal>
  </interface>
 </node>
-

--- a/src/daemon/LogindDBusTypes.cpp
+++ b/src/daemon/LogindDBusTypes.cpp
@@ -34,6 +34,18 @@ LogindPathInternal::LogindPathInternal()
     qRegisterMetaType<NamedSessionPathList>("NamedSessionPathList");
     qDBusRegisterMetaType<NamedSessionPathList>();
 
+    qRegisterMetaType<ScheduledShutdownInfo>("ScheduledShutdownInfo");
+    qDBusRegisterMetaType<ScheduledShutdownInfo>();
+
+    qRegisterMetaType<ScheduledShutdownInfoList>("ScheduledShutdownInfoList");
+    qDBusRegisterMetaType<ScheduledShutdownInfoList>();
+
+    qRegisterMetaType<CreateSessionPropertiesInfo>("CreateSessionPropertiesInfo");
+    qDBusRegisterMetaType<CreateSessionPropertiesInfo>();
+
+    qRegisterMetaType<CreateSessionPropertiesInfoList>("CreateSessionPropertiesInfoList");
+    qDBusRegisterMetaType<CreateSessionPropertiesInfoList>();
+
     qRegisterMetaType<SessionInfo>("SessionInfo");
     qDBusRegisterMetaType<SessionInfo>();
 

--- a/src/daemon/LogindDBusTypes.h
+++ b/src/daemon/LogindDBusTypes.h
@@ -15,6 +15,71 @@ struct Logind
     static QString userIfaceName();
 };
 
+struct ScheduledShutdownInfo
+{
+    QString type;
+    quint64 microseconds;
+};
+
+typedef QList<ScheduledShutdownInfo> ScheduledShutdownInfoList;
+
+inline QDBusArgument &operator<<(QDBusArgument &argument, const ScheduledShutdownInfo& scheduledShutdownInfo)
+{
+    argument.beginStructure();
+    argument << scheduledShutdownInfo.type;
+    argument << scheduledShutdownInfo.microseconds;
+    argument.endStructure();
+
+    return argument;
+}
+
+inline const QDBusArgument &operator>>(const QDBusArgument &argument, ScheduledShutdownInfo &scheduledShutdownInfo)
+{
+    argument.beginStructure();
+    argument >> scheduledShutdownInfo.type;
+    argument >> scheduledShutdownInfo.microseconds;
+    argument.endStructure();
+
+    return argument;
+}
+
+Q_DECLARE_METATYPE(ScheduledShutdownInfo);
+Q_DECLARE_METATYPE(QList<ScheduledShutdownInfo>);
+
+/*  <arg type="a(sv)" name="properties" direction="in"/>
+  <annotion name="org.qtproject.QtDBus.QtTypeName.In0" value="CreateSessionPropertiesInfoList"/>
+*/
+
+struct CreateSessionPropertiesInfo
+{
+    QString key;
+    QVariantMap value;
+};
+
+typedef QList<CreateSessionPropertiesInfo> CreateSessionPropertiesInfoList;
+
+inline QDBusArgument &operator<<(QDBusArgument &argument, const CreateSessionPropertiesInfo& createSessionPropertiesInfo)
+{
+    argument.beginStructure();
+    argument << createSessionPropertiesInfo.key;
+    argument << createSessionPropertiesInfo.value;
+    argument.endStructure();
+
+    return argument;
+}
+
+inline const QDBusArgument &operator>>(const QDBusArgument &argument, CreateSessionPropertiesInfo &createSessionPropertiesInfo)
+{
+    argument.beginStructure();
+    argument >> createSessionPropertiesInfo.key;
+    argument >> createSessionPropertiesInfo.value;
+    argument.endStructure();
+
+    return argument;
+}
+
+Q_DECLARE_METATYPE(CreateSessionPropertiesInfo);
+Q_DECLARE_METATYPE(QList<CreateSessionPropertiesInfo>);
 
 struct SessionInfo
 {


### PR DESCRIPTION
DBus interface has changed, interface XML required re-generation via
introspection, and custom types defining for IN/OUT arguments, all so
login1.Manager.RebootWithFlags() can be used.

Addresses: issue #434.