### PR TITLE
Allow themes to disable delays on login failure in the PAM backend

### DIFF
--- a/src/auth/Auth.cpp
+++ b/src/auth/Auth.cpp
@@ -71,6 +71,7 @@ namespace SDDM {
         QProcessEnvironment environment { };
         qint64 id { 0 };
         static qint64 lastId;
+        bool requiresZeroDelayOnFailAuth { false };
     };
 
     qint64 Auth::Private::lastId = 1;
@@ -247,13 +248,14 @@ namespace SDDM {
     }
 
 
-    Auth::Auth(const QString &user, const QString &session, bool autologin, QObject *parent, bool verbose)
+    Auth::Auth(const QString &user, const QString &session, bool autologin, QObject *parent, bool verbose, const bool requiresZeroDelayOnFailAuth)
             : QObject(parent)
             , d(new Private(this)) {
         setUser(user);
         setAutologin(autologin);
         setSession(session);
         setVerbose(verbose);
+        setRequiresZeroDelayOnFailAuth(requiresZeroDelayOnFailAuth);
     }
 
     Auth::Auth(QObject* parent)
@@ -301,6 +303,11 @@ namespace SDDM {
         return d->request;
     }
 
+    bool Auth::requiresZeroDelayOnFailAuth() const
+    {
+        return d->requiresZeroDelayOnFailAuth;
+    }
+
     bool Auth::isActive() const {
         return d->child->state() != QProcess::NotRunning;
     }
@@ -318,6 +325,11 @@ namespace SDDM {
             d->cookie = cookie;
             Q_EMIT cookieChanged();
         }
+    }
+
+    void Auth::setRequiresZeroDelayOnFailAuth(const bool requiresZeroDelayOnFailAuth)
+    {
+        d->requiresZeroDelayOnFailAuth = requiresZeroDelayOnFailAuth;
     }
 
     void Auth::setUser(const QString &user) {
@@ -381,6 +393,9 @@ namespace SDDM {
             args << QStringLiteral("--display-server") << d->displayServerCmd;
         if (d->greeter)
             args << QStringLiteral("--greeter");
+        if (d->requiresZeroDelayOnFailAuth)
+            args << QStringLiteral("--zeroDelayOnFailAuth");
+
         d->child->start(QStringLiteral("%1/sddm-helper").arg(QStringLiteral(LIBEXEC_INSTALL_DIR)), args);
     }
 

--- a/src/auth/Auth.h
+++ b/src/auth/Auth.h
@@ -59,7 +59,7 @@ namespace SDDM {
         Q_PROPERTY(QString session READ session WRITE setSession NOTIFY sessionChanged)
         Q_PROPERTY(AuthRequest* request READ request NOTIFY requestChanged)
     public:
-        explicit Auth(const QString &user = QString(), const QString &session = QString(), bool autologin = false, QObject *parent = 0, bool verbose = false);
+        explicit Auth(const QString &user = QString(), const QString &session = QString(), bool autologin = false, QObject *parent = 0, bool verbose = false, const bool requiresZeroDelayOnFailAuth = false);
         explicit Auth(QObject *parent);
         ~Auth();
 
@@ -99,6 +99,7 @@ namespace SDDM {
         const QString &user() const;
         const QString &session() const;
         AuthRequest *request();
+        bool requiresZeroDelayOnFailAuth() const;
         /**
          * True if an authentication or session is in progress
          */
@@ -161,6 +162,15 @@ namespace SDDM {
          * @param cookie cookie data
          */
         void setCookie(const QByteArray &cookie);
+
+        /**
+         * Set whether the auth request should have no delay on failure.
+         * Reads the "needsZeroAuthFailDelay" value from the theme configuration.
+         * If set to true, then the theme should implement its own "Grace Lock".
+         * @param requiresZeroDelayOnFailAuth: True implies that there should be no delay from pam.
+         * @sa requiresZeroDelayOnFailAuth
+         */
+        void setRequiresZeroDelayOnFailAuth(const bool requiresZeroDelayOnFailAuth);
 
     public Q_SLOTS:
         /**

--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -264,6 +264,8 @@ namespace SDDM {
         m_greeter->setSocket(m_socketServer->socketAddress());
         m_greeter->setTheme(findGreeterTheme());
 
+        m_auth->setRequiresZeroDelayOnFailAuth(m_greeter->requiresZeroDelayOnFailAuth());
+
         // start greeter
         m_greeter->start();
     }

--- a/src/daemon/Greeter.cpp
+++ b/src/daemon/Greeter.cpp
@@ -68,6 +68,9 @@ namespace SDDM {
             QString configFile = QStringLiteral("%1/%2").arg(m_themePath).arg(m_metadata->configFile());
             m_themeConfig->setTo(configFile);
         }
+        const bool themeRequiresZeroDelayOnFailAuth{m_themeConfig->value(QStringLiteral("requiresZeroDelayOnFailAuth"), false).toBool()};
+        qDebug() << "ThemeRequiresZeroDelayOnFailAuth:" << themeRequiresZeroDelayOnFailAuth;
+        m_requiresZeroDelayOnFailAuth = themeRequiresZeroDelayOnFailAuth;
     }
 
     QString Greeter::displayServerCommand() const
@@ -179,6 +182,7 @@ namespace SDDM {
             // authentication
             m_auth = new Auth(this);
             m_auth->setVerbose(true);
+            // m_auth->setRequiresZeroDelayOnFailAuth(m_requiresZeroDelayOnFailAuth); is probably not needed here
             connect(m_auth, &Auth::requestChanged, this, &Greeter::onRequestChanged);
             connect(m_auth, &Auth::sessionStarted, this, &Greeter::onSessionStarted);
             connect(m_auth, &Auth::displayServerReady, this, &Greeter::onDisplayServerReady);
@@ -335,6 +339,11 @@ namespace SDDM {
     bool Greeter::isRunning() const {
         return (m_process && m_process->state() == QProcess::Running)
             || (m_auth && m_auth->isActive());
+    }
+
+    bool Greeter::requiresZeroDelayOnFailAuth() const
+    {
+        return m_requiresZeroDelayOnFailAuth;
     }
 
     void Greeter::onReadyReadStandardError()

--- a/src/daemon/Greeter.h
+++ b/src/daemon/Greeter.h
@@ -45,6 +45,8 @@ namespace SDDM {
         void setDisplayServerCommand(const QString &cmd);
         bool isRunning() const;
 
+        bool requiresZeroDelayOnFailAuth() const;
+
     public slots:
         bool start();
         void stop();
@@ -77,6 +79,8 @@ namespace SDDM {
 
         Auth *m_auth { nullptr };
         QProcess *m_process { nullptr };
+
+        bool m_requiresZeroDelayOnFailAuth { false };
 
         static void insertEnvironmentList(QStringList names, QProcessEnvironment sourceEnv, QProcessEnvironment &targetEnv);
         static QString greeterPathForQt(int qtVersion);

--- a/src/helper/Backend.cpp
+++ b/src/helper/Backend.cpp
@@ -58,6 +58,11 @@ namespace SDDM {
         m_greeter = on;
     }
 
+    void Backend::setRequiresZeroDelayOnFailAuth(const bool requiresZeroDelayOnFailAuth)
+    {
+        m_requiresZeroDelayOnFailAuth = requiresZeroDelayOnFailAuth;
+    }
+
     bool Backend::openSession() {
         QProcessEnvironment env = m_app->session()->processEnvironment();
         struct passwd *pw;
@@ -125,4 +130,5 @@ namespace SDDM {
     bool Backend::closeSession() {
         return true;
     }
+
 }

--- a/src/helper/Backend.h
+++ b/src/helper/Backend.h
@@ -38,6 +38,7 @@ namespace SDDM {
         void setAutologin(bool on = true);
         void setDisplayServer(bool on = true);
         void setGreeter(bool on = true);
+        void setRequiresZeroDelayOnFailAuth(const bool requiresZeroDelayOnFailAuth = true);
 
     public slots:
         virtual bool start(const QString &user = QString()) = 0;
@@ -53,6 +54,7 @@ namespace SDDM {
         bool m_autologin { false };
         bool m_displayServer = false;
         bool m_greeter { false };
+        bool m_requiresZeroDelayOnFailAuth { false };
     };
 }
 

--- a/src/helper/HelperApp.cpp
+++ b/src/helper/HelperApp.cpp
@@ -119,6 +119,10 @@ namespace SDDM {
             m_backend->setGreeter(true);
         }
 
+        if ((pos = args.indexOf(QStringLiteral("--zeroDelayOnFailAuth"))) >= 0) {
+            m_backend->setRequiresZeroDelayOnFailAuth(true);
+        }
+
         if (server.isEmpty() || m_id <= 0) {
             qCritical() << "This application is not supposed to be executed manually";
             exit(Auth::HELPER_OTHER_ERROR);

--- a/src/helper/backend/PamBackend.cpp
+++ b/src/helper/backend/PamBackend.cpp
@@ -218,12 +218,15 @@ namespace SDDM {
         bool result;
 
         QString service = QStringLiteral("sddm");
+        bool requiresZeroDelayOnFailAuth{ m_requiresZeroDelayOnFailAuth };
 
         if (user == QStringLiteral("sddm") && m_greeter)
             service = QStringLiteral("sddm-greeter");
-        else if (m_autologin)
+        else if (m_autologin) {
             service = QStringLiteral("sddm-autologin");
-        result = m_pam->start(service, user);
+            requiresZeroDelayOnFailAuth = false; // PAM can introduce a delay, as the UI does not do much
+        }
+        result = m_pam->start(service, user, requiresZeroDelayOnFailAuth);
 
         if (!result)
             m_app->error(m_pam->errorString(), Auth::ERROR_INTERNAL);

--- a/src/helper/backend/PamHandle.cpp
+++ b/src/helper/backend/PamHandle.cpp
@@ -23,6 +23,11 @@
 #include <QtCore/QDebug>
 
 namespace SDDM {
+
+    static void fail_delay(int, unsigned, void*) {
+
+    }
+
     bool PamHandle::putEnv(const QProcessEnvironment& env) {
         const auto envs = env.toStringList();
         for (const QString& s : envs) {
@@ -84,6 +89,7 @@ namespace SDDM {
 
     bool PamHandle::authenticate(int flags) {
         qDebug() << "[PAM] Authenticating...";
+        pam_fail_delay(m_handle, 0);
         m_result = pam_authenticate(m_handle, flags | m_silent);
         if (m_result != PAM_SUCCESS) {
             qWarning() << "[PAM] authenticate:" << pam_strerror(m_handle, m_result);
@@ -144,7 +150,7 @@ namespace SDDM {
         return c->converse(n, msg, resp);
     }
 
-    bool PamHandle::start(const QString &service, const QString &user) {
+    bool PamHandle::start(const QString &service, const QString &user, const bool requiresZeroDelayOnFailAuth) {
         if (user.isEmpty())
             m_result = pam_start(qPrintable(service), NULL, &m_conv, &m_handle);
         else
@@ -156,6 +162,15 @@ namespace SDDM {
         else {
             qDebug() << "[PAM] Starting...";
         }
+#ifdef PAM_FAIL_DELAY
+        qDebug() << "[PAM] requiresZeroDelayOnFailAuth:" << requiresZeroDelayOnFailAuth;
+        if (requiresZeroDelayOnFailAuth) {
+            setItem(PAM_FAIL_DELAY, reinterpret_cast< void* >(fail_delay));
+        }
+#else
+        Q_UNUSED(requiresZeroDelayOnFailAuth);
+        Q_UNUSED(fail_delay);
+#endif
         return true;
     }
 

--- a/src/helper/backend/PamHandle.cpp
+++ b/src/helper/backend/PamHandle.cpp
@@ -89,7 +89,6 @@ namespace SDDM {
 
     bool PamHandle::authenticate(int flags) {
         qDebug() << "[PAM] Authenticating...";
-        pam_fail_delay(m_handle, 0);
         m_result = pam_authenticate(m_handle, flags | m_silent);
         if (m_result != PAM_SUCCESS) {
             qWarning() << "[PAM] authenticate:" << pam_strerror(m_handle, m_result);

--- a/src/helper/backend/PamHandle.h
+++ b/src/helper/backend/PamHandle.h
@@ -160,10 +160,11 @@ namespace SDDM {
         * \param service PAM service name, e.g. "sddm"
         * \param pam_conversation pointer to the PAM conversation structure to be used
         * \param user username
+        * \param requiresZeroDelayOnFailAuth: If true, then the delay function of the PAM is set to \ref fail_delay, i.e, no delay from the PAM. Default false
         *
         * \return true on success
         */
-        bool start(const QString &service, const QString &user = QString());
+        bool start(const QString &service, const QString &user = QString(), const bool requiresZeroDelayOnFailAuth = false);
 
         /**
         * Set PAM_SILENT upon the contained calls


### PR DESCRIPTION
- Define "requiresZeroDelayOnFailAuth" as a theme property, that can be set to true to disable login failure delays from PAM
-  This property is exposed by the config to the Greeter, so if not set the greeter can fall back to its old behaviour
- Required for https://bugs.kde.org/show_bug.cgi?id=407473