### PR TITLE
Display: avoid to emit loginFailed twice

### DIFF
--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -513,7 +513,14 @@ namespace SDDM {
                 emit loginSucceeded(m_socket);
         } else if (m_socket) {
             qDebug() << "Authentication for user " << user << " failed";
-            emit loginFailed(m_socket);
+
+            // Avoid to emit loginFailed twice
+            // maybe we already sent it when handle auth error
+            if (!m_loginFailedOnErrorSent) {
+                emit loginFailed(m_socket);
+            } else {
+                m_loginFailedOnErrorSent = false;
+            }
         }
         m_socket = nullptr;
     }
@@ -534,8 +541,10 @@ namespace SDDM {
             return;
 
         m_socketServer->informationMessage(m_socket, message);
-        if (error == Auth::ERROR_AUTHENTICATION)
+        if (error == Auth::ERROR_AUTHENTICATION) {
+            m_loginFailedOnErrorSent = true;
             emit loginFailed(m_socket);
+        }
     }
 
     void Display::slotHelperFinished(Auth::HelperExitStatus status) {

--- a/src/daemon/Display.h
+++ b/src/daemon/Display.h
@@ -94,6 +94,7 @@ namespace SDDM {
         DisplayServerType m_displayServerType = X11DisplayServerType;
 
         bool m_started { false };
+        bool m_loginFailedOnErrorSent { false };
 
         int m_terminalId = -1;
         int m_sessionTerminalId = 0;


### PR DESCRIPTION
We send a `loginFailed` signal on auth error handling (`slotAuthError`), as well as at the end of failed authorization process (`slotAuthenticationFinished`). 

As a result, most often these two events follow each other and two `loginFailed` signals for one auth error are sent to Greeter.

This change adds a boolean to check whether we have already sent an `loginFailed` during auth error handling, so as not to send it again at the end of the process. At the same time, if we haven't sent it yet and we immediately got to `slotAuthenticationFinished`, then we'll send it there.