### PR TITLE
Deal with absolute paths to log files

### DIFF
--- a/data/man/sddm.conf.rst.in
+++ b/data/man/sddm.conf.rst.in
@@ -135,7 +135,8 @@ OPTIONS
 	Default value is "@SESSION_COMMAND@".
 
 `SessionLogFile=`
-        Path to the user session log file, relative to the home directory.
+        Path to the user session log file.
+        Relative to the home directory, if does not begin with "/".
         Default value is ".local/share/sddm/xorg-session.log".
 
 `DisplayCommand=`
@@ -183,7 +184,8 @@ The `UserAuthFile=` option was removed, the file is always created as
 	Default value is "@WAYLAND_SESSION_COMMAND@".
 
 `SessionLogFile=`
-        Path to the user session log file, relative to the home directory.
+        Path to the user session log file.
+        Relative to the home directory, if does not begin with "/".
         Default value is ".local/share/sddm/wayland-session.log".
 
 `EnableHiDPI=`

--- a/src/helper/UserSession.cpp
+++ b/src/helper/UserSession.cpp
@@ -353,11 +353,19 @@ namespace SDDM {
             //we want to redirect after we setuid so that the log file is owned by the user
 
             // determine stderr log file based on session type
-            QString sessionLog = QStringLiteral("%1/%2")
-                    .arg(QString::fromLocal8Bit(pw.pw_dir))
-                    .arg(sessionType == QLatin1String("x11")
-                         ? mainConfig.X11.SessionLogFile.get()
-                         : mainConfig.Wayland.SessionLogFile.get());
+            QString sessionLog;
+            if (sessionType == QLatin1String("wayland"))
+            {
+                sessionLog = mainConfig.Wayland.SessionLogFile.get();
+            } else {
+                sessionLog = mainConfig.X11.SessionLogFile.get();
+            }
+            if (sessionLog.at(0) != QLatin1Char('/'))
+            {
+                sessionLog = QStringLiteral("%1/%2")
+                             .arg(QString::fromLocal8Bit(pw.pw_dir))
+                             .arg(sessionLog);
+            }
 
             // create the path
             QFileInfo finfo(sessionLog);


### PR DESCRIPTION
If path begins with "/", consider it to be an absolute path, not relative to $HOME

Example: SessionLogFile=/dev/null

Co-authored-by: Artem Proskurnev <ProskurnevAS@edu.mos.ru> (@temaps)
Signed-off-by: Mikhail Novosyolov <m.novosyolov@rosalinux.ru>