### PR TITLE
Fix sddm stuck on boot with black screen and allow reducing Xorg verbosity level in rootless mode

### DIFF
--- a/src/daemon/XorgDisplayServer.cpp
+++ b/src/daemon/XorgDisplayServer.cpp
@@ -285,7 +285,7 @@ namespace SDDM {
         connect(setCursor, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished), setCursor, &QProcess::deleteLater);
 
         // wait for finished
-        if (!setCursor->waitForFinished(1000)) {
+        if (!setCursor->waitForFinished(5000)) {
             qWarning() << "Could not setup default cursor";
             setCursor->kill();
         }
@@ -302,7 +302,7 @@ namespace SDDM {
                 xrdbProcess.write(QStringLiteral("Xcursor.size: %1\n").arg(xcursorSize).toUtf8());
 
             xrdbProcess.closeWriteChannel();
-            if (!xrdbProcess.waitForFinished(1000)) {
+            if (!xrdbProcess.waitForFinished(5000)) {
                 qDebug() << "Could not set Xcursor resources" << xrdbProcess.error();
                 xrdbProcess.kill();
             }

--- a/src/daemon/XorgDisplayServer.cpp
+++ b/src/daemon/XorgDisplayServer.cpp
@@ -243,13 +243,12 @@ namespace SDDM {
         const auto program = displayStopCommand.takeFirst();
         displayStopScript->start(program, displayStopCommand);
 
+        // delete displayStopScript on finish
+        connect(displayStopScript, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished), displayStopScript, &QProcess::deleteLater);
+
         // wait for finished
         if (!displayStopScript->waitForFinished(5000))
             displayStopScript->kill();
-
-        // clean up the script process
-        displayStopScript->deleteLater();
-        displayStopScript = nullptr;
 
         // emit signal
         emit stopped();
@@ -305,6 +304,7 @@ namespace SDDM {
             if (!xrdbProcess.waitForFinished(5000)) {
                 qDebug() << "Could not set Xcursor resources" << xrdbProcess.error();
                 xrdbProcess.kill();
+                xrdbProcess.waitForFinished(-1);
             }
         }
 

--- a/src/daemon/XorgUserDisplayServer.cpp
+++ b/src/daemon/XorgUserDisplayServer.cpp
@@ -55,13 +55,13 @@ QString XorgUserDisplayServer::command(Display *display)
              << QStringLiteral("-screen") << QStringLiteral("800x600");
     } else {
         args << mainConfig.X11.ServerPath.get()
+             << QStringLiteral("-verbose") << QStringLiteral("3")
              << mainConfig.X11.ServerArguments.get().split(QLatin1Char(' '), Qt::SkipEmptyParts)
              << QStringLiteral("-background") << QStringLiteral("none")
              << QStringLiteral("-seat") << display->seat()->name()
              << QStringLiteral("-noreset")
              << QStringLiteral("-keeptty")
-             << QStringLiteral("-novtswitch")
-             << QStringLiteral("-verbose") << QStringLiteral("3");
+             << QStringLiteral("-novtswitch");
     }
 
     return args.join(QLatin1Char(' '));

--- a/src/helper/xorguserhelper.cpp
+++ b/src/helper/xorguserhelper.cpp
@@ -215,7 +215,7 @@ void XOrgUserHelper::startDisplayCommand()
     qInfo("Setting default cursor...");
     QProcess *setCursor = nullptr;
     if (startProcess(QStringLiteral("xsetroot -cursor_name left_ptr"), env, &setCursor)) {
-        if (!setCursor->waitForFinished(1000)) {
+        if (!setCursor->waitForFinished(5000)) {
             qWarning() << "Could not setup default cursor";
             setCursor->kill();
         }
@@ -234,7 +234,7 @@ void XOrgUserHelper::startDisplayCommand()
             xrdbProcess.write(QStringLiteral("Xcursor.size: %1\n").arg(xcursorSize).toUtf8());
 
         xrdbProcess.closeWriteChannel();
-        if (!xrdbProcess.waitForFinished(1000)) {
+        if (!xrdbProcess.waitForFinished(5000)) {
             qDebug() << "Could not set Xcursor resources" << xrdbProcess.error();
             xrdbProcess.kill();
         }

--- a/src/helper/xorguserhelper.cpp
+++ b/src/helper/xorguserhelper.cpp
@@ -212,14 +212,16 @@ void XOrgUserHelper::startDisplayCommand()
         env.insert(QStringLiteral("XCURSOR_SIZE"), xcursorSize);
 
     // Set cursor
-    qInfo("Setting default cursor...");
-    QProcess *setCursor = nullptr;
-    if (startProcess(QStringLiteral("xsetroot -cursor_name left_ptr"), env, &setCursor)) {
-        if (!setCursor->waitForFinished(5000)) {
-            qWarning() << "Could not setup default cursor";
-            setCursor->kill();
+    {
+        qInfo("Setting default cursor...");
+        QProcess setCursor;
+        setCursor.setProcessEnvironment(env);
+        setCursor.start(QStringLiteral("xsetroot"), QStringList{QStringLiteral("-cursor_name"), QStringLiteral("left_ptr")});
+        if (!setCursor.waitForFinished(5000)) {
+            qWarning() << "Could not setup default cursor" << setCursor.error();
+            setCursor.kill();
+            setCursor.waitForFinished(-1);
         }
-        setCursor->deleteLater();
     }
 
     // Unlike libXcursor, xcb-util-cursor no longer looks at XCURSOR_*. Set the resources.

--- a/src/helper/xorguserhelper.cpp
+++ b/src/helper/xorguserhelper.cpp
@@ -237,6 +237,7 @@ void XOrgUserHelper::startDisplayCommand()
         if (!xrdbProcess.waitForFinished(5000)) {
             qDebug() << "Could not set Xcursor resources" << xrdbProcess.error();
             xrdbProcess.kill();
+            xrdbProcess.waitForFinished(-1);
         }
     }
 
@@ -245,9 +246,10 @@ void XOrgUserHelper::startDisplayCommand()
     qInfo("Running display setup script: %s", qPrintable(cmd));
     QProcess *displayScript = nullptr;
     if (startProcess(cmd, env, &displayScript)) {
+        // delete displayScript on finish
+        connect(displayScript, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished), displayScript, &QProcess::deleteLater);
         if (!displayScript->waitForFinished(30000))
             displayScript->kill();
-        displayScript->deleteLater();
     }
 }
 
@@ -257,9 +259,10 @@ void XOrgUserHelper::displayFinished()
     qInfo("Running display stop script: %s", qPrintable(cmd));
     QProcess *displayStopScript = nullptr;
     if (startProcess(cmd, sessionEnvironment(), &displayStopScript)) {
+        // delete displayStopScript on finish
+        connect(displayStopScript, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished), displayStopScript, &QProcess::deleteLater);
         if (!displayStopScript->waitForFinished(5000))
             displayStopScript->kill();
-        displayStopScript->deleteLater();
     }
 }
 


### PR DESCRIPTION
It appears that my system boots slower and slower over years without additional software :( So that bug happened for me rarely at first. But after recent minor qt6 libs upgrade I finally got repro in 100% cases (system won't boot into GUI).