### PR TITLE
Bring the greeter on primary screen to the front

### DIFF
--- a/src/greeter/GreeterApp.cpp
+++ b/src/greeter/GreeterApp.cpp
@@ -231,8 +231,7 @@ namespace SDDM {
         view->showFullScreen();
 
         // activate windows for the primary screen to give focus to text fields
-        if (QGuiApplication::primaryScreen() == screen)
-            view->requestActivate();
+        activatePrimary();
     }
 
     void GreeterApp::removeViewForScreen(QQuickView *view) {
@@ -291,6 +290,7 @@ namespace SDDM {
         // activate and give focus to the window assigned to the primary screen
         for (QQuickView *view : qAsConst(m_views)) {
             if (view->screen() == QGuiApplication::primaryScreen()) {
+                view->raise();
                 view->requestActivate();
                 break;
             }


### PR DESCRIPTION
When there are multiple monitors connected, sddm-greeter creates new views for each screen, and activates the primary one to focus on its password field. However, if the monitors are initially setup to display the same content, different views will overlap with each other. The views created by non-primary screens may be placed on top of the primary view. In such cases, the primary view will be focused but not visible to the user.

This is fixed by calling `view->raise` for the primary screen. The primary view should be raised whenever a new screen is added, in order to avoid being covered by the newly created view.

Fixes: https://github.com/sddm/sddm/issues/612 https://github.com/sddm/sddm/issues/514