### PR TITLE
CMake: Raise required version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.5)
 
 project(SDDM)
 


### PR DESCRIPTION
CMake >= 4.0.0-rc1 removed compatibility with versions < 3.5 and errors out with such versions passed to cmake_minimum_required(). 3.5.0 has been released 9 years ago, so I'd assume it's available almost everywhere.