### PR TITLE
auth/daemon: micro-op qbytearray move and clear instead new object

### DIFF
--- a/src/auth/AuthMessages.h
+++ b/src/auth/AuthMessages.h
@@ -181,7 +181,7 @@ namespace SDDM {
         m.type = AuthPrompt::Type(type);
         m.message = message;
         m.hidden = hidden;
-        m.response = response;
+        m.response = std::move(response);
         return s;
     }
 

--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -408,7 +408,7 @@ namespace SDDM {
             return false;
         }
 
-        m_reuseSessionId = QString();
+        m_reuseSessionId.clear();
 
         if (Logind::isAvailable() && mainConfig.Users.ReuseSession.get()) {
             OrgFreedesktopLogin1ManagerInterface manager(Logind::serviceName(), Logind::managerPath(), QDBusConnection::systemBus());


### PR DESCRIPTION
change in Display.cpp

- clear() eliminates the need to create a temporary QString object and unnecessary copy/move operations
- When using clear(), QString often saves an already allocated memory buffer (capacity) in order to reuse it if new data needs to be written to this variable in the future. Creating a new object (= QString()) this buffer may be completely released
- Using .clear() is a more idiomatic (standard) way to reset the value of a variable in C++/Qt when you need to "clear" it, rather than replace it with a new instance

change AuthMessages

- Instead of creating a complete copy of the data, the program simply "transfers ownership" of the already allocated memory block from the source to the recipient
- The std::move operation for objects like QString or std::string is an almost instantaneous operation of changing multiple pointers, while copying requires allocating new memory and cyclically rewriting data
- The original response variable (after calling std::move) remains in an "undefined but valid" state. In this context, since this happens inside the method that finishes the job, it is absolutely safe