### PR TITLE
auth/helper: micro-op use constructors as default

### DIFF
--- a/src/auth/AuthMessages.h
+++ b/src/auth/AuthMessages.h
@@ -29,7 +29,7 @@
 namespace SDDM {
     class Prompt {
     public:
-        Prompt() { }
+        Prompt() = default;
         Prompt(AuthPrompt::Type type, QString message, bool hidden)
                 : type(type), message(message), hidden(hidden) { }
         Prompt(const Prompt &o)
@@ -67,7 +67,7 @@ namespace SDDM {
 
     class Request {
     public:
-        Request() { }
+        Request() = default;
         Request(QList<Prompt> prompts)
                 : prompts(prompts) { }
         Request(const Request &o)

--- a/src/helper/backend/PamBackend.cpp
+++ b/src/helper/backend/PamBackend.cpp
@@ -55,7 +55,7 @@ namespace SDDM {
 
     static Prompt invalidPrompt {};
 
-    PamData::PamData() { }
+    PamData::PamData() = default;
 
     AuthPrompt::Type PamData::detectPrompt(const struct pam_message* msg) const {
         if (msg->msg_style == PAM_PROMPT_ECHO_OFF) {


### PR DESCRIPTION
References:
- https://stackoverflow.com/questions/59261490/why-is-there-performance-variation-using-default-constructor-instead-of
- https://stackoverflow.com/questions/56272431/how-can-a-compiler-generated-default-constructor-be-more-efficient-than-a-self-w