### PR TITLE
Fix terminal logging

### DIFF
--- a/src/common/MessageHandler.h
+++ b/src/common/MessageHandler.h
@@ -114,36 +114,27 @@ namespace SDDM {
             file.write(logMessage.toLocal8Bit());
             file.flush();
         } else {
-            fprintf(stderr, "%s", qPrintable(logMessage));
+            fputs(qPrintable(logMessage), stderr);
             fflush(stderr);
         }
     }
 
     static void messageHandler(QtMsgType type, const QMessageLogContext &context, const QString &prefix, const QString &msg) {
-        // copy message to edit it
-        QString logMessage = msg;
-
 #ifdef HAVE_JOURNALD
         // don't log to journald if running interactively, this is likely
         // the case when running sddm in test mode
         static bool isInteractive = isatty(STDERR_FILENO) && qgetenv("USER") != "sddm";
         if (!isInteractive) {
             // log to journald
-            journaldLogger(type, context, logMessage);
-        } else {
-            // prepend program name
-            logMessage = prefix + msg;
-
-            // log to file or stderr
-            standardLogger(type, logMessage);
+            journaldLogger(type, context, msg);
+            return;
         }
-#else
+#endif
         // prepend program name
-        logMessage = prefix + msg;
+        QString logMessage = prefix + msg;
 
         // log to file or stderr
         standardLogger(type, logMessage);
-#endif
     }
 
     void DaemonMessageHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg) {


### PR DESCRIPTION
Previously running `sddm` in a terminal produced no output whatsoever. With these changes it writes to `stderr` if it's a tty.

I'd prefer if we could just use Qt's message handler directly without replacing it with one of our own. It already logs to the journal properly if it's not run from a terminal. That's unfortunately not as easy though because:

* Qt might've been built without journal integration
* Logging to sddm.log is still needed in some cases
* SDDM doesn't use logging categories, only a `DAEMON:`/`HELPER:`/... prefix, which is currently set by the custom message handlers.