### PR TITLE
Align XDG_SESSION_DESKTOP value with other display managers

### DIFF
--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -441,7 +441,7 @@ namespace SDDM {
         env.insert(QStringLiteral("XDG_SEAT"), seat()->name());
         env.insert(QStringLiteral("XDG_VTNR"), QString::number(m_sessionTerminalId));
 #ifdef HAVE_SYSTEMD
-        env.insert(QStringLiteral("XDG_SESSION_DESKTOP"), session.desktopNames());
+        env.insert(QStringLiteral("XDG_SESSION_DESKTOP"), session.desktopSession());
 #endif
 
         if (session.xdgSessionType() == QLatin1String("x11")) {


### PR DESCRIPTION
The only available specification[1] for the variable is not really helpul as nobody else complies with it:
GDM[2] and LightDM[3] are using the same value for `DESKTOP_SESSION`, `XDG_SESSION_DESKTOP` and `GDMSESSION` (sddm doesn't set the last one).

Potentially breaking, as it will change `X_S_D=KDE` to `X_S_D=plasma`, but the check like that would already fail with any other display manager. At the very least, it unbreaks the valid cases where
 - `DesktopNames` key is not set
 - `DesktopNames` is set to a list of values

[1]: https://www.freedesktop.org/software/systemd/man/pam_systemd.html#desktop=
[2]: https://gitlab.gnome.org/GNOME/gdm/-/blob/a76a68c7225fba00de199139a74a8eed28c576b5/daemon/gdm-session.c#L2873
[3]: https://github.com/canonical/lightdm/blob/de3606561b5107aabebca3e624fdf413ae61924f/src/seat.c#L975