### PR TITLE
Respond to SecureAttentionKey events from logind

### DIFF
--- a/data/interfaces/org.freedesktop.login1.Manager.xml
+++ b/data/interfaces/org.freedesktop.login1.Manager.xml
@@ -185,6 +185,10 @@
    <arg type="s" direction="in"/>
    <arg type="h" direction="out"/>
   </method>
+  <signal name="SecureAttentionKey">
+   <arg type="s"/>
+   <arg type="o"/>
+  </signal>
   <signal name="SessionNew">
    <arg type="s"/>
    <arg type="o"/>

--- a/src/daemon/SeatManager.cpp
+++ b/src/daemon/SeatManager.cpp
@@ -27,6 +27,8 @@
 #include <QDBusPendingReply>
 #include <QDBusContext>
 
+#include <Login1Manager.h>
+#include <Login1Session.h>
 #include "LogindDBusTypes.h"
 
 namespace SDDM {
@@ -147,6 +149,24 @@ namespace SDDM {
         // check if seat exists
         if (!m_seats.contains(name))
             return;
+
+        // Switch to existing greeter session if available
+        if (Logind::isAvailable()) {
+            OrgFreedesktopLogin1ManagerInterface manager(Logind::serviceName(), Logind::managerPath(), QDBusConnection::systemBus());
+            auto reply = manager.ListSessions();
+            reply.waitForFinished();
+
+            const auto info = reply.value();
+            for(const SessionInfo &s : reply.value()) {
+                if (s.userName == QLatin1String("sddm")) {
+                    OrgFreedesktopLogin1SessionInterface session(Logind::serviceName(), s.sessionPath.path(), QDBusConnection::systemBus());
+                    if (session.service() == QLatin1String("sddm-greeter") && session.seat().name == name) {
+                        session.Activate();
+                        return;
+                    }
+                }
+            }
+        }
 
         // switch to greeter
         m_seats.value(name)->createDisplay(Display::defaultDisplayServerType());

--- a/src/daemon/SeatManager.cpp
+++ b/src/daemon/SeatManager.cpp
@@ -115,6 +115,7 @@ namespace SDDM {
             }
         });
 
+        QDBusConnection::systemBus().connect(Logind::serviceName(), Logind::managerPath(), Logind::managerIfaceName(), QStringLiteral("SecureAttentionKey"), this, SLOT(logindSecureAttentionKey(QString,QDBusObjectPath)));
         QDBusConnection::systemBus().connect(Logind::serviceName(), Logind::managerPath(), Logind::managerIfaceName(), QStringLiteral("SeatNew"), this, SLOT(logindSeatAdded(QString,QDBusObjectPath)));
         QDBusConnection::systemBus().connect(Logind::serviceName(), Logind::managerPath(), Logind::managerIfaceName(), QStringLiteral("SeatRemoved"), this, SLOT(logindSeatRemoved(QString,QDBusObjectPath)));
     }
@@ -170,6 +171,12 @@ namespace SDDM {
 
         // switch to greeter
         m_seats.value(name)->createDisplay(Display::defaultDisplayServerType());
+    }
+
+    void SDDM::SeatManager::logindSecureAttentionKey(const QString& name, const QDBusObjectPath& objectPath)
+    {
+        Q_UNUSED(objectPath);
+        daemonApp->seatManager()->switchToGreeter(name);
     }
 
     void SDDM::SeatManager::logindSeatAdded(const QString& name, const QDBusObjectPath& objectPath)

--- a/src/daemon/SeatManager.h
+++ b/src/daemon/SeatManager.h
@@ -43,6 +43,7 @@ namespace SDDM {
         void seatRemoved(const QString &name);
 
     private Q_SLOTS:
+        void logindSecureAttentionKey(const QString &name, const QDBusObjectPath &objectPath);
         void logindSeatAdded(const QString &name, const QDBusObjectPath &objectPath);
         void logindSeatRemoved(const QString &name, const QDBusObjectPath &objectPath);
 


### PR DESCRIPTION
This depends on https://github.com/systemd/systemd/pull/29542 not merged yet, subject to change

The first commit fixes an issue where the greeter hangs if SwitchToGreeter double fires.
Something that if the systemd MR is merged will be easier for users to accidentally trigger, at least with logind, as it is possible to hit Ctrl+Alt+Shift+Esc or whatever the final sequence is, when the greeter is active

dbus-send --system --type=method_call --print-reply --dest=org.freedesktop.DisplayManager $XDG_SEAT_PATH org.freedesktop.DisplayManager.Seat.SwitchToGreeter
sleep 5
dbus-send --system --type=method_call --print-reply --dest=org.freedesktop.DisplayManager $XDG_SEAT_PATH org.freedesktop.DisplayManager.Seat.SwitchToGreeter