### PR TITLE
Move X11 display setup into separate function

### DIFF
--- a/src/common/XSetup.cpp
+++ b/src/common/XSetup.cpp
@@ -1,0 +1,81 @@
+/***************************************************************************
+* Copyright (c) 2024 Fabian Vogt <fabian@ritter-vogt.de>
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 2 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, write to the
+* Free Software Foundation, Inc.,
+* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+***************************************************************************/
+
+#include <QProcess>
+#include <QDebug>
+
+#include "XSetup.h"
+#include "Configuration.h"
+
+namespace SDDM {
+
+void runX11Setup(const QProcessEnvironment &env)
+{
+    {
+        QProcess setCursor;
+        setCursor.setProcessEnvironment(env);
+        qDebug() << "Setting default cursor";
+        setCursor.start(QStringLiteral("xsetroot"), { QStringLiteral("-cursor_name"), QStringLiteral("left_ptr") });
+
+        // wait for finished
+        if (!setCursor.waitForFinished(1000)) {
+            qWarning() << "Could not setup default cursor" << setCursor.error();
+            setCursor.kill();
+        }
+    }
+
+    const QString xcursorTheme = env.value(QStringLiteral("XCURSOR_THEME")),
+                  xcursorSize = env.value(QStringLiteral("XCURSOR_SIZE"));
+
+    // Unlike libXcursor, xcb-util-cursor no longer looks at XCURSOR_*. Set the resources.
+    if (!xcursorTheme.isEmpty() || !xcursorSize.isEmpty()) {
+        QProcess xrdbProcess;
+        xrdbProcess.setProcessEnvironment(env);
+        xrdbProcess.start(QStringLiteral("xrdb"), QStringList{QStringLiteral("-nocpp"), QStringLiteral("-merge")});
+        if (!xcursorTheme.isEmpty())
+            xrdbProcess.write(QStringLiteral("Xcursor.theme: %1\n").arg(xcursorTheme).toUtf8());
+
+        if (!xcursorSize.isEmpty())
+            xrdbProcess.write(QStringLiteral("Xcursor.size: %1\n").arg(xcursorSize).toUtf8());
+
+        xrdbProcess.closeWriteChannel();
+        if (!xrdbProcess.waitForFinished(1000)) {
+            qDebug() << "Could not set Xcursor resources" << xrdbProcess.error();
+            xrdbProcess.kill();
+        }
+    }
+
+    {
+        QProcess displayScript;
+        displayScript.setProcessEnvironment(env);
+        // start display setup script
+        qDebug() << "Running display setup script " << mainConfig.X11.DisplayCommand.get();
+        QStringList displayCommand = QProcess::splitCommand(mainConfig.X11.DisplayCommand.get());
+        const QString program = displayCommand.takeFirst();
+        displayScript.start(program, displayCommand);
+
+        // wait for finished
+        if (!displayScript.waitForFinished(30000)) {
+            qWarning() << "Could not run display setup script" << displayScript.error();
+            displayScript.kill();
+        }
+    }
+}
+
+} // namespace SDDM

--- a/src/common/XSetup.h
+++ b/src/common/XSetup.h
@@ -1,5 +1,5 @@
 /***************************************************************************
-* Copyright (c) 2021 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+* Copyright (c) 2024 Fabian Vogt <fabian@ritter-vogt.de>
 *
 * This program is free software; you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
@@ -17,31 +17,18 @@
 * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 ***************************************************************************/
 
-#ifndef SDDM_WAYLANDDISPLAYSERVER_H
-#define SDDM_WAYLANDDISPLAYSERVER_H
+#ifndef SDDM_XSETUP_H
+#define SDDM_XSETUP_H
 
-#include "DisplayServer.h"
+class QProcessEnvironment;
 
 namespace SDDM {
 
-class WaylandDisplayServer : public DisplayServer
-{
-    Q_OBJECT
-    Q_DISABLE_COPY(WaylandDisplayServer)
-public:
-    explicit WaylandDisplayServer(Display *parent);
-    ~WaylandDisplayServer();
-
-    QString sessionType() const;
-
-    void setDisplayName(const QString &displayName);
-
-public Q_SLOTS:
-    bool start();
-    void stop();
-    void finished();
-};
+    /* Run programs to configure the X11 display.
+     * env needs to contain $DISPLAY and $XAUTHORITY.
+     */
+    void runX11Setup(const QProcessEnvironment &env);
 
 } // namespace SDDM
 
-#endif // SDDM_WAYLANDDISPLAYSERVER_H
+#endif // SDDM_XSETUP_H

--- a/src/daemon/CMakeLists.txt
+++ b/src/daemon/CMakeLists.txt
@@ -16,6 +16,7 @@ set(DAEMON_SOURCES
     ${CMAKE_SOURCE_DIR}/src/common/Session.cpp
     ${CMAKE_SOURCE_DIR}/src/common/SocketWriter.cpp
     ${CMAKE_SOURCE_DIR}/src/common/XAuth.cpp
+    ${CMAKE_SOURCE_DIR}/src/common/XSetup.cpp
     ${CMAKE_SOURCE_DIR}/src/common/SignalHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/auth/Auth.cpp
     ${CMAKE_SOURCE_DIR}/src/auth/AuthPrompt.cpp

--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -272,9 +272,6 @@ namespace SDDM {
         if (m_started)
             return;
 
-        // setup display
-        m_displayServer->setupDisplay();
-
         // log message
         qDebug() << "Display server started.";
 

--- a/src/daemon/DisplayServer.h
+++ b/src/daemon/DisplayServer.h
@@ -44,7 +44,6 @@ namespace SDDM {
         virtual bool start() = 0;
         virtual void stop() = 0;
         virtual void finished() = 0;
-        virtual void setupDisplay() = 0;
 
     signals:
         void started();

--- a/src/daemon/WaylandDisplayServer.cpp
+++ b/src/daemon/WaylandDisplayServer.cpp
@@ -69,8 +69,4 @@ void WaylandDisplayServer::finished()
 {
 }
 
-void WaylandDisplayServer::setupDisplay()
-{
-}
-
 } // namespace SDDM

--- a/src/daemon/XorgDisplayServer.h
+++ b/src/daemon/XorgDisplayServer.h
@@ -45,7 +45,6 @@ namespace SDDM {
         bool start();
         void stop();
         void finished();
-        void setupDisplay();
 
     private:
         XAuth m_xauth;

--- a/src/daemon/XorgUserDisplayServer.cpp
+++ b/src/daemon/XorgUserDisplayServer.cpp
@@ -95,8 +95,4 @@ void XorgUserDisplayServer::finished()
 {
 }
 
-void XorgUserDisplayServer::setupDisplay()
-{
-}
-
 } // namespace SDDM

--- a/src/daemon/XorgUserDisplayServer.h
+++ b/src/daemon/XorgUserDisplayServer.h
@@ -45,7 +45,6 @@ public Q_SLOTS:
     bool start();
     void stop();
     void finished();
-    void setupDisplay();
 };
 
 } // namespace SDDM

--- a/src/helper/CMakeLists.txt
+++ b/src/helper/CMakeLists.txt
@@ -68,6 +68,7 @@ add_executable(sddm-helper-start-x11user HelperStartX11User.cpp xorguserhelper.c
                                                 ${CMAKE_SOURCE_DIR}/src/common/ConfigReader.cpp
                                                 ${CMAKE_SOURCE_DIR}/src/common/Configuration.cpp
                                                 ${CMAKE_SOURCE_DIR}/src/common/XAuth.cpp
+                                                ${CMAKE_SOURCE_DIR}/src/common/XSetup.cpp
                                                 ${CMAKE_SOURCE_DIR}/src/common/SignalHandler.cpp
                                                 )
 target_link_libraries(sddm-helper-start-x11user Qt${QT_MAJOR_VERSION}::Core


### PR DESCRIPTION
Alternate version of #1904 which has some refactoring ~~to let themes specify the cursor theme again.~~

Draft because:

- [ ] Only tested in daemon test mode.
- [x] ~It uses QProcess instead of xorguserhelper's custom `startProcess`. Not sure whether that's needed though.~ Not needed, it even breaks `xrdb` because of stdin forwarding.