### PR TITLE
Adjust visibility of authentication files in the /tmp directory

### DIFF
--- a/data/man/sddm.conf.rst.in
+++ b/data/man/sddm.conf.rst.in
@@ -164,7 +164,7 @@ OPTIONS
 The `XauthPath=` option is no longer necessary, libxau is used instead.
 
 The `UserAuthFile=` option was removed, the file is always created as
-`/tmp/xauth_XXXXX`. This is necessary for to the use of `FamilyWild` entries.
+`/tmp/.xauth_XXXXX`. This is necessary for to the use of `FamilyWild` entries.
 
 [Wayland] section:
 

--- a/data/man/sddm.rst.in
+++ b/data/man/sddm.rst.in
@@ -35,7 +35,7 @@ into the **video** group, otherwise errors regarding GL and drm devices
 might be experienced.
 
 For X11 sessions, the cookie for X authorization is written into a
-temporary file `/tmp/xauth_XXXXXX`, owned and only accessible by the
+temporary file `/tmp/.xauth_XXXXXX`, owned and only accessible by the
 user.
 
 OPTIONS

--- a/services/sddm-tmpfiles.conf.in
+++ b/services/sddm-tmpfiles.conf.in
@@ -3,12 +3,12 @@ d	${STATE_DIR}	0750	sddm	sddm
 # This contains X11 auth files passed to Xorg and the greeter
 d	${RUNTIME_DIR}	0711	root	root
 # Sockets for IPC
-r!	/tmp/sddm-auth*
+r!	/tmp/.sddm-auth*
 # xauth files passed to user sessions
-r!	/tmp/xauth_*
+r!	/tmp/.xauth_*
 # "r!" above means to remove the files if existent (r), but only at boot (!).
 # tmpfiles.d/tmp.conf declares a periodic cleanup of old /tmp/ files, which
 # would ordinarily result in the deletion of our xauth files. To prevent that
 # from happening, explicitly tag these as X (ignore).
-X	/tmp/sddm-auth*
-X	/tmp/xauth_*
+X	/tmp/.sddm-auth*
+X	/tmp/.xauth_*

--- a/src/auth/Auth.cpp
+++ b/src/auth/Auth.cpp
@@ -102,7 +102,7 @@ namespace SDDM {
         static std::unique_ptr<Auth::SocketServer> self;
         if (!self) {
             self.reset(new SocketServer());
-            self->listen(QStringLiteral("sddm-auth-%1").arg(QUuid::createUuid().toString(QUuid::WithoutBraces)));
+            self->listen(QStringLiteral(".sddm-auth-%1").arg(QUuid::createUuid().toString(QUuid::WithoutBraces)));
         }
         return self.get();
     }

--- a/src/common/XAuth.cpp
+++ b/src/common/XAuth.cpp
@@ -82,7 +82,7 @@ void XAuth::setup()
     QDir().mkpath(m_authDir);
 
     // Set path
-    m_authFile.setFileTemplate(m_authDir + QStringLiteral("/xauth_XXXXXX"));
+    m_authFile.setFileTemplate(m_authDir + QStringLiteral("/.xauth_XXXXXX"));
     if(!m_authFile.open()) {
         qFatal("Failed to create xauth file");
     }

--- a/src/helper/UserSession.cpp
+++ b/src/helper/UserSession.cpp
@@ -60,7 +60,7 @@ namespace SDDM {
         bool isWaylandGreeter = false;
 
         // If the Xorg display server was already started, write the passed
-        // auth cookie to /tmp/xauth_XXXXXX. This is done in the parent process
+        // auth cookie to /tmp/.xauth_XXXXXX. This is done in the parent process
         // so that it can clean up the file on session end.
         if (env.value(QStringLiteral("XDG_SESSION_TYPE")) == QLatin1String("x11")
             && m_displayServerCmd.isEmpty()) {
@@ -74,7 +74,7 @@ namespace SDDM {
             // Place it into /tmp, which is guaranteed to be read/writeable by
             // everyone while having the sticky bit set to avoid messing with
             // other's files.
-            m_xauthFile.setFileTemplate(QStringLiteral("/tmp/xauth_XXXXXX"));
+            m_xauthFile.setFileTemplate(QStringLiteral("/tmp/.xauth_XXXXXX"));
 
             if (!m_xauthFile.open()) {
                 qCritical() << "Could not create the Xauthority file";


### PR DESCRIPTION
Since the previously used .xauthority file is designated as a hidden file, it is advisable to assign the same visibility to the files moved to /tmp in order to prevent accidental deletion.

See #2104