### PR TITLE
fix(helper): auto-release active VT on Wayland user session start

### DIFF
--- a/src/helper/UserSession.cpp
+++ b/src/helper/UserSession.cpp
@@ -229,7 +229,7 @@ namespace SDDM {
             }
 
             if (vtNumber > 0)
-                VirtualTerminal::jumpToVt(vtNumber, x11UserSession);
+                VirtualTerminal::jumpToVt(vtNumber, x11UserSession || waylandUserSession);
         }
 
 #ifdef Q_OS_LINUX


### PR DESCRIPTION
### Summary
Fixes an issue where starting a Wayland user session hangs for 30 seconds due to a VT switch timeout, causing `sddm-helper`'s `waitForStarted()` timer to fail (`Session started false`) and eventually resulting in SDDM spawning a second greeter on VT1.

Fixes #2129

### Problem Breakdown
1. During the greeter phase, the Wayland compositor (`kwin_wayland` of the greeter) runs on `VT1` and sets the VT mode to `VT_PROCESS`.
2. When logging in, `sddm-helper` starts the user session and forks a child process to switch to `VT2` via `VirtualTerminal::jumpToVt(vtNumber, x11UserSession)`.
3. Because the user session type is `wayland`, `x11UserSession` is `false`. Thus `vt_auto` in `jumpToVt` is evaluated as `false`.
4. Inside `fixVtMode(activeVtFd, vt_auto)`, since `vt_auto` is `false` and the active VT (VT1) is already in `VT_PROCESS` mode, it skips resetting VT1 back to `VT_AUTO`.
5. When `sddm-helper`'s child process calls `ioctl(activeVtFd, VT_ACTIVATE, 2)` to switch to VT2, the kernel attempts to send a release signal to the greeter's compositor. However, since the greeter compositor is terminating or defunct, it never acknowledges the release.
6. The kernel VT subsystem blocks the child process in `ioctl(activeVtFd, VT_WAITACTIVE, 2)` for **exactly 30 seconds** (the kernel's default `VT_TIMEOUT` in `drivers/tty/vt/vt.c`).
7. As a result:
   - `sddm-helper`'s `waitForStarted()` timer times out at 30 seconds, logging `Session started false`.
   - Concurrently, the kernel VT switch timeout expires, forcing the switch to VT2 and allowing the user's desktop to start.
   - However, since `sddm-helper` marked startup as failed, it exits after its 60-second `waitForFinished` timeout (90 seconds after boot), triggering the SDDM daemon to restart the greeter on VT1 and leaving the user with a duplicate login screen.

### Fix
Evaluate `x11UserSession || waylandUserSession` for the `vt_auto` argument in `jumpToVt`, resetting the active VT mode to `VT_AUTO` for Wayland user sessions just as SDDM already does for X11 user sessions.
