### PR TITLE
Themes: Qt6 compatibiltiy

### DIFF
--- a/components/2.0/Button.qml
+++ b/components/2.0/Button.qml
@@ -67,7 +67,9 @@ Rectangle {
         }
     ]
 
-    Behavior on color { NumberAnimation { duration: 200 } }
+    transitions: Transition {
+        ColorAnimation { duration: 200 }
+    }
 
     clip: true
     smooth: true

--- a/components/2.0/Button.qml
+++ b/components/2.0/Button.qml
@@ -111,7 +111,7 @@ Rectangle {
         onReleased: { container.focus = true; container.released() }
     }
 
-    Keys.onPressed: {
+    Keys.onPressed: function (event) {
         if (event.key === Qt.Key_Space) {
             container.spaceDown = true;
             container.pressed()
@@ -122,7 +122,7 @@ Rectangle {
         }
     }
 
-    Keys.onReleased: {
+    Keys.onReleased: function (event) {
         if (event.key === Qt.Key_Space) {
             container.spaceDown = false;
             container.released()

--- a/components/2.0/ComboBox.qml
+++ b/components/2.0/ComboBox.qml
@@ -70,8 +70,6 @@ FocusScope {
         border.color: container.borderColor
         border.width: container.borderWidth
 
-        Behavior on border.color { ColorAnimation { duration: 100 } }
-
         states: [
             State {
                 name: "hover"; when: mouseArea.containsMouse
@@ -82,6 +80,10 @@ FocusScope {
                 PropertyChanges { target: main; border.width: container.borderWidth; border.color: container.focusColor }
             }
         ]
+
+        transitions: Transition {
+            ColorAnimation { property: "border.color"; duration: 100 }
+        }
     }
 
     Loader {
@@ -157,8 +159,6 @@ FocusScope {
 
         clip: true
 
-        Behavior on height { NumberAnimation { duration: 100 } }
-
         Component {
             id: myDelegate
 
@@ -214,6 +214,10 @@ FocusScope {
                 PropertyChanges { target: dropDown; height: (container.height - 2*container.borderWidth) * listView.count + container.borderWidth}
             }
         ]
+
+        transitions: Transition {
+            NumberAnimation { property: "height"; duration: 100 }
+        }
     }
 
     function toggle() {

--- a/components/2.0/ComboBox.qml
+++ b/components/2.0/ComboBox.qml
@@ -134,7 +134,7 @@ FocusScope {
         }
     }
 
-    Keys.onPressed: {
+    Keys.onPressed: function (event) {
         if (event.key === Qt.Key_Up) {
             listView.decrementCurrentIndex()
         } else if (event.key === Qt.Key_Down) {

--- a/components/2.0/ImageButton.qml
+++ b/components/2.0/ImageButton.qml
@@ -53,7 +53,9 @@ Image {
         }
     ]
 
-    Behavior on opacity { NumberAnimation { duration: 200 } }
+    transitions: Transition {
+        NumberAnimation { property: "opacity"; duration: 200 }
+    }
 
     clip: true
     smooth: true

--- a/components/2.0/ImageButton.qml
+++ b/components/2.0/ImageButton.qml
@@ -77,7 +77,7 @@ Image {
         onReleased: { container.focus = true; container.released() }
     }
 
-    Keys.onPressed: {
+    Keys.onPressed: function (event) {
         if (event.key === Qt.Key_Space) {
             container.spaceDown = true;
             container.pressed()
@@ -88,7 +88,7 @@ Image {
         }
     }
 
-    Keys.onReleased: {
+    Keys.onReleased: function (event) {
         if (event.key === Qt.Key_Space) {
             container.spaceDown = false;
             container.released()

--- a/components/2.0/LayoutBox.qml
+++ b/components/2.0/LayoutBox.qml
@@ -30,12 +30,16 @@ ComboBox {
     model: keyboard.layouts
     index: keyboard.currentLayout
 
-    onValueChanged: keyboard.currentLayout = id
+    function onValueChanged(id) {
+        keyboard.currentLayout = id
+    }
 
     Connections {
         target: keyboard
 
-        onCurrentLayoutChanged: combo.index = keyboard.currentLayout
+        function onCurrentLayoutChanged() {
+            combo.index = keyboard.currentLayout
+        }
     }
 
     rowDelegate: Rectangle {

--- a/components/2.0/Menu.qml
+++ b/components/2.0/Menu.qml
@@ -34,14 +34,16 @@ Rectangle {
     property alias model: menuList.model
     property alias index: menuList.currentIndex
 
-    Behavior on height { NumberAnimation { duration: 100 } }
-
     states: [
         State {
             name: "visible";
             PropertyChanges { target: menu; height: itemHeight * menuList.count }
         }
     ]
+
+    transitions: Transition {
+        NumberAnimation { property: "height"; duration: 100 }
+    }
 
     Component {
         id: listViewItem

--- a/components/2.0/PictureBox.qml
+++ b/components/2.0/PictureBox.qml
@@ -37,8 +37,6 @@ FocusScope {
 
     signal login()
 
-    Behavior on height { NumberAnimation { duration: 100 } }
-
     states: [
         State {
             name: ""
@@ -49,6 +47,10 @@ FocusScope {
             PropertyChanges { target: container; height: 225 }
         }
     ]
+
+    transitions: Transition {
+        NumberAnimation { property: "height"; duration: 100 }
+    }
 
     Rectangle {
         id: shadow

--- a/components/2.0/PictureBox.qml
+++ b/components/2.0/PictureBox.qml
@@ -105,7 +105,7 @@ FocusScope {
             focus: true
             visible: showPassword
 
-            Keys.onPressed: {
+            Keys.onPressed: function (event) {
                 if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
                     container.login();
                     event.accepted = true

--- a/components/2.0/TextBox.qml
+++ b/components/2.0/TextBox.qml
@@ -47,8 +47,6 @@ FocusScope {
         border.color: container.borderColor
         border.width: 1
 
-        Behavior on border.color { ColorAnimation { duration: 100 } }
-
         states: [
             State {
                 name: "hover"; when: mouseArea.containsMouse
@@ -59,6 +57,10 @@ FocusScope {
                 PropertyChanges { target: main; border.width: 1; border.color: container.focusColor }
             }
         ]
+
+        transitions: Transition {
+            ColorAnimation { duration: 100 }
+        }
     }
 
     MouseArea {

--- a/data/themes/CMakeLists.txt
+++ b/data/themes/CMakeLists.txt
@@ -10,9 +10,15 @@ foreach(THEME ${THEMES})
 
     qt_add_translation(QM_FILES "${TRANSLATION_SOURCES}")
 
-    install(DIRECTORY "${THEME}" DESTINATION "${DATA_INSTALL_DIR}/themes" PATTERN "${THEME}/*.ts"
-            EXCLUDE PATTERN "${THEME}/.gitattributes"
-            EXCLUDE)
+    configure_file("${THEME}/metadata.desktop.in" "${THEME}/metadata.desktop" @ONLY)
+
+    install(DIRECTORY "${THEME}" DESTINATION "${DATA_INSTALL_DIR}/themes"
+            PATTERN "${THEME}/*.in" EXCLUDE
+            PATTERN "${THEME}/*.ts" EXCLUDE
+            PATTERN "${THEME}/.gitattributes" EXCLUDE)
+
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${THEME}/metadata.desktop"
+            DESTINATION "${DATA_INSTALL_DIR}/themes/${THEME}/")
 
     list(APPEND THEMES_QM_FILES ${QM_FILES})
 endforeach(THEME)

--- a/data/themes/elarun/Main.qml
+++ b/data/themes/elarun/Main.qml
@@ -50,11 +50,12 @@ Rectangle {
 
     Background {
         anchors.fill: parent
-        source: config.background
+        source: Qt.resolvedUrl(config.background)
         fillMode: Image.PreserveAspectCrop
         onStatusChanged: {
-            if (status == Image.Error && source != config.defaultBackground) {
-                source = config.defaultBackground
+            var defaultBackground = Qt.resolvedUrl(config.defaultBackground)
+            if (status == Image.Error && source != defaultBackground) {
+                source = defaultBackground
             }
         }
     }
@@ -72,12 +73,12 @@ Rectangle {
 
             Image {
                 anchors.fill: parent
-                source: "images/rectangle.png"
+                source: Qt.resolvedUrl("images/rectangle.png")
             }
 
             Image {
                 anchors.fill: parent
-                source: "images/rectangle_overlay.png"
+                source: Qt.resolvedUrl("images/rectangle_overlay.png")
                 opacity: 0.1
             }
 
@@ -103,7 +104,7 @@ Rectangle {
                     anchors.centerIn: parent
 
                     Row {
-                        Image { source: "images/user_icon.png" }
+                        Image { source: Qt.resolvedUrl("images/user_icon.png") }
 
                         TextBox {
                             id: user_entry
@@ -121,7 +122,7 @@ Rectangle {
 
                     Row {
 
-                        Image { source: "images/lock.png" }
+                        Image { source: Qt.resolvedUrl("images/lock.png") }
 
                         PasswordBox {
                             id: pw_entry
@@ -150,7 +151,7 @@ Rectangle {
                     anchors.verticalCenter: parent.verticalCenter
                     anchors.margins: 20
 
-                    source: "images/login_normal.png"
+                    source: Qt.resolvedUrl("images/login_normal.png")
 
                     onClicked: sddm.login(user_entry.text, pw_entry.text, sessionIndex)
 
@@ -171,7 +172,7 @@ Rectangle {
 
                         ImageButton {
                             id: system_button
-                            source: "images/system_shutdown.png"
+                            source: Qt.resolvedUrl("images/system_shutdown.png")
                             onClicked: sddm.powerOff()
 
 			    KeyNavigation.backtab: session; KeyNavigation.tab: reboot_button
@@ -179,7 +180,7 @@ Rectangle {
 
                         ImageButton {
                             id: reboot_button
-                            source: "images/system_reboot.png"
+                            source: Qt.resolvedUrl("images/system_reboot.png")
                             onClicked: sddm.reboot()
 
                             KeyNavigation.backtab: system_button; KeyNavigation.tab: suspend_button
@@ -187,7 +188,7 @@ Rectangle {
 
                         ImageButton {
                             id: suspend_button
-                            source: "images/system_suspend.png"
+                            source: Qt.resolvedUrl("images/system_suspend.png")
                             visible: sddm.canSuspend
                             onClicked: sddm.suspend()
 
@@ -196,7 +197,7 @@ Rectangle {
 
                         ImageButton {
                             id: hibernate_button
-                            source: "images/system_hibernate.png"
+                            source: Qt.resolvedUrl("images/system_hibernate.png")
                             visible: sddm.canHibernate
                             onClicked: sddm.hibernate()
 
@@ -256,7 +257,7 @@ Rectangle {
                 width: 245
                 anchors.verticalCenter: parent.verticalCenter
 
-                arrowIcon: "angle-down.png"
+                arrowIcon: Qt.resolvedUrl("angle-down.png")
 
                 model: sessionModel
                 index: sessionModel.lastIndex
@@ -285,7 +286,7 @@ Rectangle {
 
                 visible: keyboard.enabled && keyboard.layouts.length > 0
 
-                arrowIcon: "angle-down.png"
+                arrowIcon: Qt.resolvedUrl("angle-down.png")
 
                 KeyNavigation.backtab: session; KeyNavigation.tab: user_entry
             }

--- a/data/themes/elarun/Main.qml
+++ b/data/themes/elarun/Main.qml
@@ -39,11 +39,11 @@ Rectangle {
 
     Connections {
         target: sddm
-        onLoginSucceeded: {
+        function onLoginSucceeded() {
         }
-        onInformationMessage: {
+        function onInformationMessage(message) {
         }
-        onLoginFailed: {
+        function onLoginFailed() {
             pw_entry.text = ""
         }
     }
@@ -135,7 +135,7 @@ Rectangle {
 
                             KeyNavigation.backtab: user_entry; KeyNavigation.tab: login_button
 
-                            Keys.onPressed: {
+                            Keys.onPressed: function (event) {
                                 if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
                                     sddm.login(user_entry.text, pw_entry.text, sessionIndex)
                                     event.accepted = true

--- a/data/themes/elarun/Main.qml
+++ b/data/themes/elarun/Main.qml
@@ -270,6 +270,8 @@ Rectangle {
                 height: parent.height
                 anchors.verticalCenter: parent.verticalCenter
 
+                visible: layoutBox.visible
+
                 text: textConstants.layout
                 font.pixelSize: 14
                 verticalAlignment: Text.AlignVCenter
@@ -280,6 +282,8 @@ Rectangle {
                 width: 90
                 anchors.verticalCenter: parent.verticalCenter
                 font.pixelSize: 14
+
+                visible: keyboard.enabled && keyboard.layouts.length > 0
 
                 arrowIcon: "angle-down.png"
 

--- a/data/themes/elarun/metadata.desktop.in
+++ b/data/themes/elarun/metadata.desktop.in
@@ -46,4 +46,4 @@ TranslationsDirectory=translations
 Theme-Id=elarun
 Theme-API=2.0
 Website=https://github.com/sddm/sddm
-
+QtVersion=@QT_MAJOR_VERSION@

--- a/data/themes/maldives/Main.qml
+++ b/data/themes/maldives/Main.qml
@@ -201,6 +201,8 @@ Rectangle {
                         spacing : 4
                         anchors.bottom: parent.bottom
 
+                        visible: keyboard.enabled && keyboard.layouts.length > 0
+
                         Text {
                             id: lblLayout
                             width: parent.width

--- a/data/themes/maldives/Main.qml
+++ b/data/themes/maldives/Main.qml
@@ -58,11 +58,12 @@ Rectangle {
 
     Background {
         anchors.fill: parent
-        source: config.background
+        source: Qt.resolvedUrl(config.background)
         fillMode: Image.PreserveAspectCrop
         onStatusChanged: {
-            if (status == Image.Error && source != config.defaultBackground) {
-                source = config.defaultBackground
+            var defaultBackground = Qt.resolvedUrl(config.defaultBackground)
+            if (status == Image.Error && source != defaultBackground) {
+                source = defaultBackground
             }
         }
     }
@@ -87,7 +88,7 @@ Rectangle {
             width: Math.max(320, mainColumn.implicitWidth + 50)
             height: Math.max(320, mainColumn.implicitHeight + 50)
 
-            source: "rectangle.png"
+            source: Qt.resolvedUrl("rectangle.png")
 
             Column {
                 id: mainColumn
@@ -186,7 +187,7 @@ Rectangle {
                             width: parent.width; height: 30
                             font.pixelSize: 14
 
-                            arrowIcon: "angle-down.png"
+                            arrowIcon: Qt.resolvedUrl("angle-down.png")
 
                             model: sessionModel
                             index: sessionModel.lastIndex
@@ -217,7 +218,7 @@ Rectangle {
                             width: parent.width; height: 30
                             font.pixelSize: 14
 
-                            arrowIcon: "angle-down.png"
+                            arrowIcon: Qt.resolvedUrl("angle-down.png")
 
                             KeyNavigation.backtab: session; KeyNavigation.tab: loginButton
                         }

--- a/data/themes/maldives/Main.qml
+++ b/data/themes/maldives/Main.qml
@@ -40,17 +40,16 @@ Rectangle {
     Connections {
         target: sddm
 
-        onLoginSucceeded: {
+        function onLoginSucceeded() {
             errorMessage.color = "steelblue"
             errorMessage.text = textConstants.loginSucceeded
         }
-
-        onLoginFailed: {
+        function onLoginFailed() {
             password.text = ""
             errorMessage.color = "red"
             errorMessage.text = textConstants.loginFailed
         }
-        onInformationMessage: {
+        function onInformationMessage(message) {
             errorMessage.color = "red"
             errorMessage.text = message
         }
@@ -126,7 +125,7 @@ Rectangle {
 
                         KeyNavigation.backtab: rebootButton; KeyNavigation.tab: password
 
-                        Keys.onPressed: {
+                        Keys.onPressed: function (event) {
                             if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
                                 sddm.login(name.text, password.text, sessionIndex)
                                 event.accepted = true
@@ -153,7 +152,7 @@ Rectangle {
 
                         KeyNavigation.backtab: name; KeyNavigation.tab: session
 
-                        Keys.onPressed: {
+                        Keys.onPressed: function (event) {
                             if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
                                 sddm.login(name.text, password.text, sessionIndex)
                                 event.accepted = true

--- a/data/themes/maldives/metadata.desktop.in
+++ b/data/themes/maldives/metadata.desktop.in
@@ -14,3 +14,4 @@ TranslationsDirectory=translations
 Email=abdurrahmanavci@gmail.com
 Theme-Id=maldives
 Theme-API=2.0
+QtVersion=@QT_MAJOR_VERSION@

--- a/data/themes/maya/Main.qml
+++ b/data/themes/maya/Main.qml
@@ -251,7 +251,7 @@ Rectangle {
         font.family     : opensans_cond_light.name
         font.pixelSize  : spFontNormal
 
-        arrowIcon: "images/ic_arrow_drop_down_white_24px.svg"
+        arrowIcon: Qt.resolvedUrl("images/ic_arrow_drop_down_white_24px.svg")
         arrowColor: primaryHue3
 
         KeyNavigation.tab     : maya_username
@@ -296,7 +296,7 @@ Rectangle {
         font.family     : opensans_cond_light.name
         font.pixelSize  : spFontNormal
 
-        arrowIcon: "images/ic_arrow_drop_down_white_24px.svg"
+        arrowIcon: Qt.resolvedUrl("images/ic_arrow_drop_down_white_24px.svg")
         arrowColor: primaryHue3
 
         KeyNavigation.tab     : maya_layout
@@ -355,7 +355,7 @@ Rectangle {
         label       : textConstants.shutdown
         labelColor  : normalText
 
-        icon        : "images/ic_power_settings_new_white_24px.svg"
+        icon        : Qt.resolvedUrl("images/ic_power_settings_new_white_24px.svg")
         iconColor   : accentShade
 
         hoverIconColor  : powerColor
@@ -381,7 +381,7 @@ Rectangle {
         label       : textConstants.reboot
         labelColor  : normalText
 
-        icon        : "images/ic_refresh_white_24px.svg"
+        icon        : Qt.resolvedUrl("images/ic_refresh_white_24px.svg")
         iconColor   : accentLight
 
         hoverIconColor  : rebootColor
@@ -492,7 +492,7 @@ Rectangle {
         hoverColor  : accentLight
         textColor   : normalText
 
-        image       : "images/ic_warning_white_24px.svg"
+        image       : Qt.resolvedUrl("images/ic_warning_white_24px.svg")
 
         tooltipEnabled  : true
         tooltipText     : textConstants.capslockWarning

--- a/data/themes/maya/Main.qml
+++ b/data/themes/maya/Main.qml
@@ -239,6 +239,8 @@ Rectangle {
         width   : spUnit * 2
         height  : parent.height
 
+        visible : keyboard.enabled && keyboard.layouts.length > 0
+
         color       : primaryHue1
         borderColor : primaryHue3
         focusColor  : accentLight
@@ -260,6 +262,8 @@ Rectangle {
         height  : parent.height
 
         text    : textConstants.layout
+
+        visible : maya_layout.visible
 
         color   : normalText
 

--- a/data/themes/maya/Main.qml
+++ b/data/themes/maya/Main.qml
@@ -75,7 +75,7 @@ Rectangle {
   Connections {
     target: sddm
 
-    onLoginSucceeded: {
+    function onLoginSucceeded() {
       prompt_bg.color = successText
       prompt_txt.text = textConstants.loginSucceeded
 
@@ -84,7 +84,7 @@ Rectangle {
 
       anim_success.start()
     }
-    onLoginFailed: {
+    function onLoginFailed() {
       prompt_bg.color = failureText
       prompt_txt.text = textConstants.loginFailed
 
@@ -93,7 +93,7 @@ Rectangle {
 
       anim_failure.start()
     }
-    onInformationMessage: {
+    function onInformationMessage(message) {
       prompt_bg.color = failureText
       prompt_txt.text = message
 
@@ -505,7 +505,7 @@ Rectangle {
         KeyNavigation.tab     : maya_login
         KeyNavigation.backtab : maya_username
 
-        Keys.onPressed: {
+        Keys.onPressed: function (event) {
           if ((event.key === Qt.Key_Return) || (event.key === Qt.Key_Enter)) {
             maya_root.tryLogin()
 
@@ -546,7 +546,7 @@ Rectangle {
 
         onClicked: maya_root.tryLogin()
 
-        Keys.onPressed: {
+        Keys.onPressed: function (event) {
           if ((event.key === Qt.Key_Return) || (event.key === Qt.Key_Enter)) {
             maya_root.tryLogin()
 

--- a/data/themes/maya/metadata.desktop.in
+++ b/data/themes/maya/metadata.desktop.in
@@ -14,3 +14,4 @@ TranslationsDirectory=translations
 Email=spremi@ymail.com
 Theme-Id=maya
 Theme-API=2.0
+QtVersion=@QT_MAJOR_VERSION@

--- a/docs/THEMING.md
+++ b/docs/THEMING.md
@@ -13,6 +13,8 @@ We also provide models containing information about the screens, available sessi
     	index: sessionModel.lastIndex
     }
 
+Themes are run by a Qt 5 built sddm-greeter, unless the `QtVersion` property in metadata.desktop specifies a different version, such as `QtVersion=6` for using `sddm-greeter-qt6`.
+
 ## Proxy Object
 
 We provide a proxy object, called as `sddm` to the themes as a context property. This object holds some useful properties about the host system. It also acts as a proxy between the greeter and the daemon. All of the methods called on this object will be transferred to the daemon through a local socket to be executed there.

--- a/docs/THEMING.md
+++ b/docs/THEMING.md
@@ -8,7 +8,7 @@ We also provide models containing information about the screens, available sessi
 
     ComboBox {
     	id: session
-    	arrowIcon: "angle-down.png"
+    	arrowIcon: Qt.resolvedPath("angle-down.png")
     	model: sessionModel
     	index: sessionModel.lastIndex
     }

--- a/src/greeter/CMakeLists.txt
+++ b/src/greeter/CMakeLists.txt
@@ -36,6 +36,7 @@ set(GREETER_SOURCES
 )
 
 configure_file("theme.qrc" "theme.qrc")
+configure_file("theme/metadata.desktop.in" "theme/metadata.desktop" @ONLY)
 
 qt_add_resources(RESOURCES ${CMAKE_CURRENT_BINARY_DIR}/theme.qrc)
 

--- a/src/greeter/theme.qrc
+++ b/src/greeter/theme.qrc
@@ -7,7 +7,7 @@
     <file alias="Main.qml">${CMAKE_CURRENT_SOURCE_DIR}/theme/Main.qml</file>
     <file alias="reboot.png">${CMAKE_CURRENT_SOURCE_DIR}/theme/reboot.png</file>
     <file alias="shutdown.png">${CMAKE_CURRENT_SOURCE_DIR}/theme/shutdown.png</file>
-    <file alias="metadata.desktop">${CMAKE_CURRENT_SOURCE_DIR}/theme/metadata.desktop</file>
+    <file alias="metadata.desktop">${CMAKE_CURRENT_BINARY_DIR}/theme/metadata.desktop</file>
     <file alias="theme.conf">${CMAKE_CURRENT_SOURCE_DIR}/theme/theme.conf</file>
 </qresource>
 </RCC>

--- a/src/greeter/theme/Main.qml
+++ b/src/greeter/theme/Main.qml
@@ -236,6 +236,8 @@ Rectangle {
                     height: parent.height
                     anchors.verticalCenter: parent.verticalCenter
 
+                    visible: layoutBox.visible
+
                     text: textConstants.layout
                     font.pixelSize: 16
                     verticalAlignment: Text.AlignVCenter
@@ -246,6 +248,8 @@ Rectangle {
                     width: 90
                     anchors.verticalCenter: parent.verticalCenter
                     font.pixelSize: 14
+
+                    visible: keyboard.enabled && keyboard.layouts.length > 0
 
                     arrowIcon: "angle-down.png"
 

--- a/src/greeter/theme/Main.qml
+++ b/src/greeter/theme/Main.qml
@@ -40,15 +40,15 @@ Rectangle {
 
     Connections {
         target: sddm
-        onLoginSucceeded: {
+        function onLoginSucceeded() {
         }
 
-        onLoginFailed: {
+        function onLoginFailed() {
             txtMessage.text = textConstants.loginFailed
             listView.currentItem.password = ""
         }
 
-        onInformationMessage: {
+        function onInformationMessage(message) {
             txtMessage.text = message
         }
     }

--- a/src/greeter/theme/Main.qml
+++ b/src/greeter/theme/Main.qml
@@ -55,7 +55,7 @@ Rectangle {
 
     Background {
         anchors.fill: parent
-        source: "qrc:/theme/background.png"
+        source: "qrc:///theme/background.png"
         fillMode: Image.PreserveAspectCrop
         onStatusChanged: {
             if (status == Image.Error && source != config.defaultBackground) {
@@ -131,7 +131,7 @@ Rectangle {
                         anchors.left: parent.left
                         anchors.verticalCenter: parent.verticalCenter
                         anchors.margins: 10
-                        source: "angle-left.png"
+                        source: "qrc:///theme/angle-left.png"
                         onClicked: listView.decrementCurrentIndex()
 
                         KeyNavigation.backtab: btnShutdown; KeyNavigation.tab: listView
@@ -162,7 +162,7 @@ Rectangle {
                         anchors.right: parent.right
                         anchors.verticalCenter: parent.verticalCenter
                         anchors.margins: 10
-                        source: "angle-right.png"
+                        source: "qrc:///theme/angle-right.png"
                         onClicked: listView.incrementCurrentIndex()
                         KeyNavigation.backtab: listView; KeyNavigation.tab: session
                     }
@@ -222,7 +222,7 @@ Rectangle {
                     width: 245
                     anchors.verticalCenter: parent.verticalCenter
 
-                    arrowIcon: "angle-down.png"
+                    arrowIcon: "qrc:///theme/angle-down.png"
 
                     model: sessionModel
                     index: sessionModel.lastIndex
@@ -251,7 +251,7 @@ Rectangle {
 
                     visible: keyboard.enabled && keyboard.layouts.length > 0
 
-                    arrowIcon: "angle-down.png"
+                    arrowIcon: "qrc:///theme/angle-down.png"
 
                     KeyNavigation.backtab: session; KeyNavigation.tab: btnShutdown
                 }
@@ -266,7 +266,7 @@ Rectangle {
                 ImageButton {
                     id: btnReboot
                     height: parent.height
-                    source: "reboot.png"
+                    source: "qrc:///theme/reboot.png"
 
                     visible: sddm.canReboot
 
@@ -278,7 +278,7 @@ Rectangle {
                 ImageButton {
                     id: btnShutdown
                     height: parent.height
-                    source: "shutdown.png"
+                    source: "qrc:///theme/shutdown.png"
 
                     visible: sddm.canPowerOff
 

--- a/src/greeter/theme/metadata.desktop.in
+++ b/src/greeter/theme/metadata.desktop.in
@@ -14,3 +14,4 @@ TranslationsDirectory=translations
 Email=abdurrahmanavci@gmail.com
 Theme-Id=maui
 Theme-API=2.0
+QtVersion=@QT_MAJOR_VERSION@

--- a/src/greeter/waylandkeyboardbackend.cpp
+++ b/src/greeter/waylandkeyboardbackend.cpp
@@ -95,6 +95,7 @@ void WaylandKeyboardBackend::init()
     // TODO: We can't actually switch keyboard layout yet, so don't populate a list of layouts
     // so that themes can know to not show the option to change layout
     // d->layouts = parseRules(QStringLiteral("/usr/share/X11/xkb/rules/evdev.xml"), d->layout_id);
+    d->enabled = false;
 }
 
 void WaylandKeyboardBackend::disconnect()


### PR DESCRIPTION
Disclaimer: not a real QML developer. Please, suggest better ways to fix things if you know how.

See full commit messages for the problem statements, warnings addressed, etc.

Everything's been tested on Fedora 38/Qt5/X11 .. Fedora Rawhide/Qt6/Wayland (Sway) with all 4 included themes.

***
Having serious doubts about `Themes: fix deprecated signal handler declarations`: the new syntax for attached signal handlers is only documented for Qt6 and I can't find when it was introduced in Qt5.