### PR TITLE
auth/greeter: align classes for 64-bit platforms

### DIFF
--- a/src/auth/AuthMessages.h
+++ b/src/auth/AuthMessages.h
@@ -60,9 +60,9 @@ namespace SDDM {
         }
 
         AuthPrompt::Type type { AuthPrompt::NONE };
+        bool hidden { false };
         QByteArray response { };
         QString message { };
-        bool hidden { false };
     };
 
     class Request {

--- a/src/greeter/UserModel.cpp
+++ b/src/greeter/UserModel.cpp
@@ -59,8 +59,8 @@ namespace SDDM {
     class UserModelPrivate {
     public:
         int lastIndex { 0 };
-        QList<UserPtr> users;
         bool containsAllUsers { true };
+        QList<UserPtr> users;
     };
 
     UserModel::UserModel(bool needAllUsers, QObject *parent) : QAbstractListModel(parent), d(new UserModelPrivate()) {


### PR DESCRIPTION
@Vogtinator 

Affected classes (cache size before and after):
- Prompt 32 -> 24 bytes
- UserModelPrivate 24 -> 16 bytes

References:

- https://hpc.rz.rptu.de/Tutorials/AVX/alignment.shtml

- https://wr.informatik.uni-hamburg.de/_media/teaching/wintersemester_2013_2014/epc-14-haase-svenhendrik-alignmentinc-presentation.pdf

- https://en.wikipedia.org/wiki/Data_structure_alignment

- https://stackoverflow.com/a/20882083

- https://zijishi.xyz/post/optimization-technique/learning-to-use-data-alignment/