### PR TITLE
Enable build without libxau and libxcb dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ option(ENABLE_JOURNALD "Enable logging to journald" ON)
 option(NO_SYSTEMD "Disable systemd support" OFF)
 option(USE_ELOGIND "Use elogind instead of logind" OFF)
 option(BUILD_WITH_QT6 "Build with Qt 6" OFF)
+option(BUILD_WITH_X11 "Build with X11 support" ON)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -65,10 +66,14 @@ find_package(PkgConfig)
 find_package(PAM REQUIRED)
 
 # XAU
-pkg_check_modules(LIBXAU REQUIRED "xau")
+if(BUILD_WITH_X11)
+    pkg_check_modules(LIBXAU REQUIRED "xau")
+endif ()
 
 # XCB
-find_package(XCB REQUIRED)
+if(BUILD_WITH_X11)
+    find_package(XCB REQUIRED)
+endif ()
 
 # XKB
 find_package(XKB REQUIRED)
@@ -171,6 +176,13 @@ endif()
 # utmps
 find_package(utmps)
 add_feature_info("utmps" UTMPS_FOUND "utmps support")
+
+# x11
+if(BUILD_WITH_X11)
+    add_definitions(-DBUILD_WITH_X11=1)
+else ()
+    add_definitions(-DBUILD_WITH_X11=0)
+endif ()
 
 # Set constants
 set(DATA_INSTALL_DIR            "${CMAKE_INSTALL_FULL_DATADIR}/sddm"                CACHE PATH      "System application data install directory")

--- a/src/daemon/CMakeLists.txt
+++ b/src/daemon/CMakeLists.txt
@@ -3,7 +3,7 @@ include_directories(
     "${CMAKE_SOURCE_DIR}/src/auth"
     "${CMAKE_BINARY_DIR}/src/common"
     ${LIBXAU_INCLUDE_DIRS}
-    "${LIBXCB_INCLUDE_DIR}"
+    ${LIBXCB_INCLUDE_DIR}
 )
 
 configure_file(config.h.in config.h IMMEDIATE @ONLY)
@@ -15,7 +15,6 @@ set(DAEMON_SOURCES
     ${CMAKE_SOURCE_DIR}/src/common/ThemeMetadata.cpp
     ${CMAKE_SOURCE_DIR}/src/common/Session.cpp
     ${CMAKE_SOURCE_DIR}/src/common/SocketWriter.cpp
-    ${CMAKE_SOURCE_DIR}/src/common/XAuth.cpp
     ${CMAKE_SOURCE_DIR}/src/common/SignalHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/auth/Auth.cpp
     ${CMAKE_SOURCE_DIR}/src/auth/AuthPrompt.cpp
@@ -31,12 +30,18 @@ set(DAEMON_SOURCES
     Seat.cpp
     SeatManager.cpp
     SocketServer.cpp
-    XorgDisplayServer.cpp
-    XorgUserDisplayServer.cpp
-    XorgUserDisplayServer.h
     WaylandDisplayServer.cpp
     WaylandDisplayServer.h
 )
+
+if(BUILD_WITH_X11)
+list(APPEND DAEMON_SOURCES
+    ${CMAKE_SOURCE_DIR}/src/common/XAuth.cpp
+
+    XorgDisplayServer.cpp
+    XorgUserDisplayServer.cpp
+)
+endif()
 
 list(APPEND DAEMON_SOURCES ${CMAKE_SOURCE_DIR}/src/common/VirtualTerminal.cpp)
 

--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -491,8 +491,10 @@ namespace SDDM {
                 manager.UnlockSession(m_reuseSessionId);
                 manager.ActivateSession(m_reuseSessionId);
             } else {
-                if (qobject_cast<XorgDisplayServer *>(m_displayServer))
-                    m_auth->setCookie(qobject_cast<XorgDisplayServer *>(m_displayServer)->cookie());
+                if (m_displayServerType == X11DisplayServerType) {
+                    const QByteArray cookie = m_displayServer->getCookie();
+                    m_auth->setCookie(cookie);
+                }
             }
 
             // save last user and last session

--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -462,14 +462,11 @@ namespace SDDM {
         env.insert(QStringLiteral("XDG_SESSION_DESKTOP"), session.desktopNames());
 #endif
 
-        if (session.xdgSessionType() == QLatin1String("x11")) {
-          if (m_displayServerType == X11DisplayServerType)
+        if (session.xdgSessionType() == QLatin1String("x11") && m_displayServerType == X11DisplayServerType) {
             env.insert(QStringLiteral("DISPLAY"), name());
-          else
-            m_auth->setDisplayServerCommand(XorgUserDisplayServer::command(this));
         } else {
-            m_auth->setDisplayServerCommand(QStringLiteral());
-	}
+            m_auth->setDisplayServerCommand(m_displayServer->getCommand(this));
+        }
         m_auth->setUser(user);
         if (m_reuseSessionId.isNull()) {
             m_auth->setSession(session.exec());

--- a/src/daemon/DisplayServer.h
+++ b/src/daemon/DisplayServer.h
@@ -46,6 +46,8 @@ namespace SDDM {
 
         virtual QByteArray getCookie() const = 0;
 
+        virtual QString authPath() const = 0;
+
     public slots:
         virtual bool start() = 0;
         virtual void stop() = 0;

--- a/src/daemon/DisplayServer.h
+++ b/src/daemon/DisplayServer.h
@@ -38,6 +38,8 @@ namespace SDDM {
 
         const QString &display() const;
 
+        virtual void setDisplayName(const QString &displayName) = 0;
+
         virtual QString sessionType() const = 0;
 
     public slots:

--- a/src/daemon/DisplayServer.h
+++ b/src/daemon/DisplayServer.h
@@ -44,6 +44,8 @@ namespace SDDM {
 
         virtual QString getCommand(Display *display) const = 0;
 
+        virtual QByteArray getCookie() const = 0;
+
     public slots:
         virtual bool start() = 0;
         virtual void stop() = 0;

--- a/src/daemon/DisplayServer.h
+++ b/src/daemon/DisplayServer.h
@@ -42,6 +42,8 @@ namespace SDDM {
 
         virtual QString sessionType() const = 0;
 
+        virtual QString getCommand(Display *display) const = 0;
+
     public slots:
         virtual bool start() = 0;
         virtual void stop() = 0;

--- a/src/daemon/Greeter.cpp
+++ b/src/daemon/Greeter.cpp
@@ -27,7 +27,7 @@
 #include "ThemeConfig.h"
 #include "ThemeMetadata.h"
 #include "Display.h"
-#include "XorgDisplayServer.h"
+#include "DisplayServer.h"
 
 #include <QtCore/QDebug>
 #include <QtCore/QProcess>
@@ -145,7 +145,7 @@ namespace SDDM {
                 // set process environment
                 QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
                 env.insert(QStringLiteral("DISPLAY"), m_display->name());
-                env.insert(QStringLiteral("XAUTHORITY"), qobject_cast<XorgDisplayServer*>(displayServer)->authPath());
+                env.insert(QStringLiteral("XAUTHORITY"), displayServer->authPath());
                 env.insert(QStringLiteral("XCURSOR_THEME"), xcursorTheme);
                 if (!xcursorSize.isEmpty())
                     env.insert(QStringLiteral("XCURSOR_SIZE"), xcursorSize);

--- a/src/daemon/Greeter.cpp
+++ b/src/daemon/Greeter.cpp
@@ -28,8 +28,6 @@
 #include "ThemeMetadata.h"
 #include "Display.h"
 #include "XorgDisplayServer.h"
-#include "XorgUserDisplayServer.h"
-#include "WaylandDisplayServer.h"
 
 #include <QtCore/QDebug>
 #include <QtCore/QProcess>
@@ -302,14 +300,7 @@ namespace SDDM {
     void Greeter::onDisplayServerReady(const QString &displayName)
     {
         auto *displayServer = m_display->displayServer();
-
-        auto *xorgUser = qobject_cast<XorgUserDisplayServer *>(displayServer);
-        if (xorgUser)
-            xorgUser->setDisplayName(displayName);
-
-        auto *wayland = qobject_cast<WaylandDisplayServer *>(displayServer);
-        if (wayland)
-            wayland->setDisplayName(displayName);
+        displayServer->setDisplayName(displayName);
     }
 
     void Greeter::onHelperFinished(Auth::HelperExitStatus status) {

--- a/src/daemon/Greeter.cpp
+++ b/src/daemon/Greeter.cpp
@@ -216,7 +216,8 @@ namespace SDDM {
             if (m_display->displayServerType() == Display::X11DisplayServerType) {
                 env.insert(QStringLiteral("DISPLAY"), m_display->name());
                 env.insert(QStringLiteral("QT_QPA_PLATFORM"), QStringLiteral("xcb"));
-                m_auth->setCookie(qobject_cast<XorgDisplayServer*>(displayServer)->cookie());
+                const QByteArray cookie = displayServer->getCookie();
+                m_auth->setCookie(cookie);
             } else if (m_display->displayServerType() == Display::WaylandDisplayServerType) {
                 env.insert(QStringLiteral("QT_QPA_PLATFORM"), QStringLiteral("wayland"));
                 env.insert(QStringLiteral("QT_WAYLAND_SHELL_INTEGRATION"), QStringLiteral("xdg-shell"));

--- a/src/daemon/WaylandDisplayServer.cpp
+++ b/src/daemon/WaylandDisplayServer.cpp
@@ -49,6 +49,10 @@ QByteArray WaylandDisplayServer::getCookie() const {
     return {};
 }
 
+QString WaylandDisplayServer::authPath() const {
+    return {};
+}
+
 bool WaylandDisplayServer::start()
 {
     // Check flag

--- a/src/daemon/WaylandDisplayServer.cpp
+++ b/src/daemon/WaylandDisplayServer.cpp
@@ -41,6 +41,10 @@ void WaylandDisplayServer::setDisplayName(const QString &displayName)
     m_display = displayName;
 }
 
+QString WaylandDisplayServer::getCommand(Display *) const {
+    return QStringLiteral();
+}
+
 bool WaylandDisplayServer::start()
 {
     // Check flag

--- a/src/daemon/WaylandDisplayServer.cpp
+++ b/src/daemon/WaylandDisplayServer.cpp
@@ -45,6 +45,10 @@ QString WaylandDisplayServer::getCommand(Display *) const {
     return QStringLiteral();
 }
 
+QByteArray WaylandDisplayServer::getCookie() const {
+    return {};
+}
+
 bool WaylandDisplayServer::start()
 {
     // Check flag

--- a/src/daemon/WaylandDisplayServer.h
+++ b/src/daemon/WaylandDisplayServer.h
@@ -40,6 +40,8 @@ public:
 
     QByteArray getCookie() const override;
 
+    QString authPath() const override;
+
 public Q_SLOTS:
     bool start();
     void stop();

--- a/src/daemon/WaylandDisplayServer.h
+++ b/src/daemon/WaylandDisplayServer.h
@@ -36,6 +36,8 @@ public:
 
     void setDisplayName(const QString &displayName);
 
+    QString getCommand(Display *display) const override;
+
 public Q_SLOTS:
     bool start();
     void stop();

--- a/src/daemon/WaylandDisplayServer.h
+++ b/src/daemon/WaylandDisplayServer.h
@@ -38,6 +38,8 @@ public:
 
     QString getCommand(Display *display) const override;
 
+    QByteArray getCookie() const override;
+
 public Q_SLOTS:
     bool start();
     void stop();

--- a/src/daemon/XorgDisplayServer.cpp
+++ b/src/daemon/XorgDisplayServer.cpp
@@ -70,6 +70,10 @@ namespace SDDM {
         return m_xauth.cookie();
     }
 
+    QString XorgDisplayServer::getCommand(Display *) const {
+        return QStringLiteral();
+    }
+
     bool XorgDisplayServer::start() {
         // check flag
         if (m_started)

--- a/src/daemon/XorgDisplayServer.cpp
+++ b/src/daemon/XorgDisplayServer.cpp
@@ -66,7 +66,7 @@ namespace SDDM {
         return QStringLiteral("x11");
     }
 
-    const QByteArray XorgDisplayServer::cookie() const {
+    QByteArray XorgDisplayServer::getCookie() const {
         return m_xauth.cookie();
     }
 

--- a/src/daemon/XorgDisplayServer.cpp
+++ b/src/daemon/XorgDisplayServer.cpp
@@ -53,6 +53,11 @@ namespace SDDM {
         return m_display;
     }
 
+    void XorgDisplayServer::setDisplayName(const QString &)
+    {
+        // Intentional noop
+    }
+
     QString XorgDisplayServer::authPath() const {
         return m_xauth.authPath();
     }

--- a/src/daemon/XorgDisplayServer.h
+++ b/src/daemon/XorgDisplayServer.h
@@ -42,7 +42,7 @@ namespace SDDM {
 
         QString sessionType() const;
 
-        const QByteArray cookie() const;
+        QByteArray getCookie() const override;
 
         QString getCommand(Display *) const override;
 

--- a/src/daemon/XorgDisplayServer.h
+++ b/src/daemon/XorgDisplayServer.h
@@ -38,7 +38,7 @@ namespace SDDM {
 
         void setDisplayName(const QString &displayName);
 
-        QString authPath() const;
+        QString authPath() const override;
 
         QString sessionType() const;
 

--- a/src/daemon/XorgDisplayServer.h
+++ b/src/daemon/XorgDisplayServer.h
@@ -35,6 +35,9 @@ namespace SDDM {
         ~XorgDisplayServer();
 
         const QString &display() const;
+
+        void setDisplayName(const QString &displayName);
+
         QString authPath() const;
 
         QString sessionType() const;

--- a/src/daemon/XorgDisplayServer.h
+++ b/src/daemon/XorgDisplayServer.h
@@ -44,6 +44,8 @@ namespace SDDM {
 
         const QByteArray cookie() const;
 
+        QString getCommand(Display *) const override;
+
     public slots:
         bool start();
         void stop();

--- a/src/daemon/XorgUserDisplayServer.cpp
+++ b/src/daemon/XorgUserDisplayServer.cpp
@@ -67,6 +67,10 @@ QString XorgUserDisplayServer::getCommand(Display *display) const
     return args.join(QLatin1Char(' '));
 }
 
+QByteArray XorgUserDisplayServer::getCookie() const {
+    return {};
+}
+
 bool XorgUserDisplayServer::start()
 {
     // Check flag

--- a/src/daemon/XorgUserDisplayServer.cpp
+++ b/src/daemon/XorgUserDisplayServer.cpp
@@ -45,7 +45,7 @@ void XorgUserDisplayServer::setDisplayName(const QString &displayName)
     m_display = displayName;
 }
 
-QString XorgUserDisplayServer::command(Display *display)
+QString XorgUserDisplayServer::getCommand(Display *display) const
 {
     QStringList args;
 

--- a/src/daemon/XorgUserDisplayServer.cpp
+++ b/src/daemon/XorgUserDisplayServer.cpp
@@ -71,6 +71,10 @@ QByteArray XorgUserDisplayServer::getCookie() const {
     return {};
 }
 
+QString XorgUserDisplayServer::authPath() const {
+    return {};
+}
+
 bool XorgUserDisplayServer::start()
 {
     // Check flag

--- a/src/daemon/XorgUserDisplayServer.h
+++ b/src/daemon/XorgUserDisplayServer.h
@@ -39,7 +39,7 @@ public:
 
     void setDisplayName(const QString &displayName);
 
-    static QString command(Display *display);
+    QString getCommand(Display *display) const override;
 
 public Q_SLOTS:
     bool start();

--- a/src/daemon/XorgUserDisplayServer.h
+++ b/src/daemon/XorgUserDisplayServer.h
@@ -41,6 +41,8 @@ public:
 
     QString getCommand(Display *display) const override;
 
+    QByteArray getCookie() const override;
+
 public Q_SLOTS:
     bool start();
     void stop();

--- a/src/daemon/XorgUserDisplayServer.h
+++ b/src/daemon/XorgUserDisplayServer.h
@@ -43,6 +43,8 @@ public:
 
     QByteArray getCookie() const override;
 
+    QString authPath() const override;
+
 public Q_SLOTS:
     bool start();
     void stop();

--- a/src/greeter/CMakeLists.txt
+++ b/src/greeter/CMakeLists.txt
@@ -12,7 +12,7 @@ message(STATUS "Building greeter for Qt ${QT_MAJOR_VERSION} as ${GREETER_TARGET}
 include_directories(
     "${CMAKE_SOURCE_DIR}/src/common"
     "${CMAKE_BINARY_DIR}/src/common"
-    "${LIBXCB_INCLUDE_DIR}"
+    ${LIBXCB_INCLUDE_DIR}
 )
 
 set(GREETER_SOURCES
@@ -32,8 +32,11 @@ set(GREETER_SOURCES
     UserModel.cpp
     waylandkeyboardbackend.cpp
     waylandkeyboardbackend.h
-    XcbKeyboardBackend.cpp
 )
+
+if(BUILD_WITH_X11)
+    list(APPEND GREETER_SOURCES XcbKeyboardBackend.cpp)
+endif()
 
 configure_file("theme.qrc" "theme.qrc")
 configure_file("theme/metadata.desktop.in" "theme/metadata.desktop" @ONLY)

--- a/src/greeter/KeyboardModel.cpp
+++ b/src/greeter/KeyboardModel.cpp
@@ -23,7 +23,9 @@
 #include "KeyboardModel.h"
 #include "KeyboardModel_p.h"
 #include "waylandkeyboardbackend.h"
+#if BUILD_WITH_X11 == 1
 #include "XcbKeyboardBackend.h"
+#endif
 
 namespace SDDM {
     /**********************************************/
@@ -32,9 +34,13 @@ namespace SDDM {
 
     KeyboardModel::KeyboardModel() : d(new KeyboardModelPrivate) {
         if (QGuiApplication::platformName() == QLatin1String("xcb")) {
+#if BUILD_WITH_X11 == 1
             m_backend = new XcbKeyboardBackend(d);
             m_backend->init();
             m_backend->connectEventsDispatcher(this);
+#else
+            qWarning("Xcb backend is not supported in this build. Continuing anyway.");
+#endif
         } else if (QGuiApplication::platformName().contains(QLatin1String("wayland"))) {
             m_backend = new WaylandKeyboardBackend(d);
             m_backend->init();

--- a/src/helper/CMakeLists.txt
+++ b/src/helper/CMakeLists.txt
@@ -11,7 +11,6 @@ set(HELPER_SOURCES
     ${CMAKE_SOURCE_DIR}/src/common/Configuration.cpp
     ${CMAKE_SOURCE_DIR}/src/common/ConfigReader.cpp
     ${CMAKE_SOURCE_DIR}/src/common/SafeDataStream.cpp
-    ${CMAKE_SOURCE_DIR}/src/common/XAuth.cpp
     ${CMAKE_SOURCE_DIR}/src/common/SignalHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/auth/Auth.cpp
     ${CMAKE_SOURCE_DIR}/src/auth/AuthRequest.cpp
@@ -22,6 +21,10 @@ set(HELPER_SOURCES
 )
 
 list(APPEND HELPER_SOURCES ${CMAKE_SOURCE_DIR}/src/common/VirtualTerminal.cpp)
+
+if(BUILD_WITH_X11)
+    list(APPEND HELPER_SOURCES ${CMAKE_SOURCE_DIR}/src/common/XAuth.cpp)
+endif()
 
 set(HELPER_SOURCES
     ${HELPER_SOURCES}
@@ -34,7 +37,8 @@ target_link_libraries(sddm-helper
                       Qt${QT_MAJOR_VERSION}::Network
                       Qt${QT_MAJOR_VERSION}::DBus
                       Qt${QT_MAJOR_VERSION}::Qml
-                      ${LIBXAU_LINK_LIBRARIES})
+                      ${LIBXAU_LINK_LIBRARIES}
+                      ${JOURNALD_LIBRARIES})
 if("${CMAKE_SYSTEM_NAME}" STREQUAL "FreeBSD")
     # On FreeBSD (possibly other BSDs as well), we want to use
     # setusercontext() to set up the login configuration from login.conf
@@ -61,9 +65,12 @@ endif (UTMPS_FOUND)
 install(TARGETS sddm-helper RUNTIME DESTINATION "${CMAKE_INSTALL_LIBEXECDIR}")
 
 add_executable(sddm-helper-start-wayland HelperStartWayland.cpp waylandsocketwatcher.cpp waylandhelper.cpp ${CMAKE_SOURCE_DIR}/src/common/SignalHandler.cpp)
-target_link_libraries(sddm-helper-start-wayland Qt${QT_MAJOR_VERSION}::Core)
+target_link_libraries(sddm-helper-start-wayland
+                      Qt${QT_MAJOR_VERSION}::Core
+                      ${JOURNALD_LIBRARIES})
 install(TARGETS sddm-helper-start-wayland RUNTIME DESTINATION "${CMAKE_INSTALL_LIBEXECDIR}")
 
+if(BUILD_WITH_X11)
 add_executable(sddm-helper-start-x11user HelperStartX11User.cpp xorguserhelper.cpp
                                                 ${CMAKE_SOURCE_DIR}/src/common/ConfigReader.cpp
                                                 ${CMAKE_SOURCE_DIR}/src/common/Configuration.cpp
@@ -71,11 +78,7 @@ add_executable(sddm-helper-start-x11user HelperStartX11User.cpp xorguserhelper.c
                                                 ${CMAKE_SOURCE_DIR}/src/common/SignalHandler.cpp
                                                 )
 target_link_libraries(sddm-helper-start-x11user Qt${QT_MAJOR_VERSION}::Core
-                                                ${LIBXAU_LINK_LIBRARIES})
+                                                ${LIBXAU_LINK_LIBRARIES}
+                                                ${JOURNALD_LIBRARIES})
 install(TARGETS sddm-helper-start-x11user RUNTIME DESTINATION "${CMAKE_INSTALL_LIBEXECDIR}")
-
-if(JOURNALD_FOUND)
-    target_link_libraries(sddm-helper ${JOURNALD_LIBRARIES})
-    target_link_libraries(sddm-helper-start-x11user ${JOURNALD_LIBRARIES})
-    target_link_libraries(sddm-helper-start-wayland ${JOURNALD_LIBRARIES})
 endif()

--- a/src/helper/UserSession.cpp
+++ b/src/helper/UserSession.cpp
@@ -26,7 +26,9 @@
 #include "UserSession.h"
 #include "HelperApp.h"
 #include "VirtualTerminal.h"
+#if BUILD_WITH_X11 == 1
 #include "XAuth.h"
+#endif
 
 #include <functional>
 #include <sys/types.h>
@@ -64,6 +66,7 @@ namespace SDDM {
         // so that it can clean up the file on session end.
         if (env.value(QStringLiteral("XDG_SESSION_TYPE")) == QLatin1String("x11")
             && m_displayServerCmd.isEmpty()) {
+#if BUILD_WITH_X11 == 1
             // Create the Xauthority file
             QByteArray cookie = helper->cookie();
             if (cookie.isEmpty()) {
@@ -91,6 +94,10 @@ namespace SDDM {
 
             env.insert(QStringLiteral("XAUTHORITY"), m_xauthFile.fileName());
             setProcessEnvironment(env);
+#else
+            qCritical() << "Build does not support X11 sessions without display server command.";
+            return false;
+#endif
         }
 
         if (env.value(QStringLiteral("XDG_SESSION_TYPE")) == QLatin1String("x11")) {


### PR DESCRIPTION
This PR enables building SDDM without dependencies on libxcb and libxau by setting the CMake flag `BUILD_WITH_X11 =OFF`. This way, it is possible to build and use SDDM on Wayland-only systems. By default this flag is set to `ON`.

I kept preprocessor flags in the code to a minimum by using runtime polymorphism wherever feasible. In a few places runtime polymorphism would have caused a high overhead. That is where I fell back on the preprocessor flag. I see those as future places for refactoring.

Fixes: https://github.com/sddm/sddm/issues/1420