### PR TITLE
Make it possible to pass arbitrary objects to GreeterProxy::login()

### DIFF
--- a/data/themes/elarun/Main.qml
+++ b/data/themes/elarun/Main.qml
@@ -136,7 +136,11 @@ Rectangle {
 
                             Keys.onPressed: {
                                 if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
-                                    sddm.login(user_entry.text, pw_entry.text, sessionIndex)
+                                    sddm.login({
+                                        user: user_entry.text,
+                                        password: pw_entry.text,
+                                        sessionIndex: sessionIndex
+                                    })
                                     event.accepted = true
                                 }
                             }
@@ -152,7 +156,11 @@ Rectangle {
 
                     source: "images/login_normal.png"
 
-                    onClicked: sddm.login(user_entry.text, pw_entry.text, sessionIndex)
+                    onClicked: sddm.login({
+                                    user: user_entry.text,
+                                    password: pw_entry.text,
+                                    sessionIndex: sessionIndex
+                                })
 
 		    KeyNavigation.backtab: pw_entry; KeyNavigation.tab: session
                 }

--- a/data/themes/maldives/Main.qml
+++ b/data/themes/maldives/Main.qml
@@ -127,7 +127,11 @@ Rectangle {
 
                         Keys.onPressed: {
                             if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
-                                sddm.login(name.text, password.text, sessionIndex)
+                                sddm.login({
+                                    user: name.text,
+                                    password: password.text,
+                                    sessionIndex: sessionIndex
+                                })
                                 event.accepted = true
                             }
                         }
@@ -154,7 +158,11 @@ Rectangle {
 
                         Keys.onPressed: {
                             if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
-                                sddm.login(name.text, password.text, sessionIndex)
+                                sddm.login({
+                                    user: name.text,
+                                    password: password.text,
+                                    sessionIndex: sessionIndex
+                                })
                                 event.accepted = true
                             }
                         }
@@ -243,7 +251,11 @@ Rectangle {
                         text: textConstants.login
                         width: parent.btnWidth
 
-                        onClicked: sddm.login(name.text, password.text, sessionIndex)
+                        onClicked: sddm.login({
+                                    user: name.text,
+                                    password: password.text,
+                                    sessionIndex: sessionIndex
+                                })
 
                         KeyNavigation.backtab: layoutBox; KeyNavigation.tab: shutdownButton
                     }

--- a/data/themes/maya/Main.qml
+++ b/data/themes/maya/Main.qml
@@ -111,7 +111,11 @@ Rectangle {
     maya_busy.visible = true;
     maya_busy_anim.start()
 
-    sddm.login(maya_username.text, maya_password.text, maya_session.index);
+    sddm.login({
+      user: maya_username.text,
+      password: maya_password.text,
+      sessionIndex: maya_session.index
+    });
   }
 
 

--- a/src/common/Session.h
+++ b/src/common/Session.h
@@ -89,19 +89,6 @@ namespace SDDM {
 
         friend class SessionModel;
     };
-
-    inline QDataStream &operator<<(QDataStream &stream, const Session &session) {
-        stream << quint32(session.type()) << session.fileName();
-        return stream;
-    }
-
-    inline QDataStream &operator>>(QDataStream &stream, Session &session) {
-        quint32 type;
-        QString fileName;
-        stream >> type >> fileName;
-        session.setTo(static_cast<Session::Type>(type), fileName);
-        return stream;
-    }
 }
 
 #endif // SDDM_SESSION_H

--- a/src/common/SocketWriter.cpp
+++ b/src/common/SocketWriter.cpp
@@ -44,8 +44,8 @@ namespace SDDM {
         return *this;
     }
 
-    SocketWriter &SocketWriter::operator << (const Session &s) {
-        *output << s;
+    SocketWriter &SocketWriter::operator << (const QVariantMap &m) {
+        *output << m;
 
         return *this;
     }

--- a/src/common/SocketWriter.h
+++ b/src/common/SocketWriter.h
@@ -35,7 +35,7 @@ namespace SDDM {
 
         SocketWriter &operator << (const quint32 &u);
         SocketWriter &operator << (const QString &s);
-        SocketWriter &operator << (const Session &s);
+        SocketWriter &operator << (const QVariantMap &m);
 
     private:
         QByteArray data;

--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -309,9 +309,11 @@ namespace SDDM {
     }
 
     void Display::login(QLocalSocket *socket,
-                        const QString &user, const QString &password,
-                        const Session &session) {
+                        const QVariantMap &args) {
         m_socket = socket;
+
+        QString user = args[QStringLiteral("user")].toString();
+        QString password = args[QStringLiteral("password")].toString();
 
         //the SDDM user has special privileges that skip password checking so that we can load the greeter
         //block ever trying to log in as the SDDM user
@@ -319,6 +321,10 @@ namespace SDDM {
             emit loginFailed(m_socket);
             return;
         }
+
+        Session::Type sessionType = static_cast<Session::Type>(args[QStringLiteral("sessionType")].toInt());
+        QString sessionName = args[QStringLiteral("sessionName")].toString();
+        Session session(sessionType, sessionName);
 
         // authenticate
         startAuth(user, password, session);

--- a/src/daemon/Display.h
+++ b/src/daemon/Display.h
@@ -70,8 +70,7 @@ namespace SDDM {
         void stop();
 
         void login(QLocalSocket *socket,
-                   const QString &user, const QString &password,
-                   const Session &session);
+                   const QVariantMap &args);
         bool attemptAutologin();
         void displayServerStarted();
 

--- a/src/daemon/SocketServer.cpp
+++ b/src/daemon/SocketServer.cpp
@@ -109,7 +109,7 @@ namespace SDDM {
         // input stream
         QDataStream input(socket);
 
-        // Qt's QLocalSocket::readyRead is not designed to be called at every socket.write(), 
+        // Qt's QLocalSocket::readyRead is not designed to be called at every socket.write(),
         // so we need to use a loop to read all the signals.
         while(socket->bytesAvailable()) {
             // read message
@@ -136,12 +136,11 @@ namespace SDDM {
                     qDebug() << "Message received from greeter: Login";
 
                     // read username, pasword etc.
-                    QString user, password, filename;
-                    Session session;
-                    input >> user >> password >> session;
+                    QVariantMap args;
+                    input >> args;
 
                     // emit signal
-                    emit login(socket, user, password, session);
+                    emit login(socket, args);
                 }
                 break;
                 case GreeterMessages::PowerOff: {

--- a/src/daemon/SocketServer.h
+++ b/src/daemon/SocketServer.h
@@ -52,8 +52,7 @@ namespace SDDM {
 
     signals:
         void login(QLocalSocket *socket,
-                   const QString &user, const QString &password,
-                   const Session &session);
+                   const QVariantMap &args);
         void connected();
 
     private:

--- a/src/greeter/GreeterProxy.h
+++ b/src/greeter/GreeterProxy.h
@@ -1,5 +1,7 @@
 /***************************************************************************
 * Copyright (c) 2013 Abdurrahman AVCI <abdurrahmanavci@gmail.com>
+* Copyright (c) 2023 Serenity Cybersecurity, LLC <license@futurecrew.ru>
+*                    Author: Gleb Popov <arrowd@FreeBSD.org>
 *
 * This program is free software; you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
@@ -62,6 +64,8 @@ namespace SDDM {
         void hibernate();
         void hybridSleep();
 
+        void login(QVariantMap args) const;
+        // compatibility slot for old themes
         void login(const QString &user, const QString &password, const int sessionIndex) const;
 
     private slots:

--- a/src/greeter/theme/Main.qml
+++ b/src/greeter/theme/Main.qml
@@ -88,7 +88,11 @@ Rectangle {
                 focus: (listView.currentIndex === index) ? true : false
                 state: (listView.currentIndex === index) ? "active" : ""
 
-                onLogin: sddm.login(model.name, password, sessionIndex);
+                onLogin: sddm.login({
+                    user: model.name,
+                    password: password,
+                    sessionIndex: sessionIndex
+                });
 
                 MouseArea {
                     anchors.fill: parent


### PR DESCRIPTION
There are cases when it is required to pass additional data from the theme to the sddm.login() call. For instance, selecting an authentication type (password or facial recognition like Howdy) or passing some arguments to the session being started.