### PR TITLE
Port to Qt6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,7 @@ find_package(XCB REQUIRED)
 find_package(XKB REQUIRED)
 
 # Qt 6
-find_package(Qt6 5.15.0 CONFIG REQUIRED Core DBus Gui Qml Quick LinguistTools Test QuickTest)
+find_package(Qt6 6.4.2 CONFIG REQUIRED Core DBus Gui Qml Quick LinguistTools Test QuickTest)
 
 # find qt6 imports dir
 get_target_property(QMAKE_EXECUTABLE Qt6::qmake LOCATION)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,11 +96,11 @@ find_package(XCB REQUIRED)
 # XKB
 find_package(XKB REQUIRED)
 
-# Qt 5
-find_package(Qt5 5.15.0 CONFIG REQUIRED Core DBus Gui Qml Quick LinguistTools Test QuickTest)
+# Qt 6
+find_package(Qt6 5.15.0 CONFIG REQUIRED Core DBus Gui Qml Quick LinguistTools Test QuickTest)
 
-# find qt5 imports dir
-get_target_property(QMAKE_EXECUTABLE Qt5::qmake LOCATION)
+# find qt6 imports dir
+get_target_property(QMAKE_EXECUTABLE Qt6::qmake LOCATION)
 if(NOT QT_IMPORTS_DIR)
     exec_program(${QMAKE_EXECUTABLE} ARGS "-query QT_INSTALL_QML" RETURN_VALUE return_code OUTPUT_VARIABLE QT_IMPORTS_DIR)
 endif()

--- a/data/themes/CMakeLists.txt
+++ b/data/themes/CMakeLists.txt
@@ -8,7 +8,7 @@ foreach(THEME ${THEMES})
 
     set_source_files_properties(${TRANSLATION_SOURCES} PROPERTIES OUTPUT_LOCATION "${CMAKE_CURRENT_BINARY_DIR}/${TRANSLATIONS_DIR}")
 
-    qt5_add_translation(QM_FILES "${TRANSLATION_SOURCES}")
+    qt_add_translation(QM_FILES "${TRANSLATION_SOURCES}")
 
     install(DIRECTORY "${THEME}" DESTINATION "${DATA_INSTALL_DIR}/themes" PATTERN "${THEME}/*.ts"
             EXCLUDE PATTERN "${THEME}/.gitattributes"

--- a/data/translations/CMakeLists.txt
+++ b/data/translations/CMakeLists.txt
@@ -43,7 +43,7 @@ set(TRANSLATION_FILES
     zh_TW.ts
 )
 
-qt5_add_translation(QM_FILES ${TRANSLATION_FILES})
+qt_add_translation(QM_FILES ${TRANSLATION_FILES})
 
 install(FILES ${QM_FILES} DESTINATION "${COMPONENTS_TRANSLATION_DIR}")
 

--- a/src/auth/Auth.cpp
+++ b/src/auth/Auth.cpp
@@ -24,6 +24,7 @@
 #include "SafeDataStream.h"
 
 #include <QtCore/QProcess>
+#include <QtCore/QRegularExpression>
 #include <QtCore/QUuid>
 #include <QtNetwork/QLocalServer>
 #include <QtNetwork/QLocalSocket>
@@ -102,7 +103,7 @@ namespace SDDM {
         static std::unique_ptr<Auth::SocketServer> self;
         if (!self) {
             self.reset(new SocketServer());
-            self->listen(QStringLiteral("sddm-auth-%1").arg(QUuid::createUuid().toString().replace(QRegExp(QStringLiteral("[{}]")), QString())));
+            self->listen(QStringLiteral("sddm-auth-%1").arg(QUuid::createUuid().toString().replace(QRegularExpression(QStringLiteral("[{}]")), QString())));
         }
         return self.get();
     }

--- a/src/common/SafeDataStream.cpp
+++ b/src/common/SafeDataStream.cpp
@@ -21,6 +21,7 @@
 #include "SafeDataStream.h"
 
 #include <QtCore/QDebug>
+#include <QtCore/QIODevice>
 
 namespace SDDM {
     SafeDataStream::SafeDataStream(QIODevice* device)

--- a/src/common/SafeDataStream.h
+++ b/src/common/SafeDataStream.h
@@ -21,7 +21,9 @@
 #ifndef SAFEDATASTREAM_H
 #define SAFEDATASTREAM_H
 
+#include <QtCore/QByteArray>
 #include <QtCore/QDataStream>
+#include <QtCore/QIODevice>
 
 namespace SDDM {
     class SafeDataStream : public QDataStream {

--- a/src/common/Session.cpp
+++ b/src/common/Session.cpp
@@ -214,14 +214,14 @@ namespace SDDM {
     {
         QProcessEnvironment env;
 
-        const QVector<QStringRef> entryList = list.splitRef(QLatin1Char(','), Qt::SkipEmptyParts);
+        const QVector<QString> entryList = list.split(QLatin1Char(','), Qt::SkipEmptyParts);
         for (const auto &entry: entryList) {
             int midPoint = entry.indexOf(QLatin1Char('='));
             if (midPoint < 0) {
                 qWarning() << "Malformed entry in" << fileName() << ":" << entry;
                 continue;
             }
-            env.insert(entry.left(midPoint).toString(), entry.mid(midPoint+1).toString());
+            env.insert(entry.left(midPoint), entry.mid(midPoint+1));
         }
         return env;
     }

--- a/src/common/ThemeConfig.cpp
+++ b/src/common/ThemeConfig.cpp
@@ -47,12 +47,6 @@ namespace SDDM {
         QSettings settings(path, QSettings::IniFormat);
         QSettings userSettings(path + QStringLiteral(".user"), QSettings::IniFormat);
 
-        // Support non-latin strings in background picture path
-        // Warning: The codec must be set immediately after creating the QSettings object,
-        // before accessing any data.
-        settings.setIniCodec("UTF-8");
-        userSettings.setIniCodec("UTF-8");
-
         // read default keys
         for (const QString &key: settings.allKeys()) {
             insert(key, settings.value(key));

--- a/src/common/XAuth.cpp
+++ b/src/common/XAuth.cpp
@@ -93,11 +93,12 @@ void XAuth::setup()
     std::mt19937 gen(rd());
     std::uniform_int_distribution<> dis(0, 0xFF);
 
+    m_cookie.truncate(0);
     m_cookie.reserve(16);
 
     // Create a random hexadecimal number
     for(int i = 0; i < 16; i++)
-        m_cookie[i] = dis(gen);
+        m_cookie.append(dis(gen));
 }
 
 bool XAuth::addCookie(const QString &display)

--- a/src/common/XAuth.cpp
+++ b/src/common/XAuth.cpp
@@ -137,7 +137,7 @@ bool XAuth::writeCookieToFile(const QString &display, const QString &fileName,
     char cookieName[] = "MIT-MAGIC-COOKIE-1";
 
     // Skip the ':'
-    QByteArray displayNumberUtf8 = display.midRef(1).toUtf8();
+    QByteArray displayNumberUtf8 = display.mid(1).toUtf8();
 
     auth.family = FamilyLocal;
     auth.address = localhost;

--- a/src/daemon/CMakeLists.txt
+++ b/src/daemon/CMakeLists.txt
@@ -40,9 +40,9 @@ set(DAEMON_SOURCES
 
 list(APPEND DAEMON_SOURCES ${CMAKE_SOURCE_DIR}/src/common/VirtualTerminal.cpp)
 
-qt5_add_dbus_adaptor(DAEMON_SOURCES "${CMAKE_SOURCE_DIR}/data/interfaces/org.freedesktop.DisplayManager.xml"          "DisplayManager.h" SDDM::DisplayManager)
-qt5_add_dbus_adaptor(DAEMON_SOURCES "${CMAKE_SOURCE_DIR}/data/interfaces/org.freedesktop.DisplayManager.Seat.xml"     "DisplayManager.h" SDDM::DisplayManagerSeat)
-qt5_add_dbus_adaptor(DAEMON_SOURCES "${CMAKE_SOURCE_DIR}/data/interfaces/org.freedesktop.DisplayManager.Session.xml"  "DisplayManager.h" SDDM::DisplayManagerSession)
+qt_add_dbus_adaptor(DAEMON_SOURCES "${CMAKE_SOURCE_DIR}/data/interfaces/org.freedesktop.DisplayManager.xml"          "DisplayManager.h" SDDM::DisplayManager)
+qt_add_dbus_adaptor(DAEMON_SOURCES "${CMAKE_SOURCE_DIR}/data/interfaces/org.freedesktop.DisplayManager.Seat.xml"     "DisplayManager.h" SDDM::DisplayManagerSeat)
+qt_add_dbus_adaptor(DAEMON_SOURCES "${CMAKE_SOURCE_DIR}/data/interfaces/org.freedesktop.DisplayManager.Session.xml"  "DisplayManager.h" SDDM::DisplayManagerSession)
 qt_add_dbus_interface(DAEMON_SOURCES ${CMAKE_SOURCE_DIR}/data/interfaces/org.freedesktop.locale1.xml locale1_interface)
 
 
@@ -57,9 +57,9 @@ set_source_files_properties("${CMAKE_SOURCE_DIR}/data/interfaces/org.freedesktop
    INCLUDE "LogindDBusTypes.h"
 )
 
-qt5_add_dbus_interface(DAEMON_SOURCES "${CMAKE_SOURCE_DIR}/data/interfaces/org.freedesktop.login1.Manager.xml"  "Login1Manager")
-qt5_add_dbus_interface(DAEMON_SOURCES "${CMAKE_SOURCE_DIR}/data/interfaces/org.freedesktop.login1.Seat.xml"  "Login1Seat")
-qt5_add_dbus_interface(DAEMON_SOURCES "${CMAKE_SOURCE_DIR}/data/interfaces/org.freedesktop.login1.Session.xml"  "Login1Session")
+qt_add_dbus_interface(DAEMON_SOURCES "${CMAKE_SOURCE_DIR}/data/interfaces/org.freedesktop.login1.Manager.xml"  "Login1Manager")
+qt_add_dbus_interface(DAEMON_SOURCES "${CMAKE_SOURCE_DIR}/data/interfaces/org.freedesktop.login1.Seat.xml"  "Login1Seat")
+qt_add_dbus_interface(DAEMON_SOURCES "${CMAKE_SOURCE_DIR}/data/interfaces/org.freedesktop.login1.Session.xml"  "Login1Session")
 
 add_executable(sddm ${DAEMON_SOURCES})
 target_link_libraries(sddm

--- a/src/daemon/CMakeLists.txt
+++ b/src/daemon/CMakeLists.txt
@@ -63,9 +63,9 @@ qt5_add_dbus_interface(DAEMON_SOURCES "${CMAKE_SOURCE_DIR}/data/interfaces/org.f
 
 add_executable(sddm ${DAEMON_SOURCES})
 target_link_libraries(sddm
-                      Qt5::DBus
-                      Qt5::Network
-                      Qt5::Qml
+                      Qt6::DBus
+                      Qt6::Network
+                      Qt6::Qml
                       ${LIBXAU_LINK_LIBRARIES}
                       ${LIBXCB_LIBRARIES})
 if(PAM_FOUND)

--- a/src/greeter/CMakeLists.txt
+++ b/src/greeter/CMakeLists.txt
@@ -27,7 +27,7 @@ set(GREETER_SOURCES
 
 configure_file("theme.qrc" "theme.qrc")
 
-qt5_add_resources(RESOURCES ${CMAKE_CURRENT_BINARY_DIR}/theme.qrc)
+qt_add_resources(RESOURCES ${CMAKE_CURRENT_BINARY_DIR}/theme.qrc)
 
 add_executable(sddm-greeter ${GREETER_SOURCES} ${RESOURCES})
 target_link_libraries(sddm-greeter

--- a/src/greeter/CMakeLists.txt
+++ b/src/greeter/CMakeLists.txt
@@ -31,7 +31,7 @@ qt5_add_resources(RESOURCES ${CMAKE_CURRENT_BINARY_DIR}/theme.qrc)
 
 add_executable(sddm-greeter ${GREETER_SOURCES} ${RESOURCES})
 target_link_libraries(sddm-greeter
-                      Qt5::Quick
+                      Qt6::Quick
                       ${LIBXCB_LIBRARIES}
                       ${LIBXKB_LIBRARIES})
 

--- a/src/greeter/XcbKeyboardBackend.cpp
+++ b/src/greeter/XcbKeyboardBackend.cpp
@@ -19,6 +19,7 @@
 
 #include <QtCore/QDebug>
 #include <QtCore/QObject>
+#include <QtCore/QRegularExpression>
 
 #include "KeyboardModel.h"
 #include "KeyboardModel_p.h"
@@ -267,8 +268,7 @@ namespace SDDM {
     }
 
     QList<QString> XcbKeyboardBackend::parseShortNames(QString text) {
-        QRegExp re(QStringLiteral(R"(\+([a-z]+))"));
-        re.setCaseSensitivity(Qt::CaseInsensitive);
+        QRegularExpression re(QStringLiteral(R"(\+([a-z]+))"), QRegularExpression::CaseInsensitiveOption);
 
         QList<QString> res;
         QSet<QString> blackList; // blacklist wrong tokens
@@ -276,10 +276,11 @@ namespace SDDM {
 
         // Loop through matched substrings
         int pos = 0;
-        while ((pos = re.indexIn(text, pos)) != -1) {
-            if (!blackList.contains(re.cap(1)))
-                res << re.cap(1);
-            pos += re.matchedLength();
+        QRegularExpressionMatch match;
+        while ((match = re.match(text, pos)).hasMatch()) {
+            if (!blackList.contains(match.captured(1)))
+                res << match.captured(1);
+            pos += match.capturedLength();
         }
         return res;
     }

--- a/src/helper/CMakeLists.txt
+++ b/src/helper/CMakeLists.txt
@@ -13,6 +13,9 @@ set(HELPER_SOURCES
     ${CMAKE_SOURCE_DIR}/src/common/SafeDataStream.cpp
     ${CMAKE_SOURCE_DIR}/src/common/XAuth.cpp
     ${CMAKE_SOURCE_DIR}/src/common/SignalHandler.cpp
+    ${CMAKE_SOURCE_DIR}/src/auth/Auth.cpp
+    ${CMAKE_SOURCE_DIR}/src/auth/AuthRequest.cpp
+    ${CMAKE_SOURCE_DIR}/src/auth/AuthPrompt.cpp
     Backend.cpp
     HelperApp.cpp
     UserSession.cpp

--- a/src/helper/CMakeLists.txt
+++ b/src/helper/CMakeLists.txt
@@ -39,9 +39,9 @@ endif()
 
 add_executable(sddm-helper ${HELPER_SOURCES})
 target_link_libraries(sddm-helper
-                      Qt5::Network
-                      Qt5::DBus
-                      Qt5::Qml
+                      Qt6::Network
+                      Qt6::DBus
+                      Qt6::Qml
                       ${LIBXAU_LINK_LIBRARIES})
 if("${CMAKE_SYSTEM_NAME}" STREQUAL "FreeBSD")
     # On FreeBSD (possibly other BSDs as well), we want to use
@@ -64,7 +64,7 @@ endif()
 install(TARGETS sddm-helper RUNTIME DESTINATION "${CMAKE_INSTALL_LIBEXECDIR}")
 
 add_executable(sddm-helper-start-wayland HelperStartWayland.cpp waylandsocketwatcher.cpp waylandhelper.cpp ${CMAKE_SOURCE_DIR}/src/common/SignalHandler.cpp)
-target_link_libraries(sddm-helper-start-wayland Qt5::Core)
+target_link_libraries(sddm-helper-start-wayland Qt6::Core)
 install(TARGETS sddm-helper-start-wayland RUNTIME DESTINATION "${CMAKE_INSTALL_LIBEXECDIR}")
 
 add_executable(sddm-helper-start-x11user HelperStartX11User.cpp xorguserhelper.cpp
@@ -73,7 +73,7 @@ add_executable(sddm-helper-start-x11user HelperStartX11User.cpp xorguserhelper.c
                                                 ${CMAKE_SOURCE_DIR}/src/common/XAuth.cpp
                                                 ${CMAKE_SOURCE_DIR}/src/common/SignalHandler.cpp
                                                 )
-target_link_libraries(sddm-helper-start-x11user Qt5::Core
+target_link_libraries(sddm-helper-start-x11user Qt6::Core
                                                 ${LIBXAU_LINK_LIBRARIES})
 install(TARGETS sddm-helper-start-x11user RUNTIME DESTINATION "${CMAKE_INSTALL_LIBEXECDIR}")
 

--- a/src/helper/UserSession.h
+++ b/src/helper/UserSession.h
@@ -55,12 +55,11 @@ namespace SDDM {
     Q_SIGNALS:
         void finished(int exitCode);
 
-
-    protected:
-        void setupChildProcess() override;
-
     private:
         void setup();
+
+        // Don't call it directly, it will be invoked by the child process only
+        void childModifier();
 
         QString m_path { };
         QTemporaryFile m_xauthFile;

--- a/src/helper/backend/PamBackend.cpp
+++ b/src/helper/backend/PamBackend.cpp
@@ -27,6 +27,7 @@
 
 #include <QtCore/QString>
 #include <QtCore/QDebug>
+#include <QtCore/QRegularExpression>
 
 #include <stdlib.h>
 
@@ -59,14 +60,14 @@ namespace SDDM {
     AuthPrompt::Type PamData::detectPrompt(const struct pam_message* msg) const {
         if (msg->msg_style == PAM_PROMPT_ECHO_OFF) {
             QString message = QString::fromLocal8Bit(msg->msg);
-            if (message.indexOf(QRegExp(QStringLiteral("\\bpassword\\b"), Qt::CaseInsensitive)) >= 0) {
-                if (message.indexOf(QRegExp(QStringLiteral("\\b(re-?(enter|type)|again|confirm|repeat)\\b"), Qt::CaseInsensitive)) >= 0) {
+            if ((QRegularExpression(QStringLiteral("\\bpassword\\b"), QRegularExpression::CaseInsensitiveOption)).match(message).hasMatch()) {
+                if ((QRegularExpression(QStringLiteral("\\b(re-?(enter|type)|again|confirm|repeat)\\b"), QRegularExpression::CaseInsensitiveOption)).match(message).hasMatch()) {
                     return AuthPrompt::CHANGE_REPEAT;
                 }
-                else if (message.indexOf(QRegExp(QStringLiteral("\\bnew\\b"), Qt::CaseInsensitive)) >= 0) {
+                else if ((QRegularExpression(QStringLiteral("\\bnew\\b"), QRegularExpression::CaseInsensitiveOption)).match(message).hasMatch()) {
                     return AuthPrompt::CHANGE_NEW;
                 }
-                else if (message.indexOf(QRegExp(QStringLiteral("\\b(old|current)\\b"), Qt::CaseInsensitive)) >= 0) {
+                else if ((QRegularExpression(QStringLiteral("\\b(old|current)\\b"), QRegularExpression::CaseInsensitiveOption)).match(message).hasMatch()) {
                     return AuthPrompt::CHANGE_CURRENT;
                 }
                 else {
@@ -154,7 +155,7 @@ namespace SDDM {
     }
 
     Auth::Info PamData::handleInfo(const struct pam_message* msg, bool predict) {
-        if (QString::fromLocal8Bit(msg->msg).indexOf(QRegExp(QStringLiteral("^Changing password for [^ ]+$")))) {
+        if ((QRegularExpression(QStringLiteral("^Changing password for [^ ]+$"))).match(QString::fromLocal8Bit(msg->msg)).hasMatch()) {
             if (predict)
                 m_currentRequest = Request(changePassRequest);
             return Auth::INFO_PASS_CHANGE_REQUIRED;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,10 +6,10 @@ set(ConfigurationTest_SRCS ConfigurationTest.cpp ../src/common/ConfigReader.cpp)
 add_executable(ConfigurationTest ${ConfigurationTest_SRCS})
 add_test(NAME Configuration COMMAND ConfigurationTest)
 
-target_link_libraries(ConfigurationTest Qt5::Core Qt5::Test)
+target_link_libraries(ConfigurationTest Qt6::Core Qt6::Test)
 
 set(QMLThemeConfigTest_SRCS QMLThemeConfigTest.cpp ../src/common/ThemeConfig.cpp ../src/common/ThemeConfig.h)
 add_executable(QMLThemeConfigTest ${QMLThemeConfigTest_SRCS})
 target_include_directories(QMLThemeConfigTest PRIVATE ../src/common/)
 add_test(NAME QMLThemeConfig COMMAND QMLThemeConfigTest -platform offscreen -input ${CMAKE_CURRENT_SOURCE_DIR}/QMLThemeConfigTest.qml WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(QMLThemeConfigTest PRIVATE Qt5::Quick Qt5::QuickTest)
+target_link_libraries(QMLThemeConfigTest PRIVATE Qt6::Quick Qt6::QuickTest)


### PR DESCRIPTION
Port to Qt 6. Main things:
* `RegExp` has been removed, instead use `QRegularExpression`
* No more `QProcess::setupChildProcess` but instead `setChildProcessModifier`
* `QSettings` now uses UTF-8
* `QStringRef` has been removed. There is [QStringView](https://doc.qt.io/qt-6/qstringview.html) but that looks useful only for UTF-16 and [QLatin1StringView](https://doc.qt.io/qt-6/qlatin1stringview.html) but we need local encoding/UTF-8 so not usable

Something changed regarding `QMetaType` so need to include `Auth*` stuff aswell otherwise got linking failures
```
[ 70%] Linking CXX executable sddm-helper
/usr/bin/ld: CMakeFiles/sddm-helper.dir/sddm-helper_autogen/mocs_compilation.cpp.o: in function `QtPrivate::MetaObjectForType<SDDM::Auth::Info, void>::metaObjectFunction(QtPrivate::QMetaTypeInterface const*)':
/usr/src/debug/sddm-git/build/src/helper/sddm-helper_autogen/mocs_compilation.cpp:924: undefined reference to `SDDM::Auth::staticMetaObject'
/usr/bin/ld: CMakeFiles/sddm-helper.dir/sddm-helper_autogen/mocs_compilation.cpp.o: in function `QtPrivate::MetaObjectForType<SDDM::Auth::Error, void>::metaObjectFunction(QtPrivate::QMetaTypeInterface const*)':
/usr/src/debug/sddm-git/build/src/helper/sddm-helper_autogen/mocs_compilation.cpp:924: undefined reference to `SDDM::Auth::staticMetaObject'
/usr/bin/ld: CMakeFiles/sddm-helper.dir/sddm-helper_autogen/mocs_compilation.cpp.o: in function `std::enable_if<QtPrivate::IsQEnumHelper<SDDM::Auth::Info>::Value, QDebug>::type operator<< <SDDM::Auth::Info>(QDebug, SDDM::Auth::Info)':
/usr/include/qt6/QtCore/qdebug.h:398: undefined reference to `SDDM::Auth::staticMetaObject'
/usr/bin/ld: CMakeFiles/sddm-helper.dir/sddm-helper_autogen/mocs_compilation.cpp.o: in function `std::enable_if<QtPrivate::IsQEnumHelper<SDDM::Auth::Error>::Value, QDebug>::typeoperator<< <SDDM::Auth::Error>(QDebug, SDDM::Auth::Error)':
/usr/include/qt6/QtCore/qdebug.h:398: undefined reference to `SDDM::Auth::staticMetaObject'
/usr/bin/ld: CMakeFiles/sddm-helper.dir/sddm-helper_autogen/mocs_compilation.cpp.o: in function `QMetaTypeIdQObject<SDDM::Auth::Info, 16>::qt_metatype_id()':
/usr/include/qt6/QtCore/qmetatype.h:1377: undefined reference to `SDDM::Auth::staticMetaObject'
/usr/bin/ld: CMakeFiles/sddm-helper.dir/sddm-helper_autogen/mocs_compilation.cpp.o:/usr/include/qt6/QtCore/qmetatype.h:1377: more undefined references to `SDDM::Auth::staticMetaObject' follow
collect2: error: ld returned 1 exit status
make[2]: *** [src/helper/CMakeFiles/sddm-helper.dir/build.make:280: src/helper/sddm-helper] Error 1
make[1]: *** [CMakeFiles/Makefile2:581: src/helper/CMakeFiles/sddm-helper.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
```

Resolves #1251 
