### PR TITLE
Use a fully locked system account with systemd>=257

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,12 @@ if(SYSTEMD_FOUND)
         pkg_check_modules(JOURNALD "libsystemd")
     endif()
 
+    if(${SYSTEMD_VERSION} VERSION_LESS 257)
+        set(SYSTEMD_SYSUSERS_FULLY_LOCKED " ")
+    else()
+        set(SYSTEMD_SYSUSERS_FULLY_LOCKED "!")
+    endif()
+
     if(ENABLE_JOURNALD)
         if(JOURNALD_FOUND)
             add_definitions(-DHAVE_JOURNALD)

--- a/services/sddm-sysuser.conf.in
+++ b/services/sddm-sysuser.conf.in
@@ -1,2 +1,2 @@
 #Type Name ID GECOS                  Home directory Shell
-u     sddm -  "SDDM Greeter Account" ${STATE_DIR}   -
+u${SYSTEMD_SYSUSERS_FULLY_LOCKED}    sddm -  "SDDM Greeter Account" ${STATE_DIR}   -


### PR DESCRIPTION
As per upstream recommendation https://github.com/systemd/systemd/blob/25a306f6c4d9b8596e25d7771802f005ebae91ba/NEWS#L822-L832