### PR TITLE
Fix user switching

### DIFF
--- a/src/daemon/Display.h
+++ b/src/daemon/Display.h
@@ -61,6 +61,7 @@ namespace SDDM {
         const QString &name() const;
 
         QString sessionType() const;
+        QString reuseSessionId() const { return m_reuseSessionId; }
 
         Seat *seat() const;
 
@@ -94,6 +95,7 @@ namespace SDDM {
         bool m_started { false };
 
         int m_terminalId = 0;
+        int m_sessionTerminalId = 0;
 
         QString m_passPhrase;
         QString m_sessionName;


### PR DESCRIPTION
Make sure we don't start a new session if we are switching. Update the terminalId (i.e. tty) Display property as we switch from the greeter to the actual session, as they might be on different terminals now.

~~WIP because we rely on Seat::displayStopped to choose the correct tty to jump to.~~

Fixes #1642 