### PR TITLE
Raise cmake_minimum_required version to 3.16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10..3.31)
 
 project(SDDM)
 


### PR DESCRIPTION
CMake 3.31 warns about compat. for <3.10 being removed in the future. Qt6 CMake modules already require 3.16 though, so it is a good base line.

CMake 3.16 was released in 2019.