### PR TITLE
Avoid bogus "Malformed entry" warnings if X-SDDM-Env not present or empty

### DIFF
--- a/src/common/Session.cpp
+++ b/src/common/Session.cpp
@@ -202,7 +202,7 @@ namespace SDDM {
     {
         QProcessEnvironment env;
 
-        const QVector<QStringRef> entryList = list.splitRef(QLatin1Char(','));
+        const QVector<QStringRef> entryList = list.splitRef(QLatin1Char(','), Qt::SkipEmptyParts);
         for (const auto &entry: entryList) {
             int midPoint = entry.indexOf(QLatin1Char('='));
             if (midPoint < 0) {


### PR DESCRIPTION
Just skip empty parts.

Fixes a regression introduced by #1645