### PR TITLE
SessionModel: add forgotten qDeleteAll for clear sessions

### DIFF
--- a/src/greeter/SessionModel.cpp
+++ b/src/greeter/SessionModel.cpp
@@ -57,6 +57,7 @@ namespace SDDM {
             // Recheck for flag to show Wayland sessions
             bool dri_active = QFileInfo::exists(QStringLiteral("/dev/dri"));
             beginResetModel();
+            qDeleteAll(d->sessions);
             d->sessions.clear();
             d->displayNames.clear();
             if (dri_active)


### PR DESCRIPTION
@Vogtinator is there a memory leak here every time file is updated?

Reference:
- https://doc.qt.io/archives/qt-6.0/qtalgorithms.html#qDeleteAll
- https://stackoverflow.com/questions/39351966/why-qdeleteall-do-not-call-clear-on-the-container