### PR TITLE
Auth: do not manually read the '/etc/locale.conf' if we have systemd

### DIFF
--- a/src/auth/Auth.cpp
+++ b/src/auth/Auth.cpp
@@ -114,6 +114,7 @@ namespace SDDM {
             , child(new QProcess(this))
             , id(lastId++) {
         SocketServer::instance()->helpers[id] = this;
+#ifndef HAVE_SYSTEMD
         QProcessEnvironment env = child->processEnvironment();
         bool langEmpty = true;
         QFile localeFile(QStringLiteral("/etc/locale.conf"));
@@ -122,6 +123,7 @@ namespace SDDM {
             while (!in.atEnd()) {
                 QStringList parts = in.readLine().split(QLatin1Char('='));
                 if (parts.size() >= 2) {
+                    // TODO: value (parts[1]) has to be unquoted before inserting in env
                     env.insert(parts[0], parts[1]);
                     if (parts[0] == QLatin1String("LANG"))
                         langEmpty = false;
@@ -132,6 +134,7 @@ namespace SDDM {
         if (langEmpty)
             env.insert(QStringLiteral("LANG"), QStringLiteral("C"));
         child->setProcessEnvironment(env);
+#endif
         connect(child, QOverload<int,QProcess::ExitStatus>::of(&QProcess::finished), this, &Auth::Private::childExited);
         connect(child, &QProcess::errorOccurred, this, &Auth::Private::childError);
         connect(request, &AuthRequest::finished, this, &Auth::Private::requestFinished);


### PR DESCRIPTION
Looks like, we do not need to manually read the `/etc/locale.conf` if we have systemd, because systemd parse this file itself.

According to man of locale.conf: 

> The /etc/locale.conf file configures system-wide locale settings. It is read at early boot by systemd(1).`

Also, add a mention that we should unquote values before inserting them in env for non-systemd case, otherwise if values are quoted (for example `LANG="en_US.UTF-8"`) in the file `/etc/locale.conf` (what happens on some distributions), locale params will not be valid in the child process and, for example, localization for PAM will not work.