### PR TITLE
GreeterApp: Use shared contexts like in plasmashell from KDE 6

### DIFF
--- a/src/greeter/GreeterApp.cpp
+++ b/src/greeter/GreeterApp.cpp
@@ -339,6 +339,17 @@ int main(int argc, char **argv)
         qDebug() << "High-DPI autoscaling not Enabled";
     }
 
+    // GreeterApp: Use shared contexts like in plasmashell from KDE 6
+    //
+    // This fixes loading Qt6 themes that using QtWebEngine, which otherwise
+    // will crash with message:
+    // "QtWebEngineQuick::initialize() must be called from the Qt gui thread."
+    //
+    // According to Qt's docs setting the Qt::AA_ShareOpenGLContexts
+    // attribute before constructing a QGuiApplication, has the same effect as
+    // QtWebEngineQuick::initialize() but avoids pulling this dependency.
+    QGuiApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
+
     if (QLibraryInfo::version() >= QVersionNumber(5, 13, 0)) {
         auto format(QSurfaceFormat::defaultFormat());
         format.setOption(QSurfaceFormat::ResetNotification);


### PR DESCRIPTION
Fix bug for themes with QtWebEngine usage.

On Qt5 themes it will fix warning in journal: `WebEngineContext used before QtWebEngine::initialize() or OpenGL context creation failed.`

On Qt6 themes it will fix crash with message: `QtWebEngineQuick::initialize() must be called from the Qt gui thread.`

https://bugs.kde.org/show_bug.cgi?id=495758

https://invent.kde.org/plasma/plasma-workspace/-/commit/a23432f218f9a4094f31e31ea1c109464cb5bf04