### PR TITLE
drop dist target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,16 +13,6 @@ set(SDDM_VERSION_PATCH 0)
 set(SDDM_VERSION_STRING "${SDDM_VERSION_MAJOR}.${SDDM_VERSION_MINOR}.${SDDM_VERSION_PATCH}")
 add_compile_definitions("SDDM_VERSION=\"${SDDM_VERSION_STRING}\"")
 
-# Set up packaging
-set(CPACK_PACKAGE_NAME "sddm")
-set(CPACK_PACKAGE_VERSION "${SDDM_VERSION_STRING}")
-set(CPACK_GENERATOR "TGZ")
-set(CPACK_SET_DESTDIR FALSE)
-set(CPACK_SOURCE_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}")
-set(CPACK_SOURCE_IGNORE_FILES "/build/;/.git;/*.user;/.tx/;~$;${CPACK_SOURCE_IGNORE_FILES}")
-include(CPack)
-add_custom_target(dist COMMAND ${CMAKE_MAKE_PROGRAM} package_source)
-
 # Options
 option(BUILD_MAN_PAGES "Build man pages" OFF)
 option(ENABLE_JOURNALD "Enable logging to journald" ON)


### PR DESCRIPTION
it serves no real purpose since auto-generated release artifacts are expected to work correctly, so anything we do in the dist target only serves to diverge from the tag and potentially break things