### PR TITLE
Load session .desktop files as UTF-8

### DIFF
--- a/src/common/Session.cpp
+++ b/src/common/Session.cpp
@@ -167,6 +167,7 @@ namespace SDDM {
             return;
 
         QSettings settings(m_fileName, QSettings::IniFormat);
+        settings.setIniCodec("UTF-8");
         QStringList locales = { QLocale().name() };
         if (auto clean = QLocale().name().remove(QRegularExpression(QLatin1String("_.*"))); clean != locales.constFirst()) {
             locales << clean;


### PR DESCRIPTION
QSettings defaults to ISO 8859-1, but .desktop files use UTF-8.

Reported at https://old.reddit.com/r/kde/comments/120lwgj/strange_work_in_sddm_plasma_5273_is_it_possible/