### PR TITLE
Provide a fallback mechanism for failed sessions

### DIFF
--- a/src/auth/Auth.h
+++ b/src/auth/Auth.h
@@ -84,7 +84,8 @@ namespace SDDM {
             HELPER_SUCCESS = 0,
             HELPER_AUTH_ERROR,
             HELPER_SESSION_ERROR,
-            HELPER_OTHER_ERROR
+            HELPER_OTHER_ERROR,
+            HELPER_DISPLAYSERVER_ERROR,
         };
         Q_ENUM(HelperExitStatus)
 

--- a/src/common/MessageHandler.h
+++ b/src/common/MessageHandler.h
@@ -30,6 +30,8 @@
 
 #include <stdio.h>
 
+#undef HAVE_JOURNALD
+
 #ifdef HAVE_JOURNALD
 #include <systemd/sd-journal.h>
 #include <unistd.h>

--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -83,40 +83,45 @@ namespace SDDM {
         return VirtualTerminal::setUpNewVt();
     }
 
-    Display::Display(Seat *parent) : QObject(parent),
-        m_auth(new Auth(this)),
-        m_seat(parent),
-        m_socketServer(new SocketServer(this)),
-        m_greeter(new Greeter(this)) {
-
-
-        // Save display server type
+    Display::DisplayServerType Display::defaultDisplayServerType()
+    {
         const QString &displayServerType = mainConfig.DisplayServer.get().toLower();
+        DisplayServerType ret;
         if (displayServerType == QStringLiteral("x11-user")) {
-            m_displayServerType = X11UserDisplayServerType;
-            m_terminalId = fetchAvailableVt();
+            ret = X11UserDisplayServerType;
         } else if (displayServerType == QStringLiteral("wayland")) {
-            m_displayServerType = WaylandDisplayServerType;
-            m_terminalId = fetchAvailableVt();
+            ret = WaylandDisplayServerType;
         } else {
             if (displayServerType != QLatin1String("x11")) {
                 qWarning("\"%s\" is an invalid value for General.DisplayServer: fall back to \"x11\"",
-                     qPrintable(displayServerType));
+                    qPrintable(displayServerType));
             }
-            m_terminalId = VirtualTerminal::setUpNewVt();
-            m_displayServerType = X11DisplayServerType;
+            ret = X11DisplayServerType;
         }
+        return ret;
+    }
 
+    Display::Display(Seat *parent, DisplayServerType serverType)
+        : QObject(parent),
+        m_displayServerType(serverType),
+        m_auth(new Auth(this)),
+        m_seat(parent),
+        m_socketServer(new SocketServer(this)),
+        m_greeter(new Greeter(this))
+    {
         // Create display server
         switch (m_displayServerType) {
         case X11DisplayServerType:
+            m_terminalId = VirtualTerminal::setUpNewVt();
             m_displayServer = new XorgDisplayServer(this);
             break;
         case X11UserDisplayServerType:
+            m_terminalId = fetchAvailableVt();
             m_displayServer = new XorgUserDisplayServer(this);
             m_greeter->setDisplayServerCommand(XorgUserDisplayServer::command(this));
             break;
         case WaylandDisplayServerType:
+            m_terminalId = fetchAvailableVt();
             m_displayServer = new WaylandDisplayServer(this);
             m_greeter->setDisplayServerCommand(mainConfig.Wayland.CompositorCommand.get());
             break;
@@ -148,6 +153,7 @@ namespace SDDM {
                 QCoreApplication::instance(), [] {
                     QCoreApplication::instance()->exit(23);
                 });
+        connect(m_greeter, &Greeter::displayServerFailed, this, &Display::displayServerFailed);
     }
 
     Display::~Display() {

--- a/src/daemon/Display.h
+++ b/src/daemon/Display.h
@@ -49,7 +49,8 @@ namespace SDDM {
         };
         Q_ENUM(DisplayServerType)
 
-        explicit Display(Seat *parent);
+        static DisplayServerType defaultDisplayServerType();
+        explicit Display(Seat *parent, DisplayServerType serverType);
         ~Display();
 
         DisplayServerType displayServerType() const;
@@ -75,6 +76,7 @@ namespace SDDM {
 
     signals:
         void stopped();
+        void displayServerFailed();
 
         void loginFailed(QLocalSocket *socket);
         void loginSucceeded(QLocalSocket *socket);

--- a/src/daemon/Greeter.cpp
+++ b/src/daemon/Greeter.cpp
@@ -310,6 +310,10 @@ namespace SDDM {
         m_auth->deleteLater();
         m_auth = nullptr;
 
+        if (status == Auth::HELPER_DISPLAYSERVER_ERROR) {
+            Q_EMIT displayServerFailed();
+        }
+
         if (status == Auth::HELPER_SESSION_ERROR) {
             Q_EMIT failed();
         }

--- a/src/daemon/Greeter.h
+++ b/src/daemon/Greeter.h
@@ -63,6 +63,7 @@ namespace SDDM {
 
     signals:
         void failed();
+        void displayServerFailed();
 
     private:
         bool m_started { false };

--- a/src/daemon/Seat.cpp
+++ b/src/daemon/Seat.cpp
@@ -34,23 +34,37 @@
 
 namespace SDDM {
     Seat::Seat(const QString &name, QObject *parent) : QObject(parent), m_name(name) {
-        createDisplay();
+        createDisplay(Display::defaultDisplayServerType());
     }
 
     const QString &Seat::name() const {
         return m_name;
     }
 
-    void Seat::createDisplay() {
+    void Seat::createDisplay(Display::DisplayServerType serverType) {
         //reload config if needed
         mainConfig.load();
 
         // create a new display
         qDebug() << "Adding new display...";
-        Display *display = new Display(this);
+        Display *display = new Display(this, serverType);
 
         // restart display on stop
         connect(display, &Display::stopped, this, &Seat::displayStopped);
+        connect(display, &Display::displayServerFailed, this, [this, display] {
+            removeDisplay(display);
+
+            // If we failed to create a display with wayland or rootful x11, try with
+            // x11-user. There's a chance it might work. It's a handy fallback
+            // since the alternative is a black screen
+            if (display->displayServerType() != Display::X11UserDisplayServerType) {
+                qWarning() << "Failed to launch the display server, falling back to DisplayServer=x11-user";
+                createDisplay(Display::X11UserDisplayServerType);
+            } else if (m_displays.isEmpty()) {
+                qWarning() << "Failed to launch a DisplayServer=x11-user session, aborting";
+                QCoreApplication::instance()->exit(12);
+            }
+        });
 
         // add display to the list
         m_displays << display;
@@ -100,7 +114,7 @@ namespace SDDM {
 
         // restart otherwise
         if (m_displays.isEmpty()) {
-            createDisplay();
+            createDisplay(Display::defaultDisplayServerType());
         }
         // If there is still a session running on some display,
         // switch to last display in display vector.

--- a/src/daemon/Seat.h
+++ b/src/daemon/Seat.h
@@ -22,6 +22,7 @@
 
 #include <QObject>
 #include <QVector>
+#include "Display.h"
 
 namespace SDDM {
     class Display;
@@ -33,9 +34,9 @@ namespace SDDM {
         explicit Seat(const QString &name, QObject *parent = 0);
 
         const QString &name() const;
+        void createDisplay(Display::DisplayServerType serverType);
 
     public slots:
-        void createDisplay();
         void removeDisplay(SDDM::Display* display);
 
     private slots:

--- a/src/daemon/SeatManager.cpp
+++ b/src/daemon/SeatManager.cpp
@@ -149,7 +149,7 @@ namespace SDDM {
             return;
 
         // switch to greeter
-        m_seats.value(name)->createDisplay();
+        m_seats.value(name)->createDisplay(Display::defaultDisplayServerType());
     }
 
     void SDDM::SeatManager::logindSeatAdded(const QString& name, const QDBusObjectPath& objectPath)

--- a/src/helper/HelperStartWayland.cpp
+++ b/src/helper/HelperStartWayland.cpp
@@ -30,6 +30,7 @@
 #include "waylandhelper.h"
 #include "MessageHandler.h"
 #include <signal.h>
+#include "Auth.h"
 #include "SignalHandler.h"
 
 void WaylandHelperMessageHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg) {
@@ -40,15 +41,15 @@ int main(int argc, char** argv)
 {
     qInstallMessageHandler(WaylandHelperMessageHandler);
     QCoreApplication app(argc, argv);
+    using namespace SDDM;
     SDDM::SignalHandler s;
 
     Q_ASSERT(::getuid() != 0);
     if (argc != 3) {
         QTextStream(stderr) << "Wrong number of arguments\n";
-        return 1;
+        return Auth::HELPER_OTHER_ERROR;
     }
 
-    using namespace SDDM;
     WaylandHelper helper;
     QObject::connect(&s, &SDDM::SignalHandler::sigtermReceived, &app, [] {
         QCoreApplication::exit(0);
@@ -59,12 +60,12 @@ int main(int argc, char** argv)
     });
     QObject::connect(&helper, &WaylandHelper::failed, &app, [&app] {
         QTextStream(stderr) << "Failed to start wayland session" << Qt::endl;
-        app.exit(2);
+        app.exit(Auth::HELPER_SESSION_ERROR);
     });
 
     if (!helper.startCompositor(app.arguments()[1])) {
         qWarning() << "SDDM was unable to start" << app.arguments()[1];
-        return 3;
+        return Auth::HELPER_DISPLAYSERVER_ERROR;
     }
     helper.startGreeter(app.arguments()[2]);
     return app.exec();


### PR DESCRIPTION
If a session fails to load, we go into the greeter. If the greeter fails to load, we are in trouble.
This change adds a fallback into launch the greeter in a x11-user setup in case that happens as a failsafe.

To test you can configure DisplayServer=wayland and set an unexisting CompositorCommand (e.g. `CompositorCommand=banana`).

An extra test would be to add a faulty autologin session on all of that above.