### PR TITLE
Add dependabot for managing dependencies.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Dependabot monitors and and automatically creates PRs to update outdated project dependencies. 

This PR adds a `dependabot.yml` config. I wrote the very basic version to check `github-actions` daily, but it can easily be changed to weekly/monthly as needed. Other things (like the amount of PRs the bot is allowed to open, etc) can be configured as well.

More info can be found [here ](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates).