### PR TITLE
Fix inconstant cursor size when a nondefault cursor size is used

### DIFF
--- a/src/daemon/XorgDisplayServer.cpp
+++ b/src/daemon/XorgDisplayServer.cpp
@@ -269,6 +269,9 @@ namespace SDDM {
         env.insert(QStringLiteral("XAUTHORITY"), m_xauth.authPath());
         env.insert(QStringLiteral("SHELL"), QStringLiteral("/bin/sh"));
         env.insert(QStringLiteral("XCURSOR_THEME"), mainConfig.Theme.CursorTheme.get());
+        QString xcursorSize = mainConfig.Theme.CursorSize.get();
+        if (!xcursorSize.isEmpty())
+            env.insert(QStringLiteral("XCURSOR_SIZE"), xcursorSize);
         setCursor->setProcessEnvironment(env);
         displayScript->setProcessEnvironment(env);
 


### PR DESCRIPTION
This closes #965 by ensuring that the `XCURSOR_SIZE` is always correctly inserted into the process environment.

I have tested the patch on my laptop and can confirm that the bug no longer persists.