### PR TITLE
SafeDataStream: optimize receive loop use reserve() after reset stream

### DIFF
--- a/src/common/SafeDataStream.cpp
+++ b/src/common/SafeDataStream.cpp
@@ -63,6 +63,7 @@ namespace SDDM {
         if (length < 0)
             return;
         reset();
+        m_data.reserve(length);
 
         while (m_data.length() < length) {
             if (!m_device->isOpen()) {


### PR DESCRIPTION
Reference:
- https://softwareengineering.stackexchange.com/questions/461079/when-to-use-stdvector-reserve