### PR TITLE
Display: also reuse session created by sddm-autologin

### DIFF
--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -419,7 +419,9 @@ namespace SDDM {
             for(const SessionInfo &s : reply.value()) {
                 if (s.userName == user) {
                     OrgFreedesktopLogin1SessionInterface session(Logind::serviceName(), s.sessionPath.path(), QDBusConnection::systemBus());
-                    if (session.service() == QLatin1String("sddm") && session.state() == QLatin1String("online")) {
+                    if ((session.service() == QLatin1String("sddm")
+                        || session.service() == QLatin1String("sddm-autologin"))
+                            && session.state() == QLatin1String("online")) {
                         m_reuseSessionId = s.sessionId;
                         break;
                     }


### PR DESCRIPTION
### Description

If we have an online session created by 'sddm-autologin', try to reuse it as if it was created by 'sddm'

Without this change, for reuse purpose is checked only a session created by the 'sddm' service, without taking into account that the session can be created by 'sddm-autologin'.

### Procedure for reproducing the bug

1. Make sure that the 'ReuseSession' option is enabled in the SDDM configuration. 

2. Log in to the user 'user' using autologin.

3. Click on the "Switch user" (for example, in KDE Plasma) button (i.e. switch to sddm without ending the current user session).

4. Log in as the 'user'.

#### Current behaviour

- SDDM unsuccessfully tries endlessly to create a new session for the 'user' in the new tty.

#### Expected behaviour

- SDDM will successfully restore the original session of 'user', rather than trying to create a new one