### PR TITLE
Support multiple theme directories.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,6 +189,13 @@ set(DBUS_CONFIG_FILENAME        "org.freedesktop.DisplayManager.conf"           
 set(COMPONENTS_TRANSLATION_DIR  "${DATA_INSTALL_DIR}/translations"                  CACHE PATH      "Components translations directory")
 set(SDDM_INITIAL_VT             "1"                                                 CACHE STRING    "Initial tty to use")
 
+# Intentionally does not use CMAKE_INSTAL_PREFIX, just like SessionDir in the Configuration.h
+set(DEFAULT_THEME_DIRS "/usr/local/share/sddm/themes" "/usr/share/sddm/themes")
+if (NOT "${DATA_INSTALL_DIR}/themes" IN_LIST DEFAULT_THEME_DIRS)
+    list(APPEND DEFAULT_THEME_DIRS "${DATA_INSTALL_DIR}/themes")
+endif()
+string(REPLACE ";" "," DEFAULT_THEME_DIRS "${DEFAULT_THEME_DIRS}")
+set(THEME_DIRS                  "${DEFAULT_THEME_DIRS}"                             CACHE STRING    "Default theme search directories (comma-separated)")
 
 # Autodetect UID_MIN and UID_MAX from /etc/login.defs
 if(NOT DEFINED LOGIN_DEFS_PATH)

--- a/data/man/sddm.conf.rst.in
+++ b/data/man/sddm.conf.rst.in
@@ -79,8 +79,8 @@ OPTIONS
 [Theme] section:
 
 `ThemeDir=`
-	Path of the directory containing theme files.
-	Default value is "@DATA_INSTALL_DIR@/themes".
+	Comma-separated list of directories containing theme files.
+	Default value is "@THEME_DIRS@".
 
 `Current=`
 	Name of the current theme.

--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -50,7 +50,7 @@ namespace SDDM {
         Entry(GreeterEnvironment,  QStringList, QStringList(),                                  _S("Comma-separated list of environment variables to be set"));
         //  Name   Entries (but it's a regular class again)
         Section(Theme,
-            Entry(ThemeDir,            QString,     _S(DATA_INSTALL_DIR "/themes"),             _S("Theme directory path"));
+            Entry(ThemeDir,            QStringList, _S(THEME_DIRS).split(u','),                 _S("Comma-separated list of directories containing themes"));
             Entry(Current,             QString,     _S(""),                                     _S("Current theme name"));
             Entry(FacesDir,            QString,     _S(DATA_INSTALL_DIR "/faces"),              _S("Global directory for user avatars\n"
                                                                                                    "The files should be named <username>.face.icon"));

--- a/src/common/Constants.h.in
+++ b/src/common/Constants.h.in
@@ -29,6 +29,7 @@
 #define RUNTIME_DIR                 "@RUNTIME_DIR@"
 #define STATE_DIR                   "@STATE_DIR@"
 #define ACCOUNTSSERVICE_DATA_DIR    "@ACCOUNTSSERVICE_DATA_DIR@"
+#define THEME_DIRS                  "@THEME_DIRS@"
 
 #define SESSION_COMMAND             "@SESSION_COMMAND@"
 #define WAYLAND_SESSION_COMMAND     "@WAYLAND_SESSION_COMMAND@"

--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -339,11 +339,12 @@ namespace SDDM {
         if (themeName.isEmpty())
             return QString();
 
-        QDir dir(mainConfig.Theme.ThemeDir.get());
-
-        // return the default theme if it exists
-        if (dir.exists(themeName))
-            return dir.absoluteFilePath(themeName);
+        // return the configured theme if it exists
+        for (const auto& themeDir: mainConfig.Theme.ThemeDir.get()) {
+            QDir dir(themeDir);
+            if (dir.exists(themeName))
+                return dir.absoluteFilePath(themeName);
+        }
 
         // otherwise use the embedded theme
         qWarning() << "The configured theme" << themeName << "doesn't exist, using the embedded theme instead";

--- a/src/greeter/UserModel.cpp
+++ b/src/greeter/UserModel.cpp
@@ -65,9 +65,14 @@ namespace SDDM {
 
     UserModel::UserModel(bool needAllUsers, QObject *parent) : QAbstractListModel(parent), d(new UserModelPrivate()) {
         const QString facesDir = mainConfig.Theme.FacesDir.get();
-        const QString themeDir = mainConfig.Theme.ThemeDir.get();
         const QString currentTheme = mainConfig.Theme.Current.get();
-        const QString themeDefaultFace = QStringLiteral("%1/%2/faces/.face.icon").arg(themeDir).arg(currentTheme);
+        QString themeDefaultFace;
+        for (const auto& themeDir: mainConfig.Theme.ThemeDir.get()) {
+            if (QDir(themeDir).exists(currentTheme)) {
+                themeDefaultFace = QStringLiteral("%1/%2/faces/.face.icon").arg(themeDir).arg(currentTheme);
+                break;
+            }
+        }
         const QString defaultFace = QStringLiteral("%1/.face.icon").arg(facesDir);
         const QString iconURI = QStringLiteral("file://%1").arg(
                 QFile::exists(themeDefaultFace) ? themeDefaultFace : defaultFace);


### PR DESCRIPTION
Interpret `ThemeDir` option as a comma-separated list of directories. Similar to the recent change in `SessionDir` handling, the option name is preserved for compatibility.

Fixes #1561 

***

This probably should default to `QStandardPaths::locateAll(QStandardPaths::AppDataLocation, QLatin1String("themes"), QStandardPaths::LocateDirectory);` (filtering out `~/*`), but it seems a bit too much of a change when sddm is close to release.