### PR TITLE
CI: Install the right package for "dnf builddep" command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
         if: ${{ contains(matrix.container-image, 'fedora') || contains(matrix.container-image, 'centos') || contains(matrix.container-image, 'opensuse') }}
         run: |
           set -x
-          dnf --assumeyes install dnf-plugins-core
+          if [[ "${{ matrix.container-image }}" =~ "centos" ]]; then dnf --assumeyes install dnf-plugins-core; else dnf --assumeyes install dnf5-plugins; fi
           if [[ "${{ matrix.container-image }}" =~ "centos" ]]; then dnf --assumeyes config-manager --set-enabled crb && dnf --assumeyes install epel-release; fi
           dnf --assumeyes builddep sddm
           if [ "${{ matrix.qt }}" = "qt5" ] && [[ "${{ matrix.container-image }}" =~ "fedora" ]]; then dnf --assumeyes install qt5-qtbase-devel qt5-qtdeclarative-devel qt5-qttools-devel; fi


### PR DESCRIPTION
With Fedora and openSUSE transitioning to DNF5, the builddep command is now provided by "dnf5-plugins" instead of "dnf-plugins-core".