### PR TITLE
Address shutdown lockups

### DIFF
--- a/src/auth/Auth.cpp
+++ b/src/auth/Auth.cpp
@@ -383,6 +383,10 @@ namespace SDDM {
     }
 
     void Auth::stop() {
+        if (d->child->state() == QProcess::NotRunning) {
+            return;
+        }
+
         d->child->terminate();
 
         // wait for finished

--- a/src/common/SignalHandler.cpp
+++ b/src/common/SignalHandler.cpp
@@ -19,6 +19,7 @@
 
 #include "SignalHandler.h"
 
+#include <QCoreApplication>
 #include <QDebug>
 #include <QSocketNotifier>
 
@@ -37,6 +38,9 @@ namespace SDDM {
 
     SignalHandler::SignalHandler(QObject *parent) : QObject(parent) {
         std::call_once(signalsInitialized, &initialize);
+
+        // If it's done before creating the QCoreApplication, it just will not work
+        Q_ASSERT(QCoreApplication::instance());
 
         snint = new QSocketNotifier(sigintFd[1], QSocketNotifier::Read, this);
         connect(snint, &QSocketNotifier::activated, this, &SignalHandler::handleSigint);

--- a/src/helper/HelperStartWayland.cpp
+++ b/src/helper/HelperStartWayland.cpp
@@ -50,6 +50,9 @@ int main(int argc, char** argv)
 
     using namespace SDDM;
     WaylandHelper helper;
+    QObject::connect(&s, &SDDM::SignalHandler::sigtermReceived, &app, [] {
+        QCoreApplication::exit(0);
+    });
     QObject::connect(&app, &QCoreApplication::aboutToQuit, &helper, [&helper] {
         qDebug("quitting helper-start-wayland");
         helper.stop();

--- a/src/helper/HelperStartWayland.cpp
+++ b/src/helper/HelperStartWayland.cpp
@@ -39,11 +39,8 @@ void WaylandHelperMessageHandler(QtMsgType type, const QMessageLogContext &conte
 int main(int argc, char** argv)
 {
     qInstallMessageHandler(WaylandHelperMessageHandler);
-    SDDM::SignalHandler s;
     QCoreApplication app(argc, argv);
-    QObject::connect(&s, &SDDM::SignalHandler::sigtermReceived, &app, [] {
-        QCoreApplication::instance()->exit(-1);
-    });
+    SDDM::SignalHandler s;
 
     Q_ASSERT(::getuid() != 0);
     if (argc != 3) {

--- a/src/helper/HelperStartX11User.cpp
+++ b/src/helper/HelperStartX11User.cpp
@@ -40,8 +40,8 @@ void X11UserHelperMessageHandler(QtMsgType type, const QMessageLogContext &conte
 int main(int argc, char** argv)
 {
     qInstallMessageHandler(X11UserHelperMessageHandler);
-    SDDM::SignalHandler s;
     QCoreApplication app(argc, argv);
+    SDDM::SignalHandler s;
     QObject::connect(&s, &SDDM::SignalHandler::sigtermReceived, &app, [] {
         QCoreApplication::instance()->exit(-1);
     });


### PR DESCRIPTION
* Makes sure our helper processes receive the sigterms as necessary, assert if the API is misused.
* Always react to sigterm signals.
* Do not wait for a process that isn't started to finish.