### PR TITLE
Add option to disable autologin after systemd-softreboot

### DIFF
--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -103,7 +103,6 @@ namespace SDDM {
             Entry(User,                QString,     QString(),                                  _S("Username for autologin session"));
             Entry(Session,             QString,     QString(),                                  _S("Name of session file for autologin session (if empty try last logged in)"));
             Entry(Relogin,             bool,        false,                                      _S("Whether sddm should automatically log back into sessions when they exit"));
-            Entry(FirstLoginLockFile,  bool,        false,                                      _S("Whether sddm should use a temporary lock file to keep track of first login (persistent through `systemd soft-reboot`)"));
         );
     );
 

--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -103,6 +103,7 @@ namespace SDDM {
             Entry(User,                QString,     QString(),                                  _S("Username for autologin session"));
             Entry(Session,             QString,     QString(),                                  _S("Name of session file for autologin session (if empty try last logged in)"));
             Entry(Relogin,             bool,        false,                                      _S("Whether sddm should automatically log back into sessions when they exit"));
+            Entry(FirstLoginLockFile,  bool,        false,                                      _S("Whether sddm should use a temporary lock file to keep track of first login (persistent through `systemd soft-reboot`)"));
         );
     );
 

--- a/src/daemon/DaemonApp.cpp
+++ b/src/daemon/DaemonApp.cpp
@@ -47,6 +47,9 @@ namespace SDDM {
         // log message
         qDebug() << "Initializing...";
 
+        // setup logfile
+        m_firstLockFile.setFileName(QStringLiteral(RUNTIME_DIR) + QStringLiteral("/firstLock"));
+
         // set testing parameter
         m_testing = (arguments().indexOf(QStringLiteral("--test-mode")) != -1);
 
@@ -119,6 +122,25 @@ namespace SDDM {
     int DaemonApp::newSessionId() {
         return m_lastSessionId++;
     }
+
+    bool DaemonApp::hasLock() const {
+        return m_firstLockFile.exists();
+    };
+
+    bool DaemonApp::getFirst() const {
+        return self->first;
+    };
+
+    void DaemonApp::consumeFirst() {
+        self->first = false;
+        if (hasLock()) {
+            return;
+        }
+        if(!m_firstLockFile.open(QIODevice::WriteOnly)) {
+            qFatal("Failed to create lock file");
+        }
+        m_firstLockFile.close();
+    };
 }
 
 int main(int argc, char **argv) {

--- a/src/daemon/DaemonApp.cpp
+++ b/src/daemon/DaemonApp.cpp
@@ -47,8 +47,8 @@ namespace SDDM {
         // log message
         qDebug() << "Initializing...";
 
-        // setup logfile
-        m_firstLockFile.setFileName(QStringLiteral(RUNTIME_DIR) + QStringLiteral("/firstLock"));
+        // setup lockfile
+        m_firstloginLockFile.setFileName(QStringLiteral(RUNTIME_DIR) + QStringLiteral("/firstlogin.lock"));
 
         // set testing parameter
         m_testing = (arguments().indexOf(QStringLiteral("--test-mode")) != -1);
@@ -123,23 +123,12 @@ namespace SDDM {
         return m_lastSessionId++;
     }
 
-    bool DaemonApp::hasLock() const {
-        return m_firstLockFile.exists();
-    };
-
-    bool DaemonApp::getFirst() const {
-        return self->first;
-    };
-
-    void DaemonApp::consumeFirst() {
-        self->first = false;
-        if (hasLock()) {
-            return;
+    bool DaemonApp::tryLockFirstLogin() {
+        if(!m_firstloginLockFile.open(QIODevice::NewOnly)) {
+            return false;
         }
-        if(!m_firstLockFile.open(QIODevice::WriteOnly)) {
-            qFatal("Failed to create lock file");
-        }
-        m_firstLockFile.close();
+        m_firstloginLockFile.close();
+        return true;
     };
 }
 

--- a/src/daemon/DaemonApp.h
+++ b/src/daemon/DaemonApp.h
@@ -40,12 +40,10 @@ namespace SDDM {
 
         static DaemonApp *instance() { return self; }
 
-        // TODO: move these two away
+        // TODO: move this away
         bool testing() const;
 
-        bool hasLock() const;
-        bool getFirst() const;
-        void consumeFirst();
+        bool tryLockFirstLogin();
 
         QString hostName() const;
         DisplayManager *displayManager() const;
@@ -61,8 +59,7 @@ namespace SDDM {
 
         int m_lastSessionId { 0 };
 
-        bool first { true };
-        QFile m_firstLockFile;
+        QFile m_firstloginLockFile;
 
         bool m_testing { false };
         DisplayManager *m_displayManager { nullptr };

--- a/src/daemon/DaemonApp.h
+++ b/src/daemon/DaemonApp.h
@@ -21,6 +21,7 @@
 #define SDDM_DAEMONAPP_H
 
 #include <QCoreApplication>
+#include <QtCore>
 
 #define daemonApp DaemonApp::instance()
 
@@ -41,7 +42,10 @@ namespace SDDM {
 
         // TODO: move these two away
         bool testing() const;
-        bool first { true };
+
+        bool hasLock() const;
+        bool getFirst() const;
+        void consumeFirst();
 
         QString hostName() const;
         DisplayManager *displayManager() const;
@@ -56,6 +60,9 @@ namespace SDDM {
         static DaemonApp *self;
 
         int m_lastSessionId { 0 };
+
+        bool first { true };
+        QFile m_firstLockFile;
 
         bool m_testing { false };
         DisplayManager *m_displayManager { nullptr };

--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -173,7 +173,10 @@ namespace SDDM {
         connect(m_greeter, &Greeter::displayServerFailed, this, &Display::displayServerFailed);
 
         // Load autologin configuration (whether to autologin, user, session, session type)
-        if ((daemonApp->first || mainConfig.Autologin.Relogin.get()) &&
+        if (((daemonApp->getFirst() &&
+              !(daemonApp->hasLock() &&
+                mainConfig.Autologin.FirstLoginLockFile.get())) ||
+             mainConfig.Autologin.Relogin.get()) &&
             !mainConfig.Autologin.User.get().isEmpty()) {
             // determine session type
             QString autologinSession = mainConfig.Autologin.Session.get();
@@ -191,7 +194,7 @@ namespace SDDM {
         }
 
         // reset first flag
-        daemonApp->first = false;
+        daemonApp->consumeFirst();
     }
 
     Display::~Display() {

--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -173,10 +173,8 @@ namespace SDDM {
         connect(m_greeter, &Greeter::displayServerFailed, this, &Display::displayServerFailed);
 
         // Load autologin configuration (whether to autologin, user, session, session type)
-        if (((daemonApp->getFirst() &&
-              !(daemonApp->hasLock() &&
-                mainConfig.Autologin.FirstLoginLockFile.get())) ||
-             mainConfig.Autologin.Relogin.get()) &&
+        if ((mainConfig.Autologin.Relogin.get() ||
+             daemonApp->tryLockFirstLogin()) &&
             !mainConfig.Autologin.User.get().isEmpty()) {
             // determine session type
             QString autologinSession = mainConfig.Autologin.Session.get();
@@ -192,9 +190,6 @@ namespace SDDM {
                 qCritical() << "Unable to find autologin session entry" << autologinSession;
             }
         }
-
-        // reset first flag
-        daemonApp->consumeFirst();
     }
 
     Display::~Display() {


### PR DESCRIPTION
Hello,

## description
This MR add a option to keep the state of autologin through soft-reboot for `relogin=False`.

## How it  works
According to [freedesktop.org documentation on systemd-soft-reboot.service](https://www.freedesktop.org/software/systemd/man/latest/systemd-soft-reboot.service.html) : 

> The /run/ file system remains mounted and populated and may be used to pass state information between such userspace reboot cycles.

By adding lockfile in /run/sddm i can keep track of the state of autologin through soft-reboot and more (including crashes, and restart of the daemon).
The patch maintains backward compatibility, and has the new behaviour disabled by default.

## Why this patch was created
I found a unexpected way to bypass auth in my system from a "guest" user to my "main" user.

### My setup: 
- When i boot, i'm greeted by grub cryptdisk that ask for my LUKS password to access the /boot partition
- SDDM directly open my session without asking for password with the autologin

### Why i have this setup:
- When I boot I have only 1 password (LUKS in grub cryptdisk, qutologin get rid of the 2nd one)
- When I leave my computer, I have to enter my password to unlock the screen due to `relogin=False`

My intention was that i would always have EXACTLY one password to login to my user (LUKS xor SSDM).

### The problem: 
- I have a second (guest) user for when I lend my PC to a friend
- When connected to the guest user, he can use the terminal to do `systemctl soft-reboot` which reboot without reloading grub, the kernel or the initramfs, bypassing LUKS password
- after soft-reboot i am logged back into my "main" user WITHOUT any password, as the SDDM service is restarted in the process

This allow any user to login to the designated autologin session even when `relogin=False` should have prevented it.

## Other informations
This patch set have been tested in virtual machines before being tried on my laptop for 1 week, I found no issues with it in my testing.

No AIs have been used in the making of this MR (I don't know if it matters for this project).