### PR TITLE
Don't populate list of keyboard layouts in the wayland greeter

### DIFF
--- a/src/greeter/waylandkeyboardbackend.cpp
+++ b/src/greeter/waylandkeyboardbackend.cpp
@@ -92,7 +92,9 @@ QList<QObject *> parseRules(const QString &filename, int &current)
 
 void WaylandKeyboardBackend::init()
 {
-    d->layouts = parseRules(QStringLiteral("/usr/share/X11/xkb/rules/evdev.xml"), d->layout_id);
+    // TODO: We can't actually switch keyboard layout yet, so don't populate a list of layouts
+    // so that themes can know to not show the option to change layout
+    // d->layouts = parseRules(QStringLiteral("/usr/share/X11/xkb/rules/evdev.xml"), d->layout_id);
 }
 
 void WaylandKeyboardBackend::disconnect()


### PR DESCRIPTION
Layout switching is not implemented. We should keep the list of layouts empty so that themes can know to not show the option to change layout