### PR TITLE
Show saved users

### DIFF
--- a/data/man/sddm.conf.rst.in
+++ b/data/man/sddm.conf.rst.in
@@ -228,6 +228,12 @@ The `UserAuthFile=` option was removed, the file is always created as
 	won't be updated.
 	Default value is true.
 
+`ShowSavedUsers=`
+	If this flag is true, SavedUsers value will updated
+	on every successful login, if false list of last users
+	won't be updated.
+	Default value is false.
+
 [Autologin] section:
 
 `User=`

--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -97,6 +97,7 @@ namespace SDDM {
             Entry(RememberLastSession, bool,        true,                                       _S("Remember the session of the last successfully logged in user"));
 
             Entry(ReuseSession,        bool,        true,                                       _S("When logging in as the same user twice, restore the original session, rather than create a new one"));
+            Entry(ShowSavedUsers,      bool,        false,                                      _S("Save users which successfully logged in and display them in greeter"));
         );
 
         Section(Autologin,
@@ -112,6 +113,7 @@ namespace SDDM {
                                                                                                    "This session will be preselected when the login screen appears."));
             Entry(User,            QString,     QString(),                                      _S("Name of the last logged-in user.\n"
                                                                                                    "This user will be preselected when the login screen appears"));
+            Entry(SavedUsers,      QStringList, QStringList(),                                  _S("Comma-separated list of saved users that should be displayed"));
         );
     );
 

--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -505,6 +505,13 @@ namespace SDDM {
                 stateConfig.Last.Session.set(m_sessionName);
             else
                 stateConfig.Last.Session.setDefault();
+            // save users list to be displayed
+            if (mainConfig.Users.ShowSavedUsers.get()) {
+                auto savedUsers = stateConfig.Last.SavedUsers.get();
+                if (!savedUsers.contains(m_auth->user()))
+                    stateConfig.Last.SavedUsers.set(savedUsers << m_auth->user());
+            } else
+                stateConfig.Last.SavedUsers.setDefault();
             stateConfig.save();
 
             if (m_socket)


### PR DESCRIPTION
#### Save users which successfully logged in and display them in greeter

If new option `ShowSavedUsers` enabled in `[Users]` section of configuration than save users which successfully logged into `SavedUsers` (QStringList) in `state.conf` and add them to `UserModel`, i.e. show them in greeter list.

At the moment, in the case of a huge list from LDAP, AD or local, we can disable loading the entire `UserModel` via `"General/needsFullUserModel=false"` in the theme settings. This solves the problem with scrolling through a huge list and performance issues, but it only leaves us with a plain login text field.

If several users from such LDAP are used on this computer, then we lack the ability to display only those few users who have been logged in to this computer, forcing users to enter the login manually each time.

Also, enumeration of domain users can be disabled from domain service side. Like `enumerate` option in `sssd.conf`. So, with this new option, we can display local users and those domain users who logged in to this computer.

This PR allows us to save a list of such logged users in order to be able to display them on the login screen.

Thus, this PR is the continuation of the idea from #1017 and `RememberLastUser` option, because `RememberLastUser` works fine for case with one active user on this computer, but not very much if there are several of these users.

The option `ShowSavedUsers` itself is disabled by default, i.e. it is needed mainly for such cases with a large user list.

Alternative to #889