### PR TITLE
Prevent tmpfiles from removing "old" xauth files

### DIFF
--- a/services/sddm-tmpfiles.conf.in
+++ b/services/sddm-tmpfiles.conf.in
@@ -6,3 +6,9 @@ d	${RUNTIME_DIR}	0711	root	root
 r!	/tmp/sddm-auth*
 # xauth files passed to user sessions
 r!	/tmp/xauth_*
+# "r!" above means to remove the files if existent (r), but only at boot (!).
+# tmpfiles.d/tmp.conf declares a periodic cleanup of old /tmp/ files, which
+# would ordinarily result in the deletion of our xauth files. To prevent that
+# from happening, explicitly tag these as X (ignore).
+X	/tmp/sddm-auth*
+X	/tmp/xauth_*


### PR DESCRIPTION
Starting from sddm 0.20 (by https://github.com/sddm/sddm/pull/1230), the xauth file is at `/tmp/xauth_*` instead of `~/.Xauthority`. The new location is subject to systemd-tmpfiles's cleanup, which deletes files from /tmp/ that are older than 10 days: https://github.com/systemd/systemd/blob/v254/tmpfiles.d/tmp.conf

The xauth file should not be removed while the session is active, because it is needed for starting X applications. When removed, X applications won't start any more.

This patch fixes the issue by declaring these files as "ignored" in sddm-tmpfiles.conf, so that systemd-tmpfiles doesn't remove them.

Minimal test case:

```sh
touch /tmp/xauth_testonly
SYSTEMD_LOG_LEVEL=debug systemd-tmpfiles --prefix=/tmp/ --clean
```

Pre-patch output:

> File "/tmp/xauth_testonly": change time Mon 2023-10-02 01:27:38.395466 CEST is too new.

(meaning that the file was considered for removal)

Post-patch output:

> Ignoring "/tmp/xauth_testonly": a separate glob exists.

(meaning that the file is ignored and not considered for removal)