### PR TITLE
UserSession: Don't request VT signal delivery

### DIFF
--- a/src/helper/UserSession.cpp
+++ b/src/helper/UserSession.cpp
@@ -229,7 +229,7 @@ namespace SDDM {
             }
 
             if (vtNumber > 0)
-                VirtualTerminal::jumpToVt(vtNumber, x11UserSession);
+                VirtualTerminal::jumpToVt(vtNumber, true);
         }
 
 #ifdef Q_OS_LINUX


### PR DESCRIPTION
The `UserSession::childModifier()` hook is executed after the `fork()` call, right before `execv()`. This means the we're wearing the child's PID already. The `VirtualTerminal::jumpToVt()` function arms the `VT_SETMODE` ioctl on the target VT, asking the kernel to deliver signals when the VT gets switched to/from. It then arranges signal handlers for these signals. However, we soon enough call `execv()`, and all our handlers get purged, while kernel still thinks it should deliver signals to the user session process.

At least on FreeBSD this change fixes an issue when starting a Wayland session results in a quick crash - it gets a signal it isn't prepare for receiving and gets killed.