### PR TITLE
Fix GitHub Action for CentOS Stream

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
           dnf --assumeyes install dnf-plugins-core
           if [[ "${{ matrix.container-image }}" =~ "centos" ]]; then dnf --assumeyes config-manager --set-enabled crb && dnf --assumeyes install epel-release; fi
           dnf --assumeyes builddep sddm
-          dnf --assumeyes install clang clazy
+          dnf --assumeyes --allowerasing --nobest install clang clazy
       - name: Dependencies (deb-type)
         if: ${{ contains(matrix.container-image, 'ubuntu') }}
         run: |


### PR DESCRIPTION
Apparently "builddep sddm" picks clang 16 but clazy needs clang 15. Allow the downgrade.