### PR TITLE
fix: restart greeter when helper is in a wrong state

### DIFF
--- a/src/auth/Auth.cpp
+++ b/src/auth/Auth.cpp
@@ -230,7 +230,10 @@ namespace SDDM {
         else
             qWarning("Auth: sddm-helper exited with %d", exitCode);
 
-        Q_EMIT qobject_cast<Auth*>(parent())->finished((Auth::HelperExitStatus)exitCode);
+        if (exitStatus == QProcess::NormalExit)
+            Q_EMIT qobject_cast<Auth*>(parent())->finished((Auth::HelperExitStatus)exitCode);
+        else
+            Q_EMIT qobject_cast<Auth*>(parent())->finished(Auth::HELPER_OTHER_ERROR);
     }
 
     void Auth::Private::childError(QProcess::ProcessError error) {

--- a/src/helper/HelperApp.cpp
+++ b/src/helper/HelperApp.cpp
@@ -53,8 +53,13 @@ namespace SDDM {
             , m_socket(new QLocalSocket(this)) {
         qInstallMessageHandler(HelperMessageHandler);
         SignalHandler *s = new SignalHandler(this);
+        s->addCustomSignal(SIGHUP);
         QObject::connect(s, &SignalHandler::sigtermReceived, m_session, [] {
-            QCoreApplication::instance()->exit(-1);
+            QCoreApplication::instance()->exit(Auth::HELPER_OTHER_ERROR);
+        });
+
+        QObject::connect(s, &SignalHandler::customSignalReceived, m_session, [](int) {
+            QCoreApplication::instance()->exit(Auth::HELPER_OTHER_ERROR);
         });
 
         QTimer::singleShot(0, this, SLOT(setUp()));

--- a/src/helper/HelperApp.cpp
+++ b/src/helper/HelperApp.cpp
@@ -206,7 +206,11 @@ namespace SDDM {
             }
             else
                 exit(Auth::HELPER_SUCCESS);
+            return;
         }
+
+        Q_ASSERT_X(exitCode != 0, "HelperApp::sessionFinished", "Crashing with 0 is impossible");
+
         qWarning("Session crashed (killed by signal %d).", exitCode);
         exit(Auth::HELPER_SESSION_ERROR);
     }
@@ -298,7 +302,9 @@ namespace SDDM {
     HelperApp::~HelperApp() {
         Q_ASSERT(getuid() == 0);
 
-        m_session->stop();
+        // Avoid re-emitting QProcess::finished if session is not running
+        if (m_session->state() != QProcess::NotRunning)
+            m_session->stop();
         m_backend->closeSession();
 
         // write logout to utmp/wtmp

--- a/src/helper/HelperApp.cpp
+++ b/src/helper/HelperApp.cpp
@@ -302,7 +302,8 @@ namespace SDDM {
     HelperApp::~HelperApp() {
         Q_ASSERT(getuid() == 0);
 
-        // Avoid re-emitting QProcess::finished if session is not running
+        // Avoid calls to sessionFinished when exiting
+        disconnect(m_session, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished), this, &HelperApp::sessionFinished);
         if (m_session->state() != QProcess::NotRunning)
             m_session->stop();
         m_backend->closeSession();

--- a/src/helper/HelperApp.cpp
+++ b/src/helper/HelperApp.cpp
@@ -73,7 +73,7 @@ namespace SDDM {
         if ((pos = args.indexOf(QStringLiteral("--socket"))) >= 0) {
             if (pos >= args.length() - 1) {
                 qCritical() << "This application is not supposed to be executed manually";
-                exit(Auth::HELPER_OTHER_ERROR);
+                QCoreApplication::exit(Auth::HELPER_OTHER_ERROR);
                 return;
             }
             server = args[pos + 1];
@@ -82,7 +82,7 @@ namespace SDDM {
         if ((pos = args.indexOf(QStringLiteral("--id"))) >= 0) {
             if (pos >= args.length() - 1) {
                 qCritical() << "This application is not supposed to be executed manually";
-                exit(Auth::HELPER_OTHER_ERROR);
+                QCoreApplication::exit(Auth::HELPER_OTHER_ERROR);
                 return;
             }
             m_id = QString(args[pos + 1]).toLongLong();
@@ -91,7 +91,7 @@ namespace SDDM {
         if ((pos = args.indexOf(QStringLiteral("--start"))) >= 0) {
             if (pos >= args.length() - 1) {
                 qCritical() << "This application is not supposed to be executed manually";
-                exit(Auth::HELPER_OTHER_ERROR);
+                QCoreApplication::exit(Auth::HELPER_OTHER_ERROR);
                 return;
             }
             m_session->setPath(args[pos + 1]);
@@ -100,7 +100,7 @@ namespace SDDM {
         if ((pos = args.indexOf(QStringLiteral("--user"))) >= 0) {
             if (pos >= args.length() - 1) {
                 qCritical() << "This application is not supposed to be executed manually";
-                exit(Auth::HELPER_OTHER_ERROR);
+                QCoreApplication::exit(Auth::HELPER_OTHER_ERROR);
                 return;
             }
             m_user = args[pos + 1];
@@ -109,7 +109,7 @@ namespace SDDM {
         if ((pos = args.indexOf(QStringLiteral("--display-server"))) >= 0) {
             if (pos >= args.length() - 1) {
                 qCritical() << "This application is not supposed to be executed manually";
-                exit(Auth::HELPER_OTHER_ERROR);
+                QCoreApplication::exit(Auth::HELPER_OTHER_ERROR);
                 return;
             }
             m_session->setDisplayServerCommand(args[pos + 1]);
@@ -126,7 +126,7 @@ namespace SDDM {
 
         if (server.isEmpty() || m_id <= 0) {
             qCritical() << "This application is not supposed to be executed manually";
-            exit(Auth::HELPER_OTHER_ERROR);
+            QCoreApplication::exit(Auth::HELPER_OTHER_ERROR);
             return;
         }
 
@@ -151,7 +151,7 @@ namespace SDDM {
             const QString vt = env.value(QStringLiteral("XDG_VTNR"));
             utmpLogin(vt, displayId, m_user, 0, false);
 
-            exit(Auth::HELPER_AUTH_ERROR);
+            QCoreApplication::exit(Auth::HELPER_AUTH_ERROR);
             return;
         }
 
@@ -165,7 +165,7 @@ namespace SDDM {
             const QString vt = env.value(QStringLiteral("XDG_VTNR"));
             utmpLogin(vt, displayId, m_user, 0, false);
 
-            exit(Auth::HELPER_AUTH_ERROR);
+            QCoreApplication::exit(Auth::HELPER_AUTH_ERROR);
             return;
         }
 
@@ -178,7 +178,7 @@ namespace SDDM {
 
             if (!m_backend->openSession()) {
                 sessionOpened(false);
-                exit(Auth::HELPER_SESSION_ERROR);
+                QCoreApplication::exit(Auth::HELPER_SESSION_ERROR);
                 return;
             }
 
@@ -194,7 +194,7 @@ namespace SDDM {
             }
         }
         else
-            exit(Auth::HELPER_SUCCESS);
+            QCoreApplication::exit(Auth::HELPER_SUCCESS);
         return;
     }
 
@@ -202,17 +202,17 @@ namespace SDDM {
         if (exitStatus == QProcess::NormalExit) {
             if (exitCode != 0) {
                 qWarning("Session crashed (exit code %d).", exitCode);
-                exit(Auth::HELPER_SESSION_ERROR);
+                QCoreApplication::exit(Auth::HELPER_SESSION_ERROR);
             }
             else
-                exit(Auth::HELPER_SUCCESS);
+                QCoreApplication::exit(Auth::HELPER_SUCCESS);
             return;
         }
 
         Q_ASSERT_X(exitCode != 0, "HelperApp::sessionFinished", "Crashing with 0 is impossible");
 
         qWarning("Session crashed (killed by signal %d).", exitCode);
-        exit(Auth::HELPER_SESSION_ERROR);
+        QCoreApplication::exit(Auth::HELPER_SESSION_ERROR);
     }
 
     void HelperApp::info(const QString& message, Auth::Info type) {

--- a/src/helper/HelperApp.cpp
+++ b/src/helper/HelperApp.cpp
@@ -199,16 +199,16 @@ namespace SDDM {
     }
 
     void HelperApp::sessionFinished(int exitCode, QProcess::ExitStatus exitStatus) {
-        if (exitStatus == QProcess::CrashExit) {
-            qWarning("Session crashed (killed by signal %d).", exitCode);
-            exit(Auth::HELPER_SESSION_ERROR);
+        if (exitStatus == QProcess::NormalExit) {
+            if (exitCode != 0) {
+                qWarning("Session crashed (exit code %d).", exitCode);
+                exit(Auth::HELPER_SESSION_ERROR);
+            }
+            else
+                exit(Auth::HELPER_SUCCESS);
         }
-        else if (exitCode != 0) {
-            qWarning("Session crashed (exit code %d).", exitCode);
-            exit(Auth::HELPER_SESSION_ERROR);
-        }
-        else
-            exit(Auth::HELPER_SUCCESS);
+        qWarning("Session crashed (killed by signal %d).", exitCode);
+        exit(Auth::HELPER_SESSION_ERROR);
     }
 
     void HelperApp::info(const QString& message, Auth::Info type) {

--- a/src/helper/HelperApp.cpp
+++ b/src/helper/HelperApp.cpp
@@ -131,7 +131,7 @@ namespace SDDM {
         }
 
         connect(m_socket, &QLocalSocket::connected, this, &HelperApp::doAuth);
-        connect(m_session, &UserSession::finished, this, &HelperApp::sessionFinished);
+        connect(m_session, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished), this, &HelperApp::sessionFinished);
         m_socket->connectToServer(server, QIODevice::ReadWrite | QIODevice::Unbuffered);
     }
 
@@ -198,9 +198,13 @@ namespace SDDM {
         return;
     }
 
-    void HelperApp::sessionFinished(int status) {
-        if (status != 0) {
-            qWarning("Session crashed (exit code %d).", status);
+    void HelperApp::sessionFinished(int exitCode, QProcess::ExitStatus exitStatus) {
+        if (exitStatus == QProcess::CrashExit) {
+            qWarning("Session crashed (killed by signal %d).", exitCode);
+            exit(Auth::HELPER_SESSION_ERROR);
+        }
+        else if (exitCode != 0) {
+            qWarning("Session crashed (exit code %d).", exitCode);
             exit(Auth::HELPER_SESSION_ERROR);
         }
         else

--- a/src/helper/HelperApp.cpp
+++ b/src/helper/HelperApp.cpp
@@ -199,7 +199,12 @@ namespace SDDM {
     }
 
     void HelperApp::sessionFinished(int status) {
-        exit(status);
+        if (status != 0) {
+            qWarning("Session crashed (exit code %d).", status);
+            exit(Auth::HELPER_SESSION_ERROR);
+        }
+        else
+            exit(Auth::HELPER_SUCCESS);
     }
 
     void HelperApp::info(const QString& message, Auth::Info type) {

--- a/src/helper/HelperApp.h
+++ b/src/helper/HelperApp.h
@@ -54,7 +54,7 @@ namespace SDDM {
         void setUp();
         void doAuth();
 
-        void sessionFinished(int status);
+        void sessionFinished(int exitCode, QProcess::ExitStatus exitStatus);
 
     private:
         qint64 m_id { -1 };

--- a/src/helper/UserSession.cpp
+++ b/src/helper/UserSession.cpp
@@ -47,7 +47,6 @@ namespace SDDM {
     UserSession::UserSession(HelperApp *parent)
         : QProcess(parent)
     {
-        connect(this, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished), this, &UserSession::finished);
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
         setChildProcessModifier(std::bind(&UserSession::childModifier, this));
 #endif
@@ -157,7 +156,7 @@ namespace SDDM {
                 }
             }
         } else {
-            Q_EMIT finished(Auth::HELPER_OTHER_ERROR);
+            Q_EMIT finished(Auth::HELPER_OTHER_ERROR, QProcess::NormalExit);
         }
     }
 

--- a/src/helper/UserSession.cpp
+++ b/src/helper/UserSession.cpp
@@ -156,7 +156,7 @@ namespace SDDM {
                 }
             }
         } else {
-            Q_EMIT finished(Auth::HELPER_OTHER_ERROR, QProcess::NormalExit);
+            qInfo() << "Attempted to stop session, but was already not running";
         }
     }
 

--- a/src/helper/UserSession.h
+++ b/src/helper/UserSession.h
@@ -51,10 +51,6 @@ namespace SDDM {
         */
         qint64 cachedProcessId();
 
-
-    Q_SIGNALS:
-        void finished(int exitCode);
-
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     protected:
         void setupChildProcess() override;


### PR DESCRIPTION
This PR fixes a logic bug that prevents SDDM from restarting the greeter when either the session exits with code 1, or the SDDM helper gets signal-killed.

### Helper side

If the helper gets killed by a signal (currently handled are `SIGTERM` and `SIGHUP`), exit with `Auth::HELPER_OTHER_ERROR`. This will prevent the helper from exiting with code `Auth::HELPER_AUTH_ERROR`, which is wrong.
If the session exits with a bad code (!= 0), exit with `Auth::HELPER_SESSION_ERROR`. This will prevent the helper from exiting `Auth::HELPER_AUTH_ERROR` if the session deliberately ends with code 1.

### Daemon side

**DO NOT** cast the `exitCode` passed by `QProcess::finished` as a `Auth::HelperStatus` if the `exitStatus` is not `QProcess::NormalExit`. On Linux `QProcess::finished` is like a wrapper around `waitid(2)` which will put the signal number in `exitCode` if it got killed by one.
The [Qt Docs] even advises against doing it:

> exitCode is the exit code of the process **(only valid for normal exits)**

[Qt Docs]: https://doc.qt.io/qt-6/qprocess.html#finished

- Closes #1806 
- Closes #1908
- Closes #2027

For issues like #2003, this will result in a "restart loop" (which is essentially the same original symptom if the greeter fails to start in the first place).

Yes for the other session related issues, these are not SDDM related issues per se, but I think it's better UX to restart the greeter rather than leaving the user on a blank tty if a session fails.