### PR TITLE
daemon: restrict managed seats via SDDM_SEATS

### DIFF
--- a/src/daemon/SeatManager.cpp
+++ b/src/daemon/SeatManager.cpp
@@ -181,6 +181,23 @@ namespace SDDM {
 
     void SDDM::SeatManager::logindSeatAdded(const QString& name, const QDBusObjectPath& objectPath)
     {
+        // Optionally restrict which logind seats SDDM manages. Configure via the
+        // SDDM_SEATS environment variable (comma-separated, e.g. "seat0") in the
+        // service unit; if unset or empty, all seats are managed.
+        static const QString sddmSeats = QString::fromLocal8Bit(qgetenv("SDDM_SEATS")).trimmed();
+        if (!sddmSeats.isEmpty()) {
+            const QStringList allowedSeats = sddmSeats.split(QLatin1Char(','), Qt::SkipEmptyParts);
+            bool managed = false;
+            for (const QString& allowed : allowedSeats) {
+                if (name == allowed.trimmed()) {
+                    managed = true;
+                    break;
+                }
+            }
+            if (!managed)
+                return;
+        }
+
         auto logindSeat = new LogindSeat(name, objectPath);
         connect(logindSeat, &LogindSeat::canGraphicalChanged, this, [=]() {
             if (logindSeat->canGraphical()) {


### PR DESCRIPTION
Add an optional SDDM_SEATS environment variable that limits which logind seats SeatManager creates greeter/autologin sessions on. The value is a comma-separated list of seat names; surrounding whitespace is trimmed and empty entries are skipped. When unset or empty the behaviour is unchanged and SDDM manages every seat as before, so the change is fully backwards compatible.

On multi-seat systems SDDM starts a session on every seat that reports CanGraphical=true, and there is currently no way to exclude one. CanGraphical cannot serve that purpose: logind derives it from the master-of-seat udev tag rather than from the presence of a real DRM device, so a secondary seat that owns a DRM node for a dedicated client (e.g. a kiosk compositor pinned to a fixed panel) still reports CanGraphical and gets an unwanted greeter, racing the intended client for DRM master. The same tag is what keeps the seat alive, so it cannot simply be dropped to demote the seat. See https://github.com/systemd/systemd/issues/42509

The check is applied at the top of logindSeatAdded(), before the per-seat LogindSeat watcher is constructed, so an excluded seat is never queried for CanGraphical and can never reach createSeat() no matter how its DRM state changes afterwards.

Configured via the service unit, e.g.:

[Service]
Environment=SDDM_SEATS=seat0

Signed-off-by: Yury Smirnov yurymonzon@gmail.com