### PR TITLE
Provide coinstallability for Qt 5 and Qt 6 themes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,7 +186,7 @@ set(ACCOUNTSSERVICE_DATA_DIR    "/var/lib/AccountsService"                      
 set(SYSTEM_CONFIG_DIR           "${CMAKE_INSTALL_PREFIX}/lib/sddm/sddm.conf.d"      CACHE PATH      "Path of the system sddm config directory")
 set(LOG_FILE                    "${CMAKE_INSTALL_FULL_LOCALSTATEDIR}/log/sddm.log"  CACHE PATH      "Path of the sddm log file")
 set(DBUS_CONFIG_FILENAME        "org.freedesktop.DisplayManager.conf"               CACHE STRING    "Name of the sddm config file")
-set(COMPONENTS_TRANSLATION_DIR  "${DATA_INSTALL_DIR}/translations"                  CACHE PATH      "Components translations directory")
+set(COMPONENTS_TRANSLATION_DIR  "${DATA_INSTALL_DIR}/translations-qt${QT_MAJOR_VERSION}" CACHE PATH      "Components translations directory")
 set(SDDM_INITIAL_VT             "1"                                                 CACHE STRING    "Initial tty to use")
 
 

--- a/src/common/ThemeMetadata.cpp
+++ b/src/common/ThemeMetadata.cpp
@@ -28,6 +28,7 @@ namespace SDDM {
         QString mainScript { QStringLiteral("Main.qml") };
         QString configFile;
         QString translationsDirectory { QStringLiteral(".") };
+        int qtVersion = 5;
     };
 
     ThemeMetadata::ThemeMetadata(const QString &path, QObject *parent) : QObject(parent), d(new ThemeMetadataPrivate()) {
@@ -50,11 +51,16 @@ namespace SDDM {
         return d->translationsDirectory;
     }
 
+    int ThemeMetadata::qtVersion() const {
+        return d->qtVersion;
+    }
+
     void ThemeMetadata::setTo(const QString &path) {
         QSettings settings(path, QSettings::IniFormat);
         // read values
         d->mainScript = settings.value(QStringLiteral("SddmGreeterTheme/MainScript"), QStringLiteral("Main.qml")).toString();
         d->configFile = settings.value(QStringLiteral("SddmGreeterTheme/ConfigFile"), QStringLiteral("theme.conf")).toString();
         d->translationsDirectory = settings.value(QStringLiteral("SddmGreeterTheme/TranslationsDirectory"), QStringLiteral(".")).toString();
+        d->qtVersion = settings.value(QStringLiteral("SddmGreeterTheme/QtVersion"), 5).toInt();
     }
 }

--- a/src/common/ThemeMetadata.h
+++ b/src/common/ThemeMetadata.h
@@ -36,6 +36,7 @@ namespace SDDM {
         const QString &mainScript() const;
         const QString &configFile() const;
         const QString &translationsDirectory() const;
+        int qtVersion() const;
 
         void setTo(const QString &path);
 

--- a/src/daemon/Greeter.h
+++ b/src/daemon/Greeter.h
@@ -79,6 +79,7 @@ namespace SDDM {
         QProcess *m_process { nullptr };
 
         static void insertEnvironmentList(QStringList names, QProcessEnvironment sourceEnv, QProcessEnvironment &targetEnv);
+        static QString greeterPathForQt(int qtVersion);
     };
 }
 

--- a/src/greeter/CMakeLists.txt
+++ b/src/greeter/CMakeLists.txt
@@ -1,3 +1,14 @@
+if(QT_MAJOR_VERSION EQUAL "5")
+    # Keep the unversioned name for Qt5. When upgrading SDDM, the old daemon
+    # might still be running and only know about "sddm-greeter". Keeping the
+    # previous name around also helps users calling it directly.
+    set(GREETER_TARGET sddm-greeter)
+else()
+    set(GREETER_TARGET sddm-greeter-qt${QT_MAJOR_VERSION})
+endif()
+
+message(STATUS "Building greeter for Qt ${QT_MAJOR_VERSION} as ${GREETER_TARGET}")
+
 include_directories(
     "${CMAKE_SOURCE_DIR}/src/common"
     "${CMAKE_BINARY_DIR}/src/common"
@@ -28,18 +39,17 @@ configure_file("theme.qrc" "theme.qrc")
 
 qt_add_resources(RESOURCES ${CMAKE_CURRENT_BINARY_DIR}/theme.qrc)
 
-add_executable(sddm-greeter ${GREETER_SOURCES} ${RESOURCES})
-target_link_libraries(sddm-greeter
+add_executable(${GREETER_TARGET} ${GREETER_SOURCES} ${RESOURCES})
+target_link_libraries(${GREETER_TARGET}
                       Qt${QT_MAJOR_VERSION}::Quick
                       ${LIBXCB_LIBRARIES}
                       ${LIBXKB_LIBRARIES})
 
 if(JOURNALD_FOUND)
-    target_link_libraries(sddm-greeter ${JOURNALD_LIBRARIES})
+    target_link_libraries(${GREETER_TARGET} ${JOURNALD_LIBRARIES})
 endif()
 
 # Translations
-add_dependencies(sddm-greeter components-translation)
-add_dependencies(sddm-greeter themes-translation)
+add_dependencies(${GREETER_TARGET} components-translation themes-translation)
 
-install(TARGETS sddm-greeter DESTINATION "${CMAKE_INSTALL_BINDIR}")
+install(TARGETS ${GREETER_TARGET} DESTINATION "${CMAKE_INSTALL_BINDIR}")


### PR DESCRIPTION
sddm-greeter is already a separate process, so it's actually rather simple to support themes using Qt 5 and themes using Qt 6 on the same system. This PR achieves this by installing the greeter specific files with a -qt6 suffix when `BUILD_FOR_QT6=ON` and dynamically choosing which greeter to execute based on the `QtVersion=` property in the theme `metadata.desktop`. For backwards compatibility, this defaults to 5 if not present.

This means that all current Qt 6 themes (i.e. just breeze?) will have to add `QtVersion=6`, otherwise the Qt 5 greeter will be used.

Open topics:
- [ ] Are translations in .qm format compatible across Qt major versions? I couldn't find any info for this. If they are compatible, then the -qt suffix for the translation dir can be avoided. Themes can also provide .qm files.
- [ ] Should the `QtVersion` property allow to specify multiple versions as fallback? I'm not sure whether it's practical to have a theme which supports multiple major versions, especially if .qm files are not necessarily compatible.
- [ ] What should the example themes specify as Qt version? elarun currently has a broken background with Qt 6.
- [ ] For after the merge: Document the `QtVersion` property and behaviour

With https://github.com/sddm/sddm/pull/1790 on top, the Qt 6 build will automatically build and install the Qt 5 greeter as well.