### PR TITLE
Correctly integrate the greeter with layer-shell

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
           dnf --assumeyes install dnf-plugins-core
           if [[ "${{ matrix.container-image }}" =~ "centos" ]]; then dnf --assumeyes config-manager --set-enabled crb && dnf --assumeyes install epel-release; fi
           dnf --assumeyes builddep sddm
-          dnf --assumeyes --allowerasing --nobest install clang clazy
+          dnf --assumeyes --allowerasing --nobest install clang clazy layer-shell-qt-devel
       - name: Dependencies (deb-type)
         if: ${{ contains(matrix.container-image, 'ubuntu') }}
         run: |
@@ -62,7 +62,7 @@ jobs:
           if [ "${{ matrix.qt }}" = "qt6" ]; then
             DEBIAN_FRONTEND=noninteractive apt-get install clang clazy qt6-base-dev qt6-base-dev-tools qt6-tools-dev qt6-declarative-dev qml6-module-qtqml-workerscript qml6-module-qtquick-window -y
           else
-            DEBIAN_FRONTEND=noninteractive apt-get install clang clazy qml-module-qttest -y
+            DEBIAN_FRONTEND=noninteractive apt-get install clang clazy liblayershellqtinterface-dev qml-module-qttest -y
           fi
       - name: Build
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,9 @@ find_package(XCB REQUIRED)
 # XKB
 find_package(XKB REQUIRED)
 
+# LayerShell integration
+find_package(LayerShellQt REQUIRED)
+
 # Qt
 if(BUILD_WITH_QT6)
     set(QT_MAJOR_VERSION 6)

--- a/src/greeter/CMakeLists.txt
+++ b/src/greeter/CMakeLists.txt
@@ -31,6 +31,7 @@ qt_add_resources(RESOURCES ${CMAKE_CURRENT_BINARY_DIR}/theme.qrc)
 add_executable(sddm-greeter ${GREETER_SOURCES} ${RESOURCES})
 target_link_libraries(sddm-greeter
                       Qt${QT_MAJOR_VERSION}::Quick
+                      LayerShellQt::Interface
                       ${LIBXCB_LIBRARIES}
                       ${LIBXKB_LIBRARIES})
 

--- a/src/greeter/GreeterApp.cpp
+++ b/src/greeter/GreeterApp.cpp
@@ -45,6 +45,8 @@
 #include <QVersionNumber>
 #include <QSurfaceFormat>
 
+#include <LayerShellQt/Window>
+
 #include <iostream>
 
 #define TR(x) QT_TRANSLATE_NOOP("Command line parser", QStringLiteral(x))
@@ -151,6 +153,10 @@ namespace SDDM {
         //view->setGeometry(QRect(QPoint(0, 0), screen->geometry().size()));
         view->setGeometry(screen->geometry());
         view->setFlags(Qt::FramelessWindowHint);
+        if (auto layerWindow = LayerShellQt::Window::get(view)) {
+            layerWindow->setKeyboardInteractivity(LayerShellQt::Window::KeyboardInteractivityExclusive);
+        }
+
         m_views.append(view);
 
         // remove the view when the screen is removed, but we


### PR DESCRIPTION
When using Wayland as the display server it is possible and very likely that we are requested to use the layer-shell protocol to display the greeter, as it better fits its windowing model. This is selected with QT_WAYLAND_SHELL_INTEGRATION=layer-shell.

With Plasma 6 LayerShellQt has changed the default keyboard policy to not receive any inputs, now following the protocol spec. That breaks the ability type in a username/password, unless we request it to enable keyboard events again.