### PR TITLE
CI: Use KDE's CI images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,20 +22,19 @@ jobs:
           - gcc
           - clang
         container:
-          #- suse-qt512
-          - suse-qt515
+          - ci-suse-qt515
         pam:
           - ON
           - OFF
     runs-on: ubuntu-latest
     container:
-      image: liridev/${{ matrix.container }}
+      image: kdeorg/${{ matrix.container }}
     steps:
       - uses: actions/checkout@v2
       - name: Dependencies
         run: |
           set -x
-          zypper --non-interactive install python38-docutils
+          zypper --non-interactive install python3-docutils extra-cmake-modules sudo
       - name: Build
         run: |
           set -x


### PR DESCRIPTION
The current ones seem to be out of date and these we need to maintain anyway for many other projects.