### PR TITLE
SocketWriter: migrate output to stack allocation

### DIFF
--- a/src/common/SocketWriter.cpp
+++ b/src/common/SocketWriter.cpp
@@ -21,31 +21,28 @@
 #include "SocketWriter.h"
 
 namespace SDDM {
-    SocketWriter::SocketWriter(QLocalSocket *socket) : socket(socket) {
-        output = new QDataStream(&data, QIODevice::WriteOnly);
+    SocketWriter::SocketWriter(QLocalSocket *socket) : output(&data, QIODevice::WriteOnly), socket(socket) {
     }
 
     SocketWriter::~SocketWriter() {
         socket->write(data);
         socket->flush();
-
-        delete output;
     }
 
     SocketWriter &SocketWriter::operator << (const quint32 &u) {
-        *output << u;
+        output << u;
 
         return *this;
     }
 
     SocketWriter &SocketWriter::operator << (const QString &s) {
-        *output << s;
+        output << s;
 
         return *this;
     }
 
     SocketWriter &SocketWriter::operator << (const Session &s) {
-        *output << s;
+        output << s;
 
         return *this;
     }

--- a/src/common/SocketWriter.h
+++ b/src/common/SocketWriter.h
@@ -39,7 +39,7 @@ namespace SDDM {
 
     private:
         QByteArray data;
-        QDataStream *output;
+        QDataStream output;
         QLocalSocket *socket;
     };
 }


### PR DESCRIPTION
This commit eliminates allocation on the heap each time an object is created

Reference:
- https://stackoverflow.com/questions/24057331/is-accessing-data-in-the-heap-faster-than-from-the-stack