### PR TITLE
Stop rootful Xorg after starting a Wayland session

### DIFF
--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -555,6 +555,12 @@ namespace SDDM {
         qDebug() << "Session started" << success;
         if (success) {
             QTimer::singleShot(5000, m_greeter, &Greeter::stop);
+
+            // If no longer needed, stop the display server.
+            if(m_sessionTerminalId != m_terminalId) {
+                disconnect(m_displayServer, &DisplayServer::stopped, this, &Display::stop);
+                QTimer::singleShot(5000, m_displayServer, &DisplayServer::stop);
+            }
         }
     }
 }

--- a/src/daemon/XorgDisplayServer.cpp
+++ b/src/daemon/XorgDisplayServer.cpp
@@ -24,6 +24,7 @@
 #include "DaemonApp.h"
 #include "Display.h"
 #include "Seat.h"
+#include "VirtualTerminal.h"
 
 #include <QDebug>
 #include <QFile>
@@ -115,6 +116,7 @@ namespace SDDM {
             args << mainConfig.X11.ServerArguments.get().split(QLatin1Char(' '), Qt::SkipEmptyParts)
                  << QStringLiteral("-background") << QStringLiteral("none")
                  << QStringLiteral("-seat") << displayPtr()->seat()->name()
+                 << QStringLiteral("-novtswitch")
                  << QStringLiteral("vt%1").arg(displayPtr()->terminalId());
         } else {
             process->setProgram(mainConfig.X11.XephyrPath.get());
@@ -181,6 +183,10 @@ namespace SDDM {
             }
         }
         changeOwner(m_xauth.authPath());
+
+        if (displayPtr()->terminalId() > 0) {
+            VirtualTerminal::jumpToVt(displayPtr()->terminalId(), true);
+        }
 
         emit started();
 


### PR DESCRIPTION
With rootful Xorg, the display manager is kept running and used for the user
X session. If a Wayland session is started though keeping Xorg running just
wastes resources (VT, RAM, GPU) and looks weird (black screen + cursor).

To avoid that stopping Xorg causes a VT switch, https://github.com/sddm/sddm/issues/1803 needs to be fixed by adding `-novtswitch`.

Draft because:
- [x] Test logging into X11 and Wayland sessions
- [ ] Need to figure out what to do on SDDM exit. Switch to whatever VT was active during start or hardcode VT 1?
- [ ] Implement and test ^

CC @arrowd 