### PR TITLE
sddm.service: conflicts with kmsconvt@ttyX

### DIFF
--- a/services/sddm.service.in
+++ b/services/sddm.service.in
@@ -1,8 +1,8 @@
 [Unit]
 Description=Simple Desktop Display Manager
 Documentation=man:sddm(1) man:sddm.conf(5)
-Conflicts=getty@tty${SDDM_INITIAL_VT}.service
-After=systemd-user-sessions.service getty@tty${SDDM_INITIAL_VT}.service plymouth-quit.service systemd-logind.service
+Conflicts=getty@tty${SDDM_INITIAL_VT}.service kmsconvt@tty${SDDM_INITIAL_VT}.service
+After=systemd-user-sessions.service getty@tty${SDDM_INITIAL_VT}.service kmsconvt@tty${SDDM_INITIAL_VT}.service plymouth-quit.service systemd-logind.service
 PartOf=graphical.target
 StartLimitIntervalSec=30
 StartLimitBurst=2


### PR DESCRIPTION
To prevent kmscon to start on the same tty as sddm, add kmsconvt to the conflicts list, like getty.