### PR TITLE
OS Name and Version as Theme Properties

### DIFF
--- a/docs/THEMING.md
+++ b/docs/THEMING.md
@@ -21,6 +21,10 @@ We provide a proxy object, called as `sddm` to the themes as a context property.
 
 **hostName:** Holds the name of the host computer.
 
+**hostOsName:** Holds the operating system product name. "unknown", if not a recognised OS.
+
+**hostOsVersion:** Holds the operating system version. "unknown", if not a recognised OS.
+
 **canPowerOff:** true, if we can power off the machine; false, otherwise
 
 **canReboot:** true, if we can reboot the machine; false, otherwise

--- a/src/common/Messages.h
+++ b/src/common/Messages.h
@@ -35,6 +35,8 @@ namespace SDDM {
 
     enum class DaemonMessages {
         HostName,
+	HostOsName,
+	HostOsVersion,
         Capabilities,
         LoginSucceeded,
         LoginFailed,

--- a/src/daemon/DaemonApp.cpp
+++ b/src/daemon/DaemonApp.cpp
@@ -31,6 +31,7 @@
 #include <QDBusConnectionInterface>
 #include <QDebug>
 #include <QHostInfo>
+#include <QSysInfo>
 #include <QTimer>
 
 #include <iostream>
@@ -98,6 +99,14 @@ namespace SDDM {
 
     QString DaemonApp::hostName() const {
         return QHostInfo::localHostName();
+    }
+
+    QString DaemonApp::hostOsName() const {
+        return QSysInfo::productType();
+    }
+
+    QString DaemonApp::hostOsVersion() const {
+        return QSysInfo::productVersion();
     }
 
     DisplayManager *DaemonApp::displayManager() const {

--- a/src/daemon/DaemonApp.h
+++ b/src/daemon/DaemonApp.h
@@ -44,6 +44,8 @@ namespace SDDM {
         bool first { true };
 
         QString hostName() const;
+	QString hostOsName() const;
+	QString hostOsVersion() const;
         DisplayManager *displayManager() const;
         PowerManager *powerManager() const;
         SeatManager *seatManager() const;

--- a/src/daemon/SocketServer.cpp
+++ b/src/daemon/SocketServer.cpp
@@ -127,6 +127,12 @@ namespace SDDM {
                     // send host name
                     SocketWriter(socket) << quint32(DaemonMessages::HostName) << daemonApp->hostName();
 
+                    // send os name
+                    SocketWriter(socket) << quint32(DaemonMessages::HostOsName) << daemonApp->hostOsName();
+
+                    // send os version
+                    SocketWriter(socket) << quint32(DaemonMessages::HostOsVersion) << daemonApp->hostOsVersion();
+
                     // emit signal
                     emit connected();
                 }

--- a/src/greeter/GreeterProxy.cpp
+++ b/src/greeter/GreeterProxy.cpp
@@ -33,6 +33,8 @@ namespace SDDM {
         SessionModel *sessionModel { nullptr };
         QLocalSocket *socket { nullptr };
         QString hostName;
+	QString hostOsName;
+	QString hostOsVersion;
         bool canPowerOff { false };
         bool canReboot { false };
         bool canSuspend { false };
@@ -58,6 +60,14 @@ namespace SDDM {
 
     const QString &GreeterProxy::hostName() const {
         return d->hostName;
+    }
+
+    const QString &GreeterProxy::hostOsName() const {
+        return d->hostOsName;
+    }
+
+    const QString &GreeterProxy::hostOsVersion() const {
+        return d->hostOsVersion;
     }
 
     void GreeterProxy::setSessionModel(SessionModel *model) {
@@ -188,6 +198,28 @@ namespace SDDM {
 
                     // emit signal
                     emit hostNameChanged(d->hostName);
+                }
+                break;
+                case DaemonMessages::HostOsName: {
+                    // log message
+                    qDebug() << "Message received from daemon: HostOsName";
+
+                    // read os name
+                    input >> d->hostOsName;
+
+                    // emit signal
+                    emit hostOsNameChanged(d->hostOsName);
+                }
+                break;
+                case DaemonMessages::HostOsVersion: {
+                    // log message
+                    qDebug() << "Message received from daemon: HostOsVersion";
+
+                    // read os version
+                    input >> d->hostOsVersion;
+
+                    // emit signal
+                    emit hostOsVersionChanged(d->hostOsVersion);
                 }
                 break;
                 case DaemonMessages::LoginSucceeded: {

--- a/src/greeter/GreeterProxy.h
+++ b/src/greeter/GreeterProxy.h
@@ -33,6 +33,8 @@ namespace SDDM {
         Q_DISABLE_COPY(GreeterProxy)
 
         Q_PROPERTY(QString  hostName        READ hostName       NOTIFY hostNameChanged)
+        Q_PROPERTY(QString  hostOsName      READ hostOsName     NOTIFY hostOsNameChanged)
+        Q_PROPERTY(QString  hostOsVersion   READ hostOsVersion  NOTIFY hostOsVersionChanged)
         Q_PROPERTY(bool     canPowerOff     READ canPowerOff    NOTIFY canPowerOffChanged)
         Q_PROPERTY(bool     canReboot       READ canReboot      NOTIFY canRebootChanged)
         Q_PROPERTY(bool     canSuspend      READ canSuspend     NOTIFY canSuspendChanged)
@@ -44,6 +46,8 @@ namespace SDDM {
         ~GreeterProxy();
 
         const QString &hostName() const;
+	const QString &hostOsName() const;
+	const QString &hostOsVersion() const;
 
         bool canPowerOff() const;
         bool canReboot() const;
@@ -73,6 +77,8 @@ namespace SDDM {
     signals:
         void informationMessage(const QString &message);
         void hostNameChanged(const QString &hostName);
+        void hostOsNameChanged(const QString &hostOsName);
+        void hostOsVersionChanged(const QString &hostOsVersion);
         void canPowerOffChanged(bool canPowerOff);
         void canRebootChanged(bool canReboot);
         void canSuspendChanged(bool canSuspend);


### PR DESCRIPTION
Working on a theme that displays the detected OS as a graphical design element, much like some distros did with lightdm in the past.
Figured these properties would be of use on the official project for other theme designers.
These use built-in Qt stuff, so wide support and no maintenance required.