### PR TITLE
Use QProcessEnvironment::systemEnvironment() to set initial process env

### DIFF
--- a/src/daemon/XorgDisplayServer.cpp
+++ b/src/daemon/XorgDisplayServer.cpp
@@ -265,12 +265,9 @@ namespace SDDM {
                       xcursorSize = mainConfig.Theme.CursorSize.get();
 
         // set process environment
-        QProcessEnvironment env;
+        QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
         env.insert(QStringLiteral("DISPLAY"), m_display);
-        env.insert(QStringLiteral("HOME"), QStringLiteral("/"));
-        env.insert(QStringLiteral("PATH"), mainConfig.Users.DefaultPath.get());
         env.insert(QStringLiteral("XAUTHORITY"), m_xauth.authPath());
-        env.insert(QStringLiteral("SHELL"), QStringLiteral("/bin/sh"));
         if (!xcursorTheme.isEmpty())
             env.insert(QStringLiteral("XCURSOR_THEME"), xcursorTheme);
         if (!xcursorSize.isEmpty())


### PR DESCRIPTION
This fixes #2079 

XorgDisplayServer::setupDisplay()  is ignoring environment variables set by the host system. This results in sddm creating a /.cache folder on systems with versions of mesa that look for HOME. 

This changes sddm to respect the HOME, PATH, and SHELL variables set by the platform.