### PR TITLE
AuthMessages: dont use const ref for enum (int 4 byte)

### DIFF
--- a/src/auth/AuthMessages.h
+++ b/src/auth/AuthMessages.h
@@ -101,7 +101,7 @@ namespace SDDM {
         MSG_LAST,
     };
 
-    inline QDataStream& operator<<(QDataStream &s, const Msg &m) {
+    inline QDataStream& operator<<(QDataStream &s, const Msg m) {
         s << qint32(m);
         return s;
     }
@@ -118,7 +118,7 @@ namespace SDDM {
         return s;
     }
 
-    inline QDataStream& operator<<(QDataStream &s, const Auth::Error &m) {
+    inline QDataStream& operator<<(QDataStream &s, const Auth::Error m) {
         s << qint32(m);
         return s;
     }
@@ -135,7 +135,7 @@ namespace SDDM {
         return s;
     }
 
-    inline QDataStream& operator<<(QDataStream &s, const Auth::Info &m) {
+    inline QDataStream& operator<<(QDataStream &s, const Auth::Info m) {
         s << qint32(m);
         return s;
     }


### PR DESCRIPTION
This regression performance, const reference use only for type size more 16 bytes

Reference:
- https://stackoverflow.com/questions/44749658/c-is-it-better-to-pass-an-enum-class-as-value-or-const-reference
- https://stackoverflow.com/questions/6834581/c-is-it-better-to-pass-an-enum-as-a-value-or-as-a-const-reference