### PR TITLE
Add nushell-specific commands to Xsession and wayland-session

### DIFF
--- a/data/scripts/Xsession
+++ b/data/scripts/Xsession
@@ -23,6 +23,11 @@ if [ -z "$SDDM_XSESSION_PROFILE_READ" ]; then
       [ -f $HOME/.profile ] && . $HOME/.profile
       exec $SHELL --login -c 'exec $argv' $0 "$@"
       ;;
+    */nu)
+      [ -f /etc/profile ] && . /etc/profile
+      [ -f $HOME/.profile ] && . $HOME/.profile
+      exec $SHELL --login -c "exec $0 '$@'"
+      ;;
     *) # Plain sh, ksh, and anything we do not know.
       [ -f /etc/profile ] && . /etc/profile
       [ -f $HOME/.profile ] && . $HOME/.profile

--- a/data/scripts/Xsession
+++ b/data/scripts/Xsession
@@ -26,7 +26,7 @@ if [ -z "$SDDM_XSESSION_PROFILE_READ" ]; then
     */nu)
       [ -f /etc/profile ] && . /etc/profile
       [ -f $HOME/.profile ] && . $HOME/.profile
-      exec $SHELL --login -c "exec $0 '$@'"
+      exec $SHELL --login -c "exec $0 '$*'"
       ;;
     *) # Plain sh, ksh, and anything we do not know.
       [ -f /etc/profile ] && . /etc/profile

--- a/data/scripts/wayland-session
+++ b/data/scripts/wayland-session
@@ -25,7 +25,7 @@ case $SHELL in
   */nu)
     [ -f /etc/profile ] && . /etc/profile
     [ -f $HOME/.profile ] && . $HOME/.profile
-    exec $SHELL --login -c "exec $@"
+    exec $SHELL --login -c "exec $*"
     ;;
   *) # Plain sh, ksh, and anything we do not know.
     [ -f /etc/profile ] && . /etc/profile

--- a/data/scripts/wayland-session
+++ b/data/scripts/wayland-session
@@ -22,6 +22,11 @@ case $SHELL in
     [ -f $HOME/.profile ] && . $HOME/.profile
     exec $SHELL --login -c 'exec $argv' $@
     ;;
+  */nu)
+    [ -f /etc/profile ] && . /etc/profile
+    [ -f $HOME/.profile ] && . $HOME/.profile
+    exec $SHELL --login -c "exec $@"
+    ;;
   *) # Plain sh, ksh, and anything we do not know.
     [ -f /etc/profile ] && . /etc/profile
     [ -f $HOME/.profile ] && . $HOME/.profile


### PR DESCRIPTION
Add special cases in `Xsession` and `wayland-session` to load nushell's login environment if the user's shell is `nu`.