### PR TITLE
Remove guessing of XDG_RUNTIME_DIR

### DIFF
--- a/src/helper/UserSession.cpp
+++ b/src/helper/UserSession.cpp
@@ -236,7 +236,6 @@ namespace SDDM {
             qCritical() << "setgid(" << pw.pw_gid << ") failed for user: " << username;
             exit(Auth::HELPER_OTHER_ERROR);
         }
-        qputenv("XDG_RUNTIME_DIR", QByteArrayLiteral("/run/user/") + QByteArray::number(pw.pw_uid));
 
 #ifdef USE_PAM
 


### PR DESCRIPTION
It's already set properly at that point.

Tested to work with `DisplayServer=` `x11`, `x11-user` and `wayland`.