### PR TITLE
Fix the Xsession initialization file

### DIFF
--- a/data/scripts/Xsession
+++ b/data/scripts/Xsession
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 # Xsession - run as user
 # Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
 
@@ -57,13 +57,14 @@ USERXSESSIONRC=$HOME/.xsessionrc
 ALTUSERXSESSION=$HOME/.Xsession
 
 if [ -d "$xsessionddir" ]; then
-    for i in `ls $xsessionddir`; do
-        script="$xsessionddir/$i"
-        echo "Loading X session script $script"
-        if [ -r "$script"  -a -f "$script" ] && expr "$i" : '^[[:alnum:]_-]\{1,\}$' > /dev/null; then
-            . "$script"
+    pushd "$xsessionddir"
+    for s in ./*; do
+        if [[ -r "$s" ]] && [[ -f "$s" ]] && [[ "$s" =~ ^[.]/[a-zA-Z0-9_-]+$ ]]; then
+            echo "Loading X session script $xsessionddir/$s"
+            . "$s"
         fi
     done
+    popd
 fi
 
 if [ -d /etc/X11/Xresources ]; then


### PR DESCRIPTION
This commit fixes several problems with the Xsession file:

* The script was defined as #!/bin/sh, whereas in reality bash-specific syntax was used inside the script. This was fixed by correctly specifying "bash", which is then guaranteed not to break on systems where `sh` is not symlinked to `bash` but is linked to another shell.

* The previous version of the script used "weird", unusual and easy-to-make-mistakes format for testing. The updated version makes the `if` condition very structured and non-ambiguous. (For reference, even the `man` page for `test` notes that some combinations of `-a` and `-o` are ambiguous. It's really more readable to avoid this, with no penalty.)

* The previous usage of `ls $xsessionddir` would totally break in a wide spectrum of file names, from files containing dashes and double dashes to files containing newlines. This was fixed to not break on any file names.

* The previous version used an unusual, problematic handling of regular expressions. The new version updates the usage of regular expression to a simpler format, both by the usage of `+` at the end (as opposed to `\{1,\}`), and by using the recommended way for regular expression checking. For the latter, see e.g. here: https://stackoverflow.com/questions/21112707/check-if-a-string-matches-a-regex-in-bash-script

To summarize, this change unbreaks this script for certain valid scenarios and along the way makes it easier to read and more conformant with best practices.