### PR TITLE
CI: Fix Fedora, drop CentOS Stream with clang

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
           if [[ "${{ matrix.container-image }}" =~ "centos" ]]; then dnf --assumeyes config-manager --set-enabled crb && dnf --assumeyes install epel-release; fi
           dnf --assumeyes builddep sddm
           if [ "${{ matrix.qt }}" = "qt5" ] && [[ "${{ matrix.container-image }}" =~ "fedora" ]]; then dnf --assumeyes install qt5-qtbase-devel qt5-qtdeclarative-devel qt5-qttools-devel; fi
-          dnf --assumeyes --allowerasing --nobest install clang clazy
+          dnf --assumeyes install --allowerasing --nobest clang clazy
       - name: Dependencies (deb-type)
         if: ${{ contains(matrix.container-image, 'ubuntu') }}
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,6 @@ jobs:
       matrix:
         container-image:
           - "quay.io/fedora/fedora:rawhide"
-          - "quay.io/centos/centos:stream9"
           - "registry.opensuse.org/opensuse/tumbleweed-dnf"
           - "docker.io/library/ubuntu:22.04"
           - "docker.io/library/ubuntu:23.04"
@@ -31,6 +30,9 @@ jobs:
         qt:
           - "qt5"
         include:
+          - container-image: "quay.io/centos/centos:stream9"
+            compiler: gcc
+            qt: "qt5"
           - container-image: "docker.io/library/ubuntu:23.04"
             compiler: clang
             qt: "qt6"


### PR DESCRIPTION
CC @Conan-Kudo about the clazy crash on CentOS. I guess the libraries are incompatible somehow and dependencies don't reflect that.