### PR TITLE
fix(greeter): show dark fallback background when image fails to load

### DIFF
--- a/components/2.0/Background.qml
+++ b/components/2.0/Background.qml
@@ -31,6 +31,12 @@ FocusScope {
     property alias fillMode: image.fillMode
     property alias status: image.status
 
+    Rectangle {
+        id: fallback
+        anchors.fill: parent
+        color: "#2b2b2b"
+        visible: image.status === Image.Error
+    }
 
     Image {
         id: image


### PR DESCRIPTION
## Summary
- Add a dark gray (`#2b2b2b`) fallback `Rectangle` behind the `Image` in the `Background` component
- The fallback is only visible when the image fails to load (`status === Image.Error`)
- Fixes white-on-white rendering when both the configured background and the default fallback image are invalid

## Changes
| File | Change |
|------|--------|
| `components/2.0/Background.qml` | Add fallback Rectangle with dark background |

## Test Plan
- [ ] Install a theme with an invalid `background` path in sddm.conf
- [ ] Verify the login screen shows a readable dark gray background instead of white-on-white
- [ ] Verify normal themes (with valid backgrounds) are unaffected

Fixes #2162
