### PR TITLE
Add count property to SessionModel

### DIFF
--- a/src/greeter/SessionModel.h
+++ b/src/greeter/SessionModel.h
@@ -34,6 +34,7 @@ namespace SDDM {
         Q_OBJECT
         Q_DISABLE_COPY(SessionModel)
         Q_PROPERTY(int lastIndex READ lastIndex CONSTANT)
+        Q_PROPERTY(int count READ rowCount CONSTANT)
     public:
         enum SessionRole {
             DirectoryRole = Qt::UserRole + 1,


### PR DESCRIPTION
I added `count` property to `src/greeter/SessionModel.h` like in `UserModel.h` to make models look more consistent