### PR TITLE
Don't quit when there are no screens

### DIFF
--- a/src/greeter/GreeterApp.cpp
+++ b/src/greeter/GreeterApp.cpp
@@ -362,6 +362,8 @@ int main(int argc, char **argv)
 
     QGuiApplication app(argc, argv);
     SDDM::SignalHandler s;
+
+    app.setQuitOnLastWindowClosed(false);
     QObject::connect(&s, &SDDM::SignalHandler::sigtermReceived, &app, [] {
         QCoreApplication::instance()->exit(-1);
     });


### PR DESCRIPTION
Default Qt behaviour is to quit when all windows are closed.

Windows can get a close event when the output is being removed, potentially slightly before we handle the output removed and delete the window.

This ordering means we can have no screens for enough time for this hook to take effect.