### PR TITLE
Allow recovering from tty switching failures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,6 +197,7 @@ set(SYSTEM_CONFIG_DIR           "${CMAKE_INSTALL_PREFIX}/lib/sddm/sddm.conf.d"  
 set(LOG_FILE                    "${CMAKE_INSTALL_FULL_LOCALSTATEDIR}/log/sddm.log"  CACHE PATH      "Path of the sddm log file")
 set(DBUS_CONFIG_FILENAME        "org.freedesktop.DisplayManager.conf"               CACHE STRING    "Name of the sddm config file")
 set(COMPONENTS_TRANSLATION_DIR  "${DATA_INSTALL_DIR}/translations"                  CACHE PATH      "Components translations directory")
+set(SDDM_INITIAL_VT             "1"                                                 CACHE STRING    "Initial tty to use")
 
 
 # Autodetect UID_MIN and UID_MAX from /etc/login.defs

--- a/README.md
+++ b/README.md
@@ -47,6 +47,17 @@ Distributions without pam and systemd will need to put the "sddm" user
 into the "video" group, otherwise errors regarding GL and drm devices
 might be experienced.
 
+## VIRTUAL TERMINALS
+
+SDDM is assumed to start at the tty specified by the cmake variable
+SDDM_INITIAL_VT which is an integer and defaults to 1.
+
+If SDDM_INITIAL_VT wasn't available, SDDM will use the next available one
+instead.
+
+You can override SDDM_INITIAL_VT if you want to have a different one if,
+for example, you were planning on using tty1 for something else.
+
 ## LICENSE
 
 Source code of SDDM is licensed under GNU GPL version 2 or later (at your choosing).

--- a/services/sddm.service.in
+++ b/services/sddm.service.in
@@ -1,8 +1,8 @@
 [Unit]
 Description=Simple Desktop Display Manager
 Documentation=man:sddm(1) man:sddm.conf(5)
-Conflicts=getty@tty1.service
-After=systemd-user-sessions.service getty@tty1.service plymouth-quit.service systemd-logind.service
+Conflicts=getty@tty${SDDM_INITIAL_VT}.service
+After=systemd-user-sessions.service getty@tty${SDDM_INITIAL_VT}.service plymouth-quit.service systemd-logind.service
 PartOf=graphical.target
 StartLimitIntervalSec=30
 StartLimitBurst=2

--- a/src/auth/Auth.h
+++ b/src/auth/Auth.h
@@ -86,6 +86,7 @@ namespace SDDM {
             HELPER_SESSION_ERROR,
             HELPER_OTHER_ERROR,
             HELPER_DISPLAYSERVER_ERROR,
+            HELPER_TTY_ERROR,
         };
         Q_ENUM(HelperExitStatus)
 

--- a/src/daemon/CMakeLists.txt
+++ b/src/daemon/CMakeLists.txt
@@ -5,6 +5,7 @@ include_directories(
     "${LIBXCB_INCLUDE_DIR}"
 )
 
+configure_file(config.h.in config.h IMMEDIATE @ONLY)
 set(DAEMON_SOURCES
     ${CMAKE_SOURCE_DIR}/src/common/Configuration.cpp
     ${CMAKE_SOURCE_DIR}/src/common/SafeDataStream.cpp

--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -52,6 +52,8 @@
 #include "VirtualTerminal.h"
 #include "WaylandDisplayServer.h"
 
+static int s_ttyFailures = 0;
+
 
 namespace SDDM {
     bool isTtyInUse(const QString &desiredTty) {
@@ -149,10 +151,17 @@ namespace SDDM {
         connect(this, &Display::loginFailed, m_socketServer, &SocketServer::loginFailed);
         connect(this, &Display::loginSucceeded, m_socketServer, &SocketServer::loginSucceeded);
 
-        connect(m_greeter, &Greeter::failed,
-                QCoreApplication::instance(), [] {
-                    QCoreApplication::instance()->exit(23);
-                });
+        connect(m_greeter, &Greeter::failed, this, &Display::stop);
+        connect(m_greeter, &Greeter::ttyFailed, this, [this] {
+            ++s_ttyFailures;
+            if (s_ttyFailures > 5) {
+                QCoreApplication::exit(23);
+            }
+            // It might be the case that we are trying a tty that has been taken over by a
+            // different process. In such a case, switch back to the initial one and try again.
+            VirtualTerminal::jumpToVt(1, true);
+            stop();
+        });
         connect(m_greeter, &Greeter::displayServerFailed, this, &Display::displayServerFailed);
     }
 

--- a/src/daemon/Greeter.cpp
+++ b/src/daemon/Greeter.cpp
@@ -32,6 +32,7 @@
 
 #include <QtCore/QDebug>
 #include <QtCore/QProcess>
+#include <VirtualTerminal.h>
 
 namespace SDDM {
     Greeter::Greeter(Display *parent)
@@ -312,9 +313,9 @@ namespace SDDM {
 
         if (status == Auth::HELPER_DISPLAYSERVER_ERROR) {
             Q_EMIT displayServerFailed();
-        }
-
-        if (status == Auth::HELPER_SESSION_ERROR) {
+        } else if (status == Auth::HELPER_TTY_ERROR) {
+            Q_EMIT ttyFailed();
+        } else if (status == Auth::HELPER_SESSION_ERROR) {
             Q_EMIT failed();
         }
     }

--- a/src/daemon/Greeter.h
+++ b/src/daemon/Greeter.h
@@ -62,6 +62,7 @@ namespace SDDM {
         void authError(const QString &message, Auth::Error error);
 
     signals:
+        void ttyFailed();
         void failed();
         void displayServerFailed();
 

--- a/src/daemon/config.h.in
+++ b/src/daemon/config.h.in
@@ -1,0 +1,2 @@
+#pragma once
+static const int SDDM_INITIAL_VT = @SDDM_INITIAL_VT@;

--- a/src/helper/UserSession.cpp
+++ b/src/helper/UserSession.cpp
@@ -180,7 +180,7 @@ namespace SDDM {
                 if (ioctl(STDIN_FILENO, TIOCSCTTY) < 0) {
                     const auto error = strerror(errno);
                     qCritical().nospace() << "Failed to take control of " << ttyString << " (" << QFileInfo(ttyString).owner() << "): " << error;
-                    exit(Auth::HELPER_OTHER_ERROR);
+                    exit(Auth::HELPER_TTY_ERROR);
                 }
             }
 


### PR DESCRIPTION
If we fail to switch tty when showing the greeter, exit saying so then switch back to tty 1 and try launching the Display again.

Fixes #1636

~~Draft because:~~
- ~~we should avoid looping infinitely.~~ works
- ~~we should do something similar for autologin use cases.~~ works
- ~~we should do something similar for user switching use cases.~~ https://github.com/sddm/sddm/issues/1642