### PR TITLE
Fix index check for UserModel

### DIFF
--- a/src/greeter/UserModel.cpp
+++ b/src/greeter/UserModel.cpp
@@ -183,7 +183,7 @@ namespace SDDM {
     }
 
     QVariant UserModel::data(const QModelIndex &index, int role) const {
-        if (index.row() < 0 || index.row() > d->users.count())
+        if (index.row() < 0 || index.row() >= d->users.count())
             return QVariant();
 
         // get user


### PR DESCRIPTION
when 'index.row() == d->users.count()', it's an out-of-bounds access to an array