### PR TITLE
x11: Also run xsessions on the greeter session

### DIFF
--- a/src/helper/UserSession.cpp
+++ b/src/helper/UserSession.cpp
@@ -54,12 +54,7 @@ namespace SDDM {
 
         bool isWaylandGreeter = false;
         if (env.value(QStringLiteral("XDG_SESSION_TYPE")) == QLatin1String("x11")) {
-            QString command;
-            if (env.value(QStringLiteral("XDG_SESSION_CLASS")) == QLatin1String("greeter")) {
-                command = m_path;
-            } else {
-                command = QStringLiteral("%1 \"%2\"").arg(mainConfig.X11.SessionCommand.get()).arg(m_path);
-            }
+            const QString command = QStringLiteral("%1 \"%2\"").arg(mainConfig.X11.SessionCommand.get()).arg(m_path);
 
             qInfo() << "Starting X11 session:" << m_displayServerCmd << command;
             if (m_displayServerCmd.isEmpty()) {


### PR DESCRIPTION
It initializes things that seem necessary at times, like scripts to initialize how to load, like xrandr scripts.

To test, add a script in `/etc/X11/Xsessions.d/` and see it getting executed.