### PR TITLE
Enable HiDPI scaling by default

### DIFF
--- a/data/man/sddm.conf.rst.in
+++ b/data/man/sddm.conf.rst.in
@@ -159,7 +159,7 @@ OPTIONS
 `EnableHiDPI=`
 	Enables Qt's automatic HiDPI scaling.
 	Can be either "true" or "false".
-	Default value is "false".
+	Default value is "true".
 
 The `XauthPath=` option is no longer necessary, libxau is used instead.
 
@@ -189,7 +189,7 @@ The `UserAuthFile=` option was removed, the file is always created as
 `EnableHiDPI=`
 	Enables Qt's automatic HiDPI scaling.
 	Can be either "true" or "false".
-	Default value is "false".
+	Default value is "true".
 
 [Users] section:
 

--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -74,7 +74,7 @@ namespace SDDM {
             Entry(SessionLogFile,      QString,     _S(".local/share/sddm/xorg-session.log"),   _S("Path to the user session log file"));
             Entry(DisplayCommand,      QString,     _S(DATA_INSTALL_DIR "/scripts/Xsetup"),     _S("Path to a script to execute when starting the display server"));
             Entry(DisplayStopCommand,  QString,     _S(DATA_INSTALL_DIR "/scripts/Xstop"),      _S("Path to a script to execute when stopping the display server"));
-            Entry(EnableHiDPI,         bool,        false,                                      _S("Enable Qt's automatic high-DPI scaling"));
+            Entry(EnableHiDPI,         bool,        true,                                      _S("Enable Qt's automatic high-DPI scaling"));
         );
 
         Section(Wayland,
@@ -83,7 +83,7 @@ namespace SDDM {
                                                      _S("/usr/share/wayland-sessions")},        _S("Comma-separated list of directories containing available Wayland sessions"));
             Entry(SessionCommand,      QString,     _S(WAYLAND_SESSION_COMMAND),                _S("Path to a script to execute when starting the desktop session"));
             Entry(SessionLogFile,      QString,     _S(".local/share/sddm/wayland-session.log"),_S("Path to the user session log file"));
-            Entry(EnableHiDPI,         bool,        false,                                      _S("Enable Qt's automatic high-DPI scaling"));
+            Entry(EnableHiDPI,         bool,        true,                                       _S("Enable Qt's automatic high-DPI scaling"));
         );
 
         Section(Users,


### PR DESCRIPTION
This setting works properly out of the box now.

Would obviate https://bugs.kde.org/show_bug.cgi?id=467039 in KDE.