### PR TITLE
Move autologin fallback (handle auth error) from `slotAuthError` to `slotAuthenticationFinished`

### DIFF
--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -463,6 +463,11 @@ namespace SDDM {
     }
 
     void Display::slotAuthenticationFinished(const QString &user, bool success) {
+        if (m_auth->autologin() && !success) {
+            handleAutologinFailure();
+            return;
+        }
+
         if (success) {
             qDebug() << "Authentication for user " << user << " successful";
 
@@ -507,11 +512,6 @@ namespace SDDM {
 
     void Display::slotAuthError(const QString &message, Auth::Error error) {
         qWarning() << "Authentication error:" << error << message;
-
-        if (m_auth->autologin()) {
-            handleAutologinFailure();
-            return;
-        }
 
         if (!m_socket)
             return;


### PR DESCRIPTION
There may be a case when pam authentication error not only of the `auth` type, but also, for example, of the `session` type fall into the `slotAuthError` during autologin. For example, a pam module error in the file `/etc/pam.d/postlogin` already during the loaded session. As a result, a fallback (`handleAutologinFailure`) is triggered that loads greeter (sddm-theme) already on top of the loaded session, which leads to unpleasant consequences.

In my opinion, this is incorrect, and I think it's worth transferring the fallback to the `slotAuthenticationFinished` method and calling fallback if `success` = false, then the fallback will trigger exactly when an error of the `auth` type occurred, i.e. when the session really wasn't loaded and the greeter should be loaded to avoid black screen with only cursor.