### PR TITLE
gitignore: Drop filter on "user" files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 /build/
 *~
-*.user


### PR DESCRIPTION
This causes git-archive(1) to filter out the sysuser files from the tarball.