### PR TITLE
Handle autologin auth attempt errors

### DIFF
--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -394,12 +394,6 @@ namespace SDDM {
             qCritical() << "Failed to find command for session" << session.fileName();
             return false;
         }
-        // check if the user even exists
-        struct passwd *pw = getpwnam(qPrintable(user));
-        if (!pw) {
-            qCritical() << "Failed to find the user" << user;
-            return false;
-        }
 
         m_reuseSessionId = QString();
 

--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -220,11 +220,20 @@ namespace SDDM {
             return false;
         }
 
+        const QString username = mainConfig.Autologin.User.get();
+
+        // check if the user even exists
+        struct passwd *pw = getpwnam(qPrintable(username));
+        if (!pw) {
+            qCritical() << "Failed to find the autologin user:" << username;
+            return false;
+        }
+
         Session session;
         session.setTo(sessionType, autologinSession);
 
         m_auth->setAutologin(true);
-        startAuth(mainConfig.Autologin.User.get(), QString(), session);
+        startAuth(username, QString(), session);
 
         return true;
     }

--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -397,7 +397,7 @@ namespace SDDM {
         // check if the user even exists
         struct passwd *pw = getpwnam(qPrintable(user));
         if (!pw) {
-            qCritical() << "Failed to find the autologin user" << user;
+            qCritical() << "Failed to find the user" << user;
             return false;
         }
 

--- a/src/daemon/Display.h
+++ b/src/daemon/Display.h
@@ -86,8 +86,10 @@ namespace SDDM {
         QString findGreeterTheme() const;
         bool findSessionEntry(const QStringList &dirPaths, const QString &name) const;
 
-        void startAuth(const QString &user, const QString &password,
+        bool startAuth(const QString &user, const QString &password,
                        const Session &session);
+
+        void startSocketServerAndGreeter();
 
         DisplayServerType m_displayServerType = X11DisplayServerType;
 

--- a/src/daemon/Display.h
+++ b/src/daemon/Display.h
@@ -90,6 +90,7 @@ namespace SDDM {
                        const Session &session);
 
         void startSocketServerAndGreeter();
+        void handleAutologinFailure();
 
         DisplayServerType m_displayServerType = X11DisplayServerType;
 


### PR DESCRIPTION
If the autologin auth attempt failed for any reason, then start socket server and greeter (launch sddm theme, like as if there was no autologin at all).
