### PR TITLE
Display: add plymouth integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ option(ENABLE_JOURNALD "Enable logging to journald" ON)
 option(NO_SYSTEMD "Disable systemd support" OFF)
 option(USE_ELOGIND "Use elogind instead of logind" OFF)
 option(BUILD_WITH_QT6 "Build with Qt 6" OFF)
+option(WITH_PLYMOUTH "Integrate with plymouth at startup" ON)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -168,6 +169,15 @@ else()
     set(RUNTIME_DIR_DEFAULT "${CMAKE_INSTALL_FULL_LOCALSTATEDIR}/run/sddm")
 endif()
 
+# plymouth
+if (WITH_PLYMOUTH)
+    pkg_check_modules(PLYMOUTH "ply-boot-client")
+endif()
+
+if (PLYMOUTH_FOUND)
+    add_definitions(-DHAVE_PLYMOUTH)
+endif()
+add_feature_info("plymouth" PLYMOUTH_FOUND "plymouth smooth transition support")
 
 # Set constants
 set(DATA_INSTALL_DIR            "${CMAKE_INSTALL_FULL_DATADIR}/sddm"                CACHE PATH      "System application data install directory")

--- a/services/sddm.service.in
+++ b/services/sddm.service.in
@@ -2,7 +2,7 @@
 Description=Simple Desktop Display Manager
 Documentation=man:sddm(1) man:sddm.conf(5)
 Conflicts=getty@tty${SDDM_INITIAL_VT}.service
-After=systemd-user-sessions.service getty@tty${SDDM_INITIAL_VT}.service plymouth-quit.service systemd-logind.service
+After=systemd-user-sessions.service getty@tty${SDDM_INITIAL_VT}.service systemd-logind.service
 PartOf=graphical.target
 StartLimitIntervalSec=30
 StartLimitBurst=2

--- a/src/daemon/Display.h
+++ b/src/daemon/Display.h
@@ -91,6 +91,9 @@ namespace SDDM {
 
         void startSocketServerAndGreeter();
         void handleAutologinFailure();
+#if HAVE_PLYMOUTH
+        bool m_plymouthIsRunning;
+#endif
 
         DisplayServerType m_displayServerType = X11DisplayServerType;
 


### PR DESCRIPTION
This provides plymouth smooth transition support in SDDM::Display by telling Plymouth to deactivate and quit as the greeter is brought online.

This is similar in goal to #1013, although following the suggestion in https://github.com/sddm/sddm/pull/1013#issuecomment-1493269798, the plan is to handle the transition from within the sddm daemon.

I wouldn't consider this PR complete, primarily due to the following lines in src/daemon/Display.cpp:

```cpp
        switch (m_displayServerType) {
        case X11DisplayServerType:
            if (seat()->canTTY()) {
#if HAVE_PLYMOUTH
                // TODO: why can't rootful X11 use fetchAvailableVt?
                if (m_plymouthIsRunning) {
                    quitPlymouth(false);
                    m_plymouthIsRunning = false;
                }
#endif
                m_terminalId = VirtualTerminal::setUpNewVt();
            }
```

More specifically, the `x11` display server type always creates a new VT, whereas `x11-user` and `wayland` will use `fetchAvailableVt()`. Is there a requirement for this to be the case?

My understanding of Plymouth is that to support a smooth transition, the DM needs to load on the active VT (i.e., same as the splash screen), so if there is a requirement, `x11` display server type won't be able to support smooth transition support with this method.