### PR TITLE
Add loginFailedDelayStarted event

### DIFF
--- a/src/auth/Auth.cpp
+++ b/src/auth/Auth.cpp
@@ -210,6 +210,13 @@ namespace SDDM {
                     str.send();
                     break;
                 }
+                case LOGIN_FAILED_DELAY_STARTED: {
+                    uint uSecDelay {0};
+                    str >> uSecDelay;
+                    qDebug() << "Auth: Login failed delay started notification received; delay duration:" << uSecDelay;
+                    Q_EMIT auth->loginFailedDelayStarted(uSecDelay);
+                    break;
+                }
                 default: {
                     Q_EMIT auth->error(QStringLiteral("Auth: Unexpected value received: %1").arg(m), ERROR_INTERNAL);
                 }

--- a/src/auth/Auth.h
+++ b/src/auth/Auth.h
@@ -230,6 +230,13 @@ namespace SDDM {
         */
         void info(QString message, Auth::Info type);
 
+        /**
+        * Event to indicate that a wrong password lockout has been started, with a certain duration.
+        *
+        * @param uSecDelay: The duration of the lockout delay (in MicroSeconds)
+        */
+        void loginFailedDelayStarted(const uint uSecDelay);
+
     private:
         class Private;
         class SocketServer;

--- a/src/auth/AuthMessages.h
+++ b/src/auth/AuthMessages.h
@@ -98,6 +98,7 @@ namespace SDDM {
         AUTHENTICATED,
         SESSION_STATUS,
         DISPLAY_SERVER_STARTED,
+        LOGIN_FAILED_DELAY_STARTED,
         MSG_LAST,
     };
 

--- a/src/common/Messages.h
+++ b/src/common/Messages.h
@@ -39,6 +39,7 @@ namespace SDDM {
         LoginSucceeded,
         LoginFailed,
         InformationMessage,
+        LoginFailedDelayStarted // Emitted after we know that the login attempt has failed, but PAM still hasn't returned control. This is the start of the failure delay.
     };
 
     enum Capability {

--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -147,6 +147,7 @@ namespace SDDM {
         connect(m_auth, &Auth::finished, this, &Display::slotHelperFinished);
         connect(m_auth, &Auth::info, this, &Display::slotAuthInfo);
         connect(m_auth, &Auth::error, this, &Display::slotAuthError);
+        connect(m_auth, &Auth::loginFailedDelayStarted, this, &Display::slotAuthLoginFailedDelayStarted);
 
         // restart display after display server ended
         connect(m_displayServer, &DisplayServer::started, this, &Display::displayServerStarted);
@@ -534,6 +535,14 @@ namespace SDDM {
         m_socketServer->informationMessage(m_socket, message);
         if (error == Auth::ERROR_AUTHENTICATION)
             emit loginFailed(m_socket);
+    }
+
+    void Display::slotAuthLoginFailedDelayStarted(const uint uSecDuration)
+    {
+        if (!m_socket)
+            return;
+
+        m_socketServer->loginFailedDelayStarted(m_socket, uSecDuration);
     }
 
     void Display::slotHelperFinished(Auth::HelperExitStatus status) {

--- a/src/daemon/Display.h
+++ b/src/daemon/Display.h
@@ -118,6 +118,7 @@ namespace SDDM {
         void slotHelperFinished(Auth::HelperExitStatus status);
         void slotAuthInfo(const QString &message, Auth::Info info);
         void slotAuthError(const QString &message, Auth::Error error);
+        void slotAuthLoginFailedDelayStarted(const uint uSecDuration);
     };
 }
 

--- a/src/daemon/SocketServer.cpp
+++ b/src/daemon/SocketServer.cpp
@@ -200,6 +200,11 @@ namespace SDDM {
         SocketWriter(socket) << quint32(DaemonMessages::LoginSucceeded);
     }
 
+    void SocketServer::loginFailedDelayStarted(QLocalSocket *socket, const uint uSecDelay)
+    {
+        SocketWriter(socket) << static_cast< quint32 >(DaemonMessages::LoginFailedDelayStarted) << uSecDelay;
+    }
+
     void SocketServer::informationMessage(QLocalSocket *socket, const QString &message) {
         SocketWriter(socket) << quint32(DaemonMessages::InformationMessage) << message;
     }

--- a/src/daemon/SocketServer.h
+++ b/src/daemon/SocketServer.h
@@ -49,6 +49,7 @@ namespace SDDM {
         void informationMessage(QLocalSocket *socket, const QString &message);
         void loginFailed(QLocalSocket *socket);
         void loginSucceeded(QLocalSocket *socket);
+        void loginFailedDelayStarted(QLocalSocket *socket, const uint uSecDelay);
 
     signals:
         void login(QLocalSocket *socket,

--- a/src/greeter/GreeterProxy.cpp
+++ b/src/greeter/GreeterProxy.cpp
@@ -214,6 +214,13 @@ namespace SDDM {
                     emit informationMessage(message);
                 }
                 break;
+                case DaemonMessages::LoginFailedDelayStarted: {
+                    uint delay {0};
+                    input >> delay;
+                    qDebug() << "Login failed delay started notification received from daemon; delay duration:" << delay;
+                    Q_EMIT loginFailedDelayStarted(delay);
+                    break;
+                }
                 default: {
                     // log message
                     qWarning() << "Unknown message received from daemon.";

--- a/src/greeter/GreeterProxy.h
+++ b/src/greeter/GreeterProxy.h
@@ -81,6 +81,7 @@ namespace SDDM {
 
         void socketDisconnected();
         void loginFailed();
+        void loginFailedDelayStarted(const uint uSecDelay);
         void loginSucceeded();
 
     private:

--- a/src/helper/Backend.cpp
+++ b/src/helper/Backend.cpp
@@ -38,6 +38,15 @@ namespace SDDM {
     Backend::Backend(HelperApp* parent)
             : QObject(parent)
             , m_app(parent) {
+
+        connect(this, &Backend::loginFailedDelayStarted, this, [this](const uint uSecDelay) noexcept -> void {
+            if (!m_app) {
+                qWarning() << "[Backend] Cannot handle loginFailedDelayStarted, as the HelperApp is a nullptr";
+                return;
+            }
+            m_app->loginFailedDelayStarted(uSecDelay);
+        });
+
     }
 
     Backend *Backend::get(HelperApp* parent)

--- a/src/helper/Backend.h
+++ b/src/helper/Backend.h
@@ -39,6 +39,8 @@ namespace SDDM {
         void setDisplayServer(bool on = true);
         void setGreeter(bool on = true);
 
+        Q_SIGNAL void loginFailedDelayStarted(const uint uSecDelay);
+
     public slots:
         virtual bool start(const QString &user = QString()) = 0;
         virtual bool authenticate() = 0;

--- a/src/helper/HelperApp.cpp
+++ b/src/helper/HelperApp.cpp
@@ -152,8 +152,6 @@ namespace SDDM {
 
         Q_ASSERT(getuid() == 0);
         if (!m_backend->authenticate()) {
-            authenticated(QString());
-
             // write failed login to btmp
             const QProcessEnvironment env = m_session->processEnvironment();
             const QString displayId = env.value(QStringLiteral("DISPLAY"));
@@ -207,6 +205,14 @@ namespace SDDM {
     void HelperApp::error(const QString& message, Auth::Error type) {
         SafeDataStream str(m_socket);
         str << Msg::ERROR << message << type;
+        str.send();
+        m_socket->waitForBytesWritten();
+    }
+
+    void HelperApp::loginFailedDelayStarted(const uint uSecDelay)
+    {
+        SafeDataStream str(m_socket);
+        str << Msg::LOGIN_FAILED_DELAY_STARTED << uSecDelay;
         str.send();
         m_socket->waitForBytesWritten();
     }

--- a/src/helper/HelperApp.h
+++ b/src/helper/HelperApp.h
@@ -46,6 +46,7 @@ namespace SDDM {
         Request request(const Request &request);
         void info(const QString &message, Auth::Info type);
         void error(const QString &message, Auth::Error type);
+        void loginFailedDelayStarted(const uint uSecDelay);
         QProcessEnvironment authenticated(const QString &user);
         void displayServerStarted(const QString &displayName);
         void sessionOpened(bool success);

--- a/src/helper/backend/PamHandle.cpp
+++ b/src/helper/backend/PamHandle.cpp
@@ -21,8 +21,25 @@
 #include "PamBackend.h"
 
 #include <QtCore/QDebug>
+#include <QThread>
 
 namespace SDDM {
+    static void fail_delay(int retval, uint usec_delay, void* appdata_ptr) {
+        auto* backend = reinterpret_cast< PamBackend* >(appdata_ptr); // Refer the pam_conv (@sa m_conv) structure for info on appdata_ptr
+        if (!backend) {
+            qFatal() << "[PAM] appdata_ptr not convertible to a valid PamBackend! Cannot apply fail delay";
+            return;
+        }
+        if (retval == PAM_SUCCESS) {
+            qDebug() << "[PAM] Fail delay function was called, but authentication result was a success!";
+            return;
+        }
+        Q_EMIT backend->loginFailedDelayStarted(usec_delay);
+        if (usec_delay > 0u) {
+            QThread::usleep(usec_delay); // This calls nanosleep as of Qt 6.8. It also handles EINTR (restarts the sleep with the remainder duration when interrupted), but not EFAULT or EINVAL.
+        }
+    }
+
     bool PamHandle::putEnv(const QProcessEnvironment& env) {
         const auto envs = env.toStringList();
         for (const QString& s : envs) {
@@ -149,6 +166,13 @@ namespace SDDM {
             m_result = pam_start(qPrintable(service), NULL, &m_conv, &m_handle);
         else
             m_result = pam_start(qPrintable(service), qPrintable(user), &m_conv, &m_handle);
+
+#if defined(HAVE_PAM_FAIL_DELAY)
+        setItem(PAM_FAIL_DELAY, reinterpret_cast< void* >(fail_delay));
+#else
+        Q_UNUSED(fail_delay);
+#endif
+
         if (m_result != PAM_SUCCESS) {
             qWarning() << "[PAM] start" << pam_strerror(m_handle, m_result);
             return false;


### PR DESCRIPTION
- Prevent duplicate loginFailed event
- On authentication failure, inform the greeter about the start of the PAM delay by triggering the loginFailedDelayStarted event.
- Required for https://bugs.kde.org/show_bug.cgi?id=407473