### PR TITLE
Fix typos

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -51,8 +51,8 @@
     * Don't disable authentication in --test-mode
     - Fix X not having access control on startup
       (fixes CVE-2020-28049)
-    - Don't fill UserModel if theme does not require it
-    * Set re-use session option by default
+    - Set RUNTIME_DIR to /run/sddm when using systemd to follow FHS 3.0
+    * Set reuse session option by default
     * Avoid adjusting active auth sessions
     * Cleanup sessions on exit
     * Don't abort on failure to start the display server
@@ -121,10 +121,10 @@
     - Do not truncate XAUTHORITY on login.
     - Make enabled property of Button functional.
     - Fix typos in documentation.
-    * Re-use existing sessions.
+    * Reuse existing sessions.
     * Add ConsoleKit 2 support.
     * Stop assuming shadow(5) is always available.
-    * Explicitely set XDG_SEAT when starting a user session.
+    * Explicitly set XDG_SEAT when starting a user session.
     * Suppress errors when pam_elogind is not available.
     * Suppress errors when pam_systemd is not available.
     * Added possibility to change color of dropdown menu.
@@ -181,7 +181,7 @@
     + Add ENABLE_PAM option to toggle PAM support at build time.
     + Allow overriding textColor in ComboBox.
     - Don't cast QByteArray to (char *).
-    - Disable greeters from loading KDE's debug hander
+    - Disable greeters from loading KDE's debug handler
       (fix CVE-2015-0856).
     - Fix multi-screen support for some setups.
     * Added Serbian translation.
@@ -266,7 +266,7 @@
     - Fixed incorrect PAM handling causing PulseAudio to fail.
     - Fixed a crash caused by incorrect handling of PAM
     - Fixed compilation with Qt 5.0.0
-    - Correctly import PAM environment into the sesion
+    - Correctly import PAM environment into the session
     - Fixed missing environment variables
     - Find empty displays and virtual desktops automatically
     - Exit gracefully when SIGTERM is received
@@ -279,4 +279,3 @@
 ## 0.1.0 - 2013-03-19
 ---------------------
     * Initial release
-

--- a/LICENSE.CC-BY-3.0
+++ b/LICENSE.CC-BY-3.0
@@ -31,7 +31,7 @@ IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND CONDITIONS.
     work that constitutes a Collection will not be considered an Adaptation for
     the purpose of this License. For the avoidance of doubt, where the Work is
     a musical work, performance or phonogram, the synchronization of the Work
-    in timed-relation with a moving image ("synching") will be considered an
+    in timed-relation with a moving image ("syncing") will be considered an
     Adaptation for the purpose of this License.
  b. "Collection" means a collection of literary or artistic works, such as
     encyclopedias and anthologies, or performances, phonograms or broadcasts,
@@ -210,7 +210,7 @@ subject to and limited by the following restrictions:
 UNLESS OTHERWISE MUTUALLY AGREED TO BY THE PARTIES IN WRITING, LICENSOR OFFERS
 THE WORK AS-IS AND MAKES NO REPRESENTATIONS OR WARRANTIES OF ANY KIND
 CONCERNING THE WORK, EXPRESS, IMPLIED, STATUTORY OR OTHERWISE, INCLUDING,
-WITHOUT LIMITATION, WARRANTIES OF TITLE, MERCHANTIBILITY, FITNESS FOR A
+    WITHOUT LIMITATION, WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A
 PARTICULAR PURPOSE, NONINFRINGEMENT, OR THE ABSENCE OF LATENT OR OTHER DEFECTS,
 ACCURACY, OR THE PRESENCE OF ABSENCE OF ERRORS, WHETHER OR NOT DISCOVERABLE.
 SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION OF IMPLIED WARRANTIES, SO SUCH

--- a/data/themes/maldives/LICENSE
+++ b/data/themes/maldives/LICENSE
@@ -31,7 +31,7 @@ IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND CONDITIONS.
     work that constitutes a Collection will not be considered an Adaptation for
     the purpose of this License. For the avoidance of doubt, where the Work is
     a musical work, performance or phonogram, the synchronization of the Work
-    in timed-relation with a moving image ("synching") will be considered an
+    in timed-relation with a moving image ("syncing") will be considered an
     Adaptation for the purpose of this License.
  b. "Collection" means a collection of literary or artistic works, such as
     encyclopedias and anthologies, or performances, phonograms or broadcasts,
@@ -248,9 +248,9 @@ subject to and limited by the following restrictions:
 UNLESS OTHERWISE MUTUALLY AGREED TO BY THE PARTIES IN WRITING, LICENSOR OFFERS
 THE WORK AS-IS AND MAKES NO REPRESENTATIONS OR WARRANTIES OF ANY KIND
 CONCERNING THE WORK, EXPRESS, IMPLIED, STATUTORY OR OTHERWISE, INCLUDING,
-WITHOUT LIMITATION, WARRANTIES OF TITLE, MERCHANTIBILITY, FITNESS FOR A
+    WITHOUT LIMITATION, WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A
 PARTICULAR PURPOSE, NONINFRINGEMENT, OR THE ABSENCE OF LATENT OR OTHER DEFECTS,
-ACCURACY, OR THE PRESENCE OF ABSENCE OF ERRORS, WHETHER OR NOT DISCOVERABLE.
+ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT DISCOVERABLE.
 SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION OF IMPLIED WARRANTIES, SO SUCH
 EXCLUSION MAY NOT APPLY TO YOU.
 

--- a/src/daemon/SocketServer.cpp
+++ b/src/daemon/SocketServer.cpp
@@ -109,7 +109,7 @@ namespace SDDM {
         // input stream
         QDataStream input(socket);
 
-        // Qt's QLocalSocket::readyRead is not designed to be called at every socket.write(), 
+        // Qt's QLocalSocket::readyRead is not designed to be called at every socket.write(),
         // so we need to use a loop to read all the signals.
         while(socket->bytesAvailable()) {
             // read message
@@ -135,7 +135,7 @@ namespace SDDM {
                     // log message
                     qDebug() << "Message received from greeter: Login";
 
-                    // read username, pasword etc.
+                    // read username, password etc.
                     QString user, password, filename;
                     Session session;
                     input >> user >> password >> session;

--- a/src/greeter/SessionModel.cpp
+++ b/src/greeter/SessionModel.cpp
@@ -51,7 +51,7 @@ namespace SDDM {
         populate(Session::X11Session, mainConfig.X11.SessionDir.get());
         endResetModel();
 
-        // refresh everytime a file is changed, added or removed
+        // refresh every time a file is changed, added or removed
         QFileSystemWatcher *watcher = new QFileSystemWatcher(this);
         connect(watcher, &QFileSystemWatcher::directoryChanged, [this]() {
             // Recheck for flag to show Wayland sessions

--- a/src/greeter/XcbKeyboardBackend.cpp
+++ b/src/greeter/XcbKeyboardBackend.cpp
@@ -325,7 +325,7 @@ namespace SDDM {
         // Flush connection
         xcb_flush(m_conn);
 
-        // Get file descripor and init socket listener
+        // Get file descriptor and init socket listener
         int fd = xcb_get_file_descriptor(m_conn);
         m_socket = new QSocketNotifier(fd, QSocketNotifier::Read);
 

--- a/src/greeter/theme/LICENSE
+++ b/src/greeter/theme/LICENSE
@@ -31,7 +31,7 @@ IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND CONDITIONS.
     work that constitutes a Collection will not be considered an Adaptation for
     the purpose of this License. For the avoidance of doubt, where the Work is
     a musical work, performance or phonogram, the synchronization of the Work
-    in timed-relation with a moving image ("synching") will be considered an
+    in timed-relation with a moving image ("syncing") will be considered an
     Adaptation for the purpose of this License.
  b. "Collection" means a collection of literary or artistic works, such as
     encyclopedias and anthologies, or performances, phonograms or broadcasts,
@@ -248,9 +248,9 @@ subject to and limited by the following restrictions:
 UNLESS OTHERWISE MUTUALLY AGREED TO BY THE PARTIES IN WRITING, LICENSOR OFFERS
 THE WORK AS-IS AND MAKES NO REPRESENTATIONS OR WARRANTIES OF ANY KIND
 CONCERNING THE WORK, EXPRESS, IMPLIED, STATUTORY OR OTHERWISE, INCLUDING,
-WITHOUT LIMITATION, WARRANTIES OF TITLE, MERCHANTIBILITY, FITNESS FOR A
+    WITHOUT LIMITATION, WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A
 PARTICULAR PURPOSE, NONINFRINGEMENT, OR THE ABSENCE OF LATENT OR OTHER DEFECTS,
-ACCURACY, OR THE PRESENCE OF ABSENCE OF ERRORS, WHETHER OR NOT DISCOVERABLE.
+ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT DISCOVERABLE.
 SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION OF IMPLIED WARRANTIES, SO SUCH
 EXCLUSION MAY NOT APPLY TO YOU.
 

--- a/src/helper/backend/PamBackend.cpp
+++ b/src/helper/backend/PamBackend.cpp
@@ -112,7 +112,7 @@ namespace SDDM {
     bool PamData::insertPrompt(const struct pam_message* msg, bool predict) {
         Prompt &p = findPrompt(msg);
 
-        // first, check if we already have stored this propmpt
+        // first, check if we already have stored this prompt
         if (p.valid()) {
             // we have a response already - do nothing
             if (m_sent)

--- a/src/helper/backend/PamHandle.h
+++ b/src/helper/backend/PamHandle.h
@@ -60,7 +60,7 @@ namespace SDDM {
         bool isOpen() const;
 
         /**
-        * pam_set_item - set and update PAM informations
+        * pam_set_item - set and update PAM information
         *
         * \param item_type PAM item type
         * \param item item pointer
@@ -70,7 +70,7 @@ namespace SDDM {
         bool setItem(int item_type, const void *item);
 
         /**
-        * pam_get_item - getting PAM informations
+        * pam_get_item - getting PAM information
         *
         * \param item_type
         *

--- a/src/helper/waylandhelper.cpp
+++ b/src/helper/waylandhelper.cpp
@@ -98,7 +98,7 @@ bool WaylandHelper::startProcess(const QString &cmd, QProcess **p)
     if (p)
         *p = process;
 
-    qDebug() << "started succesfully" << cmd;
+    qDebug() << "started successfully" << cmd;
     return true;
 }
 

--- a/test/ConfigurationTest.cpp
+++ b/test/ConfigurationTest.cpp
@@ -166,22 +166,22 @@ void ConfigurationTest::RightOnInitDir() {
 
     QFile confFileA(SYS_CONF_DIR+QStringLiteral("/0001A"));
     confFileA.open(QIODevice::WriteOnly | QIODevice::Truncate);
-    confFileA.write("Custom=Foo\n"); //overriden by B
+    confFileA.write("Custom=Foo\n"); //overridden by B
     confFileA.write("Boolean=false\n");
     confFileA.close();
 
     QFile confFileB(CONF_DIR+QStringLiteral("/0001A"));
     confFileB.open(QIODevice::WriteOnly | QIODevice::Truncate);
-    confFileB.write("String=a\n"); //overriden by C
+    confFileB.write("String=a\n"); //overridden by C
     confFileB.write("Custom=Bar\n");
     confFileB.write("StringList=a,b,c\n");
-    confFileB.write("Int=1111111\n"); //this is set in this config file but overriden in CONF_FILE
+    confFileB.write("Int=1111111\n"); //this is set in this config file but overridden in CONF_FILE
     confFileB.close();
 
     QFile confFileC(CONF_DIR+QStringLiteral("/0001B"));
     confFileC.open(QIODevice::WriteOnly | QIODevice::Truncate);
     confFileC.write("String=b\n");
-    confFileC.write("Int=1111111\n"); //overriden in CONF_FILE
+    confFileC.write("Int=1111111\n"); //overridden in CONF_FILE
     confFileC.close();
 
     QFile confFileMain(CONF_FILE);
@@ -229,7 +229,7 @@ void ConfigurationTest::FileChanged()
     //add file to conf dir
     QFile confFileA(CONF_DIR+QStringLiteral("/0001A"));
     confFileA.open(QIODevice::WriteOnly | QIODevice::Truncate);
-    confFileA.write("Int=1111111\n"); //this is set in this config file but overriden in CONF_FILE
+    confFileA.write("Int=1111111\n"); //this is set in this config file but overridden in CONF_FILE
     confFileA.close();
     config->load();
     QVERIFY(config->Int.get() ==1111111);
@@ -238,7 +238,7 @@ void ConfigurationTest::FileChanged()
     //modify existing file in conf dir
 
     confFileA.open(QIODevice::WriteOnly | QIODevice::Truncate);
-    confFileA.write("Int=222222\n"); //this is set in this config file but overriden in CONF_FILE
+    confFileA.write("Int=222222\n"); //this is set in this config file but overridden in CONF_FILE
     confFileA.close();
     config->load();
     QVERIFY(config->Int.get() == 222222);


### PR DESCRIPTION
- normalize “reuse”, “Explicitly”, “handler”, and “session” wording in the changelog @ChangeLog#49-269
- correct spelling in bundled CC‑BY license documents @LICENSE.CC-BY-3.0#33-214 @data/themes/maldives/LICENSE#33-252 @src/greeter/theme/LICENSE#33-252
- tidy misspellings in comments and logs across tests, greeter, helper, and PAM backend code @test/ConfigurationTest.cpp#169-242 @src/greeter/SessionModel.cpp#54-63 @src/greeter/XcbKeyboardBackend.cpp#328-332 @src/daemon/SocketServer.cpp#138-144 @src/helper/waylandhelper.cpp#101-102 @src/helper/backend/PamBackend.cpp#112-124 @src/helper/backend/PamHandle.h#63-74

Author: rezky_nightky <with.rezky@gmail.com>
Timestamp: 2025-12-01T19:19:34Z
Repository: sddm
Branch: develop
Signing: GPG (989AF9F0)
Performance: 11 files, +28/-29 lines