### PR TITLE
VirtualTerminal: take over stale VT_PROCESS handler

### DIFF
--- a/src/common/VirtualTerminal.cpp
+++ b/src/common/VirtualTerminal.cpp
@@ -106,6 +106,16 @@ namespace SDDM {
             return ok;
         }
 
+        void ignoreVtSwitches() {
+            // For callers that execve() while still the VT_PROCESS owner:
+            // handled dispositions reset to SIG_DFL across exec, so a switch
+            // request in the window before the new compositor takes VT control
+            // would kill the process. SIG_IGN survives exec; the kernel defers
+            // the switch until the compositor re-establishes VT handling.
+            signal(RELEASE_DISPLAY_SIGNAL, SIG_IGN);
+            signal(ACQUIRE_DISPLAY_SIGNAL, SIG_IGN);
+        }
+
         static void fixVtMode(int fd, bool vt_auto) {
             vt_mode getmodeReply { };
             int kernelDisplayMode = 0;

--- a/src/common/VirtualTerminal.cpp
+++ b/src/common/VirtualTerminal.cpp
@@ -117,6 +117,14 @@ namespace SDDM {
                 ok = false;
             }
 
+            // The previous VT_PROCESS owner (logind for Wayland greeters)
+            // can clear its VT mode mid-switch, leaving VT_WAITACTIVE hung.
+            // Take over so the relsig handshake completes locally.
+            if (getmodeReply.mode == VT_PROCESS) {
+                ok = handleVtSwitches(fd);
+                modeFixed = true;
+            }
+
             if (getmodeReply.mode != VT_AUTO)
                 goto out;
 

--- a/src/common/VirtualTerminal.h
+++ b/src/common/VirtualTerminal.h
@@ -30,6 +30,7 @@ namespace SDDM {
         int currentVt();
         int setUpNewVt();
         void jumpToVt(int vt, bool vt_auto);
+        void ignoreVtSwitches();
     }
 }
 

--- a/src/helper/UserSession.cpp
+++ b/src/helper/UserSession.cpp
@@ -228,8 +228,12 @@ namespace SDDM {
                 }
             }
 
-            if (vtNumber > 0)
+            if (vtNumber > 0) {
                 VirtualTerminal::jumpToVt(vtNumber, x11UserSession);
+                // This process becomes the session via execve(); leave the VT
+                // switch signals ignored so they survive the exec.
+                VirtualTerminal::ignoreVtSwitches();
+            }
         }
 
 #ifdef Q_OS_LINUX


### PR DESCRIPTION
## What?
This fix mitigates a race condition between sddm-helper and kwin-wayland in which Kwin's signal to clean up tty1 can race ahead of sddm-helper's signal to release tty1.

## Why?
When kwin-wayland's signal races ahead and lands first, it leads to the following unhealthy behavior:
VT_WAITACTIVE holds back Plasma-Wayland from building the desktop for ~30 seconds until QT's QProcess::waitForStarted clears it.
A few minutes after the Plasma Desktop starts, the cleanup signal kicks the user back to the SDDM login screen.
If the user attempts to log in again, the system hangs fully.
If the user attempts to get back to the Plasma Desktop by switching the tty, they can do so - but the desktop session is left in an unhealthy "closing state" - authentication is repeatedly required for any Discovery store actions, applications hang during shutdown, and some apps misbehave (low framerates, etc).

## How?
The race is overcome by making sddm-helper the handshake process for the handoff between SDDM and Plasma Desktop.  By doing so, sddm-helper's signal is much more likely to land before kwin-wayland's signal, with no known or observed downside.

## Testing?
- Local build (Fedora 43, sddm-0.21.0-10.fc43 SRPM + this patch)
- 6 of 6 successful cold-boot logins post-patch (vs ~68% failure pre-patch)
- 6 cycles each: logout → relogin, lock/unlock, suspend (S3) → resume, VT round-trip
- No regression in a fullscreen 3D game session
- `clang-tidy` and `clazy-standalone -checks=level1` clean on the patch lines
- CI cross-distro runs pending

## Anything Else? 
I used Claude Code (Opus 4.7 1m) to help craft the patch - multiple iterations of strace, ptrace, btftrace and more + booting through the "Bad" boot path repeatedly, coupled with review of the SDDM, Logind and other modules' source code.  This allowed me to refine the race hypothesis and ultimately narrow down the culprit, and come up with a minimum-scope fix that had a fully mapped and relatively "safe" blast radius.

The race itself is a systemd-logind bug; I'm filing a separate issue there. Detailed mechanism analysis with bpftrace evidence, the ustack proving the handler attribution, and the full investigation methodology are at https://gist.github.com/dustinspace217/c7e46a43cd3274921a8266134d17a049

**Closes #1443**
