### PR TITLE
XAuth: Fix `m_cookie` creation for `QByteArray`

### DIFF
--- a/src/common/XAuth.cpp
+++ b/src/common/XAuth.cpp
@@ -93,11 +93,12 @@ void XAuth::setup()
     std::mt19937 gen(rd());
     std::uniform_int_distribution<> dis(0, 0xFF);
 
+    m_cookie.truncate(0);
     m_cookie.reserve(16);
 
     // Create a random hexadecimal number
     for(int i = 0; i < 16; i++)
-        m_cookie[i] = dis(gen);
+        m_cookie.append(dis(gen));
 }
 
 bool XAuth::addCookie(const QString &display)


### PR DESCRIPTION
Qt6 have changed behaviour that `qbytearray[i]` doesn't affect `size()` calculation.

It's still working fine with Qt `5.15.8` but we can fix it already.
