### PR TITLE
Make greeter window fullscreen

### DIFF
--- a/src/greeter/GreeterApp.cpp
+++ b/src/greeter/GreeterApp.cpp
@@ -228,7 +228,7 @@ namespace SDDM {
 
         // show
         qDebug() << "Adding view for" << screen->name() << screen->geometry();
-        view->show();
+        view->showFullScreen();
 
         // activate windows for the primary screen to give focus to text fields
         if (QGuiApplication::primaryScreen() == screen)


### PR DESCRIPTION
Only fullscreen clients can decide the output display on wayland

Fixes #1672 