### PR TITLE
Ignore InputMethod=qtvirtualkeyboard on wayland

### DIFF
--- a/src/greeter/GreeterApp.cpp
+++ b/src/greeter/GreeterApp.cpp
@@ -319,7 +319,7 @@ int main(int argc, char **argv)
         platform = QString::fromUtf8(qgetenv("QT_QPA_PLATFORM"));
     }
     if (platform.isEmpty()) {
-        platform = QStringLiteral("xcb");
+        platform = qEnvironmentVariableIsSet("WAYLAND_DISPLAY") ? QStringLiteral("wayland") : QStringLiteral("xcb");
     }
 
     // Install message handler

--- a/src/greeter/GreeterApp.cpp
+++ b/src/greeter/GreeterApp.cpp
@@ -351,8 +351,14 @@ int main(int argc, char **argv)
     qputenv("KDE_DEBUG", "1");
 
     // Qt IM module
-    if (!SDDM::mainConfig.InputMethod.get().isEmpty())
-        qputenv("QT_IM_MODULE", SDDM::mainConfig.InputMethod.get().toLocal8Bit().constData());
+    QString inputMethod = SDDM::mainConfig.InputMethod.get();
+    // Using qtvirtualkeyboard as IM on wayland doesn't really work,
+    // it has to be done by the compositor instead.
+    if (platform.startsWith(QStringLiteral("wayland")) && inputMethod == QStringLiteral("qtvirtualkeyboard"))
+        inputMethod = QString{};
+
+    if (!inputMethod.isEmpty())
+        qputenv("QT_IM_MODULE", inputMethod.toLocal8Bit());
 
     QGuiApplication app(argc, argv);
     SDDM::SignalHandler s;


### PR DESCRIPTION
Using QT_IM_MODULE=qtvirtualkeyboard in wayland client applications is not
supported by Qt, but is sddm's builtin default. Avoid setting that.

Maybe it makes sense to move `InputMethod` into `[X11]` and `[Wayland]` sections?