### PR TITLE
If autologin is used, avoid starting a display server for the greeter

### DIFF
--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -175,9 +175,6 @@ namespace SDDM {
         // Load autologin configuration (whether to autologin, user, session, session type)
         if ((daemonApp->first || mainConfig.Autologin.Relogin.get()) &&
             !mainConfig.Autologin.User.get().isEmpty()) {
-            // reset first flag
-            daemonApp->first = false;
-
             // determine session type
             QString autologinSession = mainConfig.Autologin.Session.get();
             // not configured: try last successful logged in
@@ -192,6 +189,9 @@ namespace SDDM {
                 qCritical() << "Unable to find autologin session entry" << autologinSession;
             }
         }
+
+        // reset first flag
+        daemonApp->first = false;
     }
 
     Display::~Display() {
@@ -254,9 +254,6 @@ namespace SDDM {
 
         // start greeter
         m_greeter->start();
-
-        // reset first flag
-        daemonApp->first = false;
     }
 
     void Display::handleAutologinFailure() {
@@ -273,9 +270,6 @@ namespace SDDM {
         qDebug() << "Display server started.";
 
         if (m_autologinSession.isValid()) {
-            // reset first flag
-            daemonApp->first = false;
-
             m_auth->setAutologin(true);
             if (!startAuth(mainConfig.Autologin.User.get(), QString(), m_autologinSession))
                 handleAutologinFailure();

--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -171,6 +171,27 @@ namespace SDDM {
             stop();
         });
         connect(m_greeter, &Greeter::displayServerFailed, this, &Display::displayServerFailed);
+
+        // Load autologin configuration (whether to autologin, user, session, session type)
+        if ((daemonApp->first || mainConfig.Autologin.Relogin.get()) &&
+            !mainConfig.Autologin.User.get().isEmpty()) {
+            // reset first flag
+            daemonApp->first = false;
+
+            // determine session type
+            QString autologinSession = mainConfig.Autologin.Session.get();
+            // not configured: try last successful logged in
+            if (autologinSession.isEmpty()) {
+                autologinSession = stateConfig.Last.Session.get();
+            }
+            if (findSessionEntry(mainConfig.Wayland.SessionDir.get(), autologinSession)) {
+                m_autologinSession.setTo(Session::WaylandSession, autologinSession);
+            } else if (findSessionEntry(mainConfig.X11.SessionDir.get(), autologinSession)) {
+                m_autologinSession.setTo(Session::X11Session, autologinSession);
+            } else {
+                qCritical() << "Unable to find autologin session entry" << autologinSession;
+            }
+        }
     }
 
     Display::~Display() {
@@ -213,31 +234,6 @@ namespace SDDM {
         return m_displayServer->start();
     }
 
-    bool Display::attemptAutologin() {
-        Session::Type sessionType = Session::X11Session;
-
-        // determine session type
-        QString autologinSession = mainConfig.Autologin.Session.get();
-        // not configured: try last successful logged in
-        if (autologinSession.isEmpty()) {
-            autologinSession = stateConfig.Last.Session.get();
-        }
-        if (findSessionEntry(mainConfig.Wayland.SessionDir.get(), autologinSession)) {
-            sessionType = Session::WaylandSession;
-        } else if (findSessionEntry(mainConfig.X11.SessionDir.get(), autologinSession)) {
-            sessionType = Session::X11Session;
-        } else {
-            qCritical() << "Unable to find autologin session entry" << autologinSession;
-            return false;
-        }
-
-        Session session;
-        session.setTo(sessionType, autologinSession);
-
-        m_auth->setAutologin(true);
-        return startAuth(mainConfig.Autologin.User.get(), QString(), session);
-    }
-
     void Display::startSocketServerAndGreeter() {
         // start socket server
         m_socketServer->start(m_displayServer->display());
@@ -276,13 +272,12 @@ namespace SDDM {
         // log message
         qDebug() << "Display server started.";
 
-        if ((daemonApp->first || mainConfig.Autologin.Relogin.get()) &&
-            !mainConfig.Autologin.User.get().isEmpty()) {
+        if (m_autologinSession.isValid()) {
             // reset first flag
             daemonApp->first = false;
 
-            const bool autologinStarted = attemptAutologin();
-            if (!autologinStarted)
+            m_auth->setAutologin(true);
+            if (!startAuth(mainConfig.Autologin.User.get(), QString(), m_autologinSession))
                 handleAutologinFailure();
 
             return;

--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -205,7 +205,12 @@ namespace SDDM {
     }
 
     bool Display::start() {
-        return m_started || m_displayServer->start();
+        if (m_started)
+            return true;
+
+        m_started = true;
+
+        return m_displayServer->start();
     }
 
     bool Display::attemptAutologin() {
@@ -256,9 +261,6 @@ namespace SDDM {
 
         // reset first flag
         daemonApp->first = false;
-
-        // set flags
-        m_started = true;
     }
 
     void Display::handleAutologinFailure() {
@@ -268,10 +270,6 @@ namespace SDDM {
     }
 
     void Display::displayServerStarted() {
-        // check flag
-        if (m_started)
-            return;
-
         // setup display
         m_displayServer->setupDisplay();
 
@@ -282,9 +280,6 @@ namespace SDDM {
             !mainConfig.Autologin.User.get().isEmpty()) {
             // reset first flag
             daemonApp->first = false;
-
-            // set flags
-            m_started = true;
 
             const bool autologinStarted = attemptAutologin();
             if (!autologinStarted)
@@ -484,7 +479,6 @@ namespace SDDM {
                 OrgFreedesktopLogin1ManagerInterface manager(Logind::serviceName(), Logind::managerPath(), QDBusConnection::systemBus());
                 manager.UnlockSession(m_reuseSessionId);
                 manager.ActivateSession(m_reuseSessionId);
-                m_started = true;
             } else {
                 if (qobject_cast<XorgDisplayServer *>(m_displayServer))
                     m_auth->setCookie(qobject_cast<XorgDisplayServer *>(m_displayServer)->cookie());

--- a/src/daemon/Display.h
+++ b/src/daemon/Display.h
@@ -72,7 +72,6 @@ namespace SDDM {
         void login(QLocalSocket *socket,
                    const QString &user, const QString &password,
                    const Session &session);
-        bool attemptAutologin();
         void displayServerStarted();
 
     signals:
@@ -102,6 +101,8 @@ namespace SDDM {
         QString m_passPhrase;
         QString m_sessionName;
         QString m_reuseSessionId;
+
+        Session m_autologinSession;
 
         Auth *m_auth { nullptr };
         DisplayServer *m_displayServer { nullptr };

--- a/src/daemon/Display.h
+++ b/src/daemon/Display.h
@@ -89,7 +89,7 @@ namespace SDDM {
                        const Session &session);
 
         void startSocketServerAndGreeter();
-        void handleAutologinFailure();
+        bool handleAutologinFailure();
 
         DisplayServerType m_displayServerType = X11DisplayServerType;
 

--- a/src/daemon/Display.h
+++ b/src/daemon/Display.h
@@ -94,7 +94,6 @@ namespace SDDM {
 
         DisplayServerType m_displayServerType = X11DisplayServerType;
 
-        bool m_relogin { true };
         bool m_started { false };
 
         int m_terminalId = -1;


### PR DESCRIPTION
Introduce a new "early autologin" path that starts the session without
starting the display server first. This avoids starting a rootful X just
to then ignore it and start a Wayland session in a separate VT.

This should avoid the race condition causing tty opening failures with wayland autologin, which is actually separate from #1844. In the autologin case, SDDM first starts the display server, which switches to e.g. tty2, then starts the user session which then picks e.g. tty1 which is about to be used by getty.

Needed some refactoring of Display.cpp. It's split into various small commits, should be simple to read individually.

I think I tested all possible combinations:
- [x] `DisplayServer=x11` + autologin into `plasmawayland`
- [x] `DisplayServer=x11` + autologin into `plasma6` (x11)
- [x] `DisplayServer=x11` + failed autologin (invalid user) into `plasma6` (x11)
- [x] `DisplayServer=x11` + failed autologin (invalid user) into `plasmawayland`
- [x] `DisplayServer=x11-user` + autologin into `plasmawayland`
- [x] `DisplayServer=wayland` + autologin into `plasma6`

All of those cases behaved as expected.