### PR TITLE
Switch the Wayland greeter default to use Weston's Kiosk shell

### DIFF
--- a/data/man/sddm.conf.rst.in
+++ b/data/man/sddm.conf.rst.in
@@ -170,7 +170,7 @@ The `UserAuthFile=` option was removed, the file is always created as
 
 `CompositorCommand=`
         Path of the compositor to execute when starting the greeter.
-        Default value is "weston --shell=fullscreen-shell.so".
+        Default value is "weston --shell=kiosk".
 
 `SessionDir=`
 	Comma-separated list of directories containing session files.

--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -78,7 +78,7 @@ namespace SDDM {
         );
 
         Section(Wayland,
-            Entry(CompositorCommand,   QString,     _S("weston --shell=fullscreen-shell.so"),   _S("Path of the Wayland compositor to execute when starting the greeter"));
+            Entry(CompositorCommand,   QString,     _S("weston --shell=kiosk"),                 _S("Path of the Wayland compositor to execute when starting the greeter"));
             Entry(SessionDir,          QStringList, {_S("/usr/local/share/wayland-sessions"),
                                                      _S("/usr/share/wayland-sessions")},        _S("Comma-separated list of directories containing available Wayland sessions"));
             Entry(SessionCommand,      QString,     _S(WAYLAND_SESSION_COMMAND),                _S("Path to a script to execute when starting the desktop session"));

--- a/src/daemon/Greeter.cpp
+++ b/src/daemon/Greeter.cpp
@@ -221,7 +221,7 @@ namespace SDDM {
                 m_auth->setCookie(qobject_cast<XorgDisplayServer*>(displayServer)->cookie());
             } else if (m_display->displayServerType() == Display::WaylandDisplayServerType) {
                 env.insert(QStringLiteral("QT_QPA_PLATFORM"), QStringLiteral("wayland"));
-                env.insert(QStringLiteral("QT_WAYLAND_SHELL_INTEGRATION"), QStringLiteral("fullscreen-shell-v1"));
+                env.insert(QStringLiteral("QT_WAYLAND_SHELL_INTEGRATION"), QStringLiteral("xdg-shell"));
             }
             m_auth->insertEnvironment(env);
 


### PR DESCRIPTION
Weston introduced the kiosk shell in Weston 9.0 and deprecated the fullscreen shell in Weston 12.0.