### PR TITLE
disable automatic portal launching

### DIFF
--- a/src/greeter/GreeterApp.cpp
+++ b/src/greeter/GreeterApp.cpp
@@ -349,6 +349,8 @@ int main(int argc, char **argv)
     // crash handler which we don't want counterintuitively setting this env
     // disables that handler
     qputenv("KDE_DEBUG", "1");
+    // Qt internally may load the xdg portal system early on, prevent this, we do not have a functional session running.
+    qputenv("QT_NO_XDG_DESKTOP_PORTAL", "1");
 
     // Qt IM module
     if (!SDDM::mainConfig.InputMethod.get().isEmpty())


### PR DESCRIPTION
in Qt6 (and the KDE patch collection for Qt 5) genericunixservices will internally attempt to probe the portal tech early on in the app life cycle. this causes the protal system to launch app and then crash because we aren't actually providing a fully functional session. instead opt out of this altogether