### PR TITLE
ThemeConfig: Provide typed accessors to values

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
           sudo sed -i '/^#\sdeb-src /s/^#//' "/etc/apt/sources.list"
           sudo apt-get update -y
           DEBIAN_FRONTEND=noninteractive sudo apt-get build-dep sddm -y
-          DEBIAN_FRONTEND=noninteractive sudo apt-get install clang clazy sudo -y
+          DEBIAN_FRONTEND=noninteractive sudo apt-get install clang clazy sudo qml-module-qttest -y
       - name: Build
         run: |
           set -x
@@ -49,3 +49,8 @@ jobs:
             -DENABLE_PAM:BOOL=${{ matrix.pam }}
           make -j $(getconf _NPROCESSORS_ONLN)
           sudo make install
+      - name: Test
+        env:
+          CTEST_OUTPUT_ON_FAILURE: "1"
+        working-directory: build
+        run: make test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,7 +99,7 @@ find_package(XCB REQUIRED)
 find_package(XKB REQUIRED)
 
 # Qt 5
-find_package(Qt5 5.15.0 CONFIG REQUIRED Core DBus Gui Qml Quick LinguistTools Test)
+find_package(Qt5 5.15.0 CONFIG REQUIRED Core DBus Gui Qml Quick LinguistTools Test QuickTest)
 
 # find qt5 imports dir
 get_target_property(QMAKE_EXECUTABLE Qt5::qmake LOCATION)

--- a/src/common/ThemeConfig.cpp
+++ b/src/common/ThemeConfig.cpp
@@ -1,4 +1,5 @@
 /***************************************************************************
+* Copyright (c) 2023 Fabian Vogt <fabian@ritter-vogt.de>
 * Copyright (c) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
 * Copyright (c) 2014 David Edmundson <davidedmundson@kde.org>
 * Copyright (c) 2013 Abdurrahman AVCI <abdurrahmanavci@gmail.com>
@@ -26,12 +27,15 @@
 #include <QStringList>
 
 namespace SDDM {
-    ThemeConfig::ThemeConfig(const QString &path) {
+    ThemeConfig::ThemeConfig(const QString &path, QObject *parent)
+        : QQmlPropertyMap(this, parent) {
         setTo(path);
     }
 
     void ThemeConfig::setTo(const QString &path) {
-        clear();
+        for(const QString &key : keys()) {
+            clear(key);
+        }
 
         if (path.isNull()) {
             qDebug() << "Loaded empty theme configuration";
@@ -65,5 +69,39 @@ namespace SDDM {
         if (settings.contains(QStringLiteral("background"))) {
             insert(QStringLiteral("defaultBackground"), settings.value(QStringLiteral("background")));
         }
+    }
+
+    QVariant ThemeConfig::value(const QString &key, const QVariant &def) {
+        if (!contains(key)) {
+            return def;
+        }
+
+        return value(key);
+    }
+
+    bool ThemeConfig::boolValue(const QString &key) {
+        return value(key).toBool();
+    }
+
+    int ThemeConfig::intValue(const QString &key) {
+        bool ok;
+        auto ret = value(key).toInt(&ok);
+        if (!ok) {
+            qWarning() << "Could not convert" << key << "(value" << value(key) << ") to int";
+        }
+        return ret;
+    }
+
+    qreal ThemeConfig::realValue(const QString &key) {
+        bool ok;
+        auto ret = value(key).toReal(&ok);
+        if (!ok) {
+            qWarning() << "Could not convert" << key << "(value" << value(key) << ") to real";
+        }
+        return ret;
+    }
+
+    QString ThemeConfig::stringValue(const QString &key) {
+        return value(key).toString();
     }
 }

--- a/src/common/ThemeConfig.h
+++ b/src/common/ThemeConfig.h
@@ -21,14 +21,26 @@
 #ifndef SDDM_THEMECONFIG_H
 #define SDDM_THEMECONFIG_H
 
-#include <QVariantMap>
+#include <QQmlPropertyMap>
 
 namespace SDDM {
-    class ThemeConfig : public QVariantMap {
+    class ThemeConfig : public QQmlPropertyMap {
+        Q_OBJECT
     public:
-        explicit ThemeConfig(const QString &path);
+        explicit ThemeConfig(const QString &path, QObject *parent = nullptr);
 
         void setTo(const QString &path);
+
+        // Also provide QVariantMap's value(key, default) method
+        using QQmlPropertyMap::value;
+        QVariant value(const QString &key, const QVariant &def);
+
+        // QSettings::IniFormat returns string types for basic
+        // types. Let the theme request specific conversions.
+        Q_INVOKABLE bool boolValue(const QString &key);
+        Q_INVOKABLE int intValue(const QString &key);
+        Q_INVOKABLE qreal realValue(const QString &key);
+        Q_INVOKABLE QString stringValue(const QString &key);
     };
 }
 

--- a/src/greeter/GreeterApp.cpp
+++ b/src/greeter/GreeterApp.cpp
@@ -112,7 +112,7 @@ namespace SDDM {
         if (m_themeConfig)
             m_themeConfig->setTo(configFile);
         else
-            m_themeConfig = new ThemeConfig(configFile);
+            m_themeConfig = new ThemeConfig(configFile, this);
 
         const bool themeNeedsAllUsers = m_themeConfig->value(QStringLiteral("needsFullUserModel"), true).toBool();
         if(m_userModel && themeNeedsAllUsers && !m_userModel->containsAllUsers()) {
@@ -187,7 +187,7 @@ namespace SDDM {
         view->rootContext()->setContextProperty(QStringLiteral("sessionModel"), m_sessionModel);
         view->rootContext()->setContextProperty(QStringLiteral("screenModel"), screenModel);
         view->rootContext()->setContextProperty(QStringLiteral("userModel"), m_userModel);
-        view->rootContext()->setContextProperty(QStringLiteral("config"), *m_themeConfig);
+        view->rootContext()->setContextProperty(QStringLiteral("config"), m_themeConfig);
         view->rootContext()->setContextProperty(QStringLiteral("sddm"), m_proxy);
         view->rootContext()->setContextProperty(QStringLiteral("keyboard"), m_keyboard);
         view->rootContext()->setContextProperty(QStringLiteral("primaryScreen"), QGuiApplication::primaryScreen() == screen);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,3 +7,8 @@ add_executable(ConfigurationTest ${ConfigurationTest_SRCS})
 add_test(NAME Configuration COMMAND ConfigurationTest)
 
 target_link_libraries(ConfigurationTest Qt5::Core Qt5::Test)
+
+set(QMLThemeConfigTest_SRCS QMLThemeConfigTest.cpp ../src/common/ThemeConfig.cpp ../src/common/ThemeConfig.h)
+add_executable(QMLThemeConfigTest ${QMLThemeConfigTest_SRCS})
+add_test(NAME QMLThemeConfig COMMAND QMLThemeConfigTest)
+target_link_libraries(QMLThemeConfigTest Qt5::QuickTest)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,5 +10,6 @@ target_link_libraries(ConfigurationTest Qt5::Core Qt5::Test)
 
 set(QMLThemeConfigTest_SRCS QMLThemeConfigTest.cpp ../src/common/ThemeConfig.cpp ../src/common/ThemeConfig.h)
 add_executable(QMLThemeConfigTest ${QMLThemeConfigTest_SRCS})
-add_test(NAME QMLThemeConfig COMMAND QMLThemeConfigTest)
-target_link_libraries(QMLThemeConfigTest Qt5::QuickTest)
+target_include_directories(QMLThemeConfigTest PRIVATE ../src/common/)
+add_test(NAME QMLThemeConfig COMMAND QMLThemeConfigTest -platform offscreen -input ${CMAKE_CURRENT_SOURCE_DIR}/QMLThemeConfigTest.qml WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(QMLThemeConfigTest PRIVATE Qt5::Quick Qt5::QuickTest)

--- a/test/QMLThemeConfigTest.cpp
+++ b/test/QMLThemeConfigTest.cpp
@@ -1,0 +1,39 @@
+/***************************************************************************
+* Copyright (c) 2023 Fabian Vogt <fabian@ritter-vogt.de>
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 2 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, write to the
+* Free Software Foundation, Inc.,
+* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+***************************************************************************/
+
+#include <QQmlContext>
+#include <QQmlEngine>
+#include <QtQuickTest>
+
+#include "ThemeConfig.h"
+
+class Setup : public QObject
+{
+    Q_OBJECT
+public slots:
+    void qmlEngineAvailable(QQmlEngine *engine)
+    {
+        auto *config = new SDDM::ThemeConfig(QStringLiteral("theme.conf"), this);
+        engine->rootContext()->setContextProperty(QStringLiteral("config"), config);
+    }
+};
+
+QUICK_TEST_MAIN_WITH_SETUP(QMLThemeConfigTest, Setup)
+
+#include "QMLThemeConfigTest.moc"

--- a/test/QMLThemeConfigTest.qml
+++ b/test/QMLThemeConfigTest.qml
@@ -1,0 +1,67 @@
+/***************************************************************************
+* Copyright (c) 2023 Fabian Vogt <fabian@ritter-vogt.de>
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 2 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, write to the
+* Free Software Foundation, Inc.,
+* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+***************************************************************************/
+
+import QtQuick 2.3
+import QtTest 1.0
+
+TestCase {
+    name: "QMLThemeConfigTest"
+
+    function test_keys() {
+        let keys = Object.keys(config);
+        compare(keys.indexOf("doesnotexist"), -1);
+        verify(keys.indexOf("someInteger") >= 0);
+        keys = config.keys();
+        compare(keys.indexOf("doesnotexist"), -1);
+        verify(keys.indexOf("someInteger") >= 0);
+    }
+
+    // Everything is a string
+    function test_propertyAPI() {
+        compare(config.doesnotexist, undefined);
+        compare(config.someTrueBool, "yes");
+        compare(!!config.someTrueBool, true);
+        compare(config.someFalseBool, "false");
+        // "false" as a string is truthy!
+        compare(!!config.someFalseBool, true);
+        compare(config.someInteger, "042");
+        compare(+config.someInteger, 42);
+        compare(config.someRealNumber, "01.5");
+        compare(+config.someRealNumber, 1.5);
+        compare(config.someString, "Pie/180");
+    }
+
+    // Strings are converted to specific types
+    function test_typedAPI() {
+        compare(config.stringValue("doesnotexist"), "");
+        compare(config.boolValue("someTrueBool"), true);
+        compare(config.boolValue("someFalseBool"), false);
+        // "false" as a string is truthy!
+        compare(!!config.someFalseBool, true);
+        compare(config.stringValue("someInteger"), "042");
+        compare(config.intValue("someInteger"), 42);
+        compare(config.realValue("someRealNumber"), 1.5);
+        // conversion fails -> 0
+        compare(config.intValue("someRealNumber"), 0);
+        compare(config.stringValue("someString"), "Pie/180");
+        // conversion fails -> 0
+        compare(config.intValue("someString"), 0);
+        compare(config.realValue("someString"), 0);
+    }
+}

--- a/test/theme.conf
+++ b/test/theme.conf
@@ -1,0 +1,6 @@
+[General]
+someTrueBool=yes
+someFalseBool=false
+someInteger=042
+someRealNumber=01.5
+someString="Pie/180"


### PR DESCRIPTION
Some methods are added to interpret theme.conf settings as bool, int, real and string explicitly. Previously, most basic types were returned as string and needed manual handling in QML code.

To allow exporting those methods to QML, it was necessary to port the class from QVariantMap over to QQmlPropertyMap. A single method had to be added to make it API compatible with the rest of the code.

Small breaking change: This returns more members when used with Object.keys, e.g. the added methods and QObject's objectName.

Fixes #1097

Test:

theme.conf:

```
[General]
showlogo=hidden
logo=/usr/share/sddm/themes/breeze/default-logo.svg
type=image
color=#1d99f3
fontSize=10
background=components/artwork/1920x1080.jpg
something=007
```

Main.qml:

```
console.log(Object.keys(config))
console.log(config.something)
console.log(config.boolValue("something"))
console.log(config.stringValue("something"))
console.log(config.intValue("something"))
console.log(config.realValue("something"))
```

Output:

```
qml: [objectName,background,color,fontSize,logo,showlogo,something,type,defaultBackground,alwaysShowClock,objectNameChanged,valueChanged,keys,boolValue,intValue,realValue,stringValue,__0,__1,__2,__3,__4,__5,__6,__7,__8]
qml: 007
qml: true
qml: 007
qml: 7
qml: 7
```