### PR TITLE
Emit loginFailed when trying to log in as sddm user

### DIFF
--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -316,6 +316,7 @@ namespace SDDM {
         //the SDDM user has special privileges that skip password checking so that we can load the greeter
         //block ever trying to log in as the SDDM user
         if (user == QLatin1String("sddm")) {
+            emit loginFailed(m_socket);
             return;
         }
 


### PR DESCRIPTION
The greeter expects either success or failure getting emitted for login attempts, just returning early leaves it waiting indefinitely.