### PR TITLE
fix(daemon): close server socket before calling deleteLater

### DIFF
--- a/src/daemon/SocketServer.cpp
+++ b/src/daemon/SocketServer.cpp
@@ -82,6 +82,9 @@ namespace SDDM {
         // log message
         qDebug() << "Socket server stopping...";
 
+        // stop listening first
+        m_server->close();
+
         // delete server
         m_server->deleteLater();
         m_server = nullptr;


### PR DESCRIPTION
Fixes: #2207

There is a problem happening on certain machines where logging out from your session will systematically result in a broken SDDM (there will only be a black screen and a mouse cursor), and the log would shout that:
```
(EE) GREETER: Socket error:  "QLocalSocket::connectToServer: Invalid name"
(EE) GREETER: Cannot connect to the daemon - is it running?
```

After some investigation, it appears that the socket would be totally inexistent at the time the greeter tries to connect, even though the daemon said that:

```
(II) DAEMON: Socket server starting...
(II) DAEMON: Socket server started.
```

There weren't any apparent problems in the code opening the socket. So the problem was where the socket was closed. The fact that the deletion of the server socket was delayed could cause it to happen after the creation of the newer server socket.

After making sure that the server socket was properly closed before opening a new one, the problem entirely disappeared (on my machine at least).

This is what this pull request does: call close on the server before calling deleteLater to make sure there won't be any dangling socket that could be used by the newer server socket.

I cannot say for certain, however it seems like those two issues are related to this, because of the description:
[sddm/sddm#1535](https://github.com/sddm/sddm/issues/1535)
[sddm/sddm#2134](https://github.com/sddm/sddm/issues/2134)
