### PR TITLE
greeter: Don't quit when the last window closes

### DIFF
--- a/src/greeter/GreeterApp.cpp
+++ b/src/greeter/GreeterApp.cpp
@@ -361,6 +361,10 @@ int main(int argc, char **argv)
         qputenv("QT_IM_MODULE", inputMethod.toLocal8Bit());
 
     QGuiApplication app(argc, argv);
+
+    // Don't quit when the last screen and thus the last view disappears
+    app.setQuitOnLastWindowClosed(false);
+
     SDDM::SignalHandler s;
     QObject::connect(&s, &SDDM::SignalHandler::sigtermReceived, &app, [] {
         QCoreApplication::instance()->exit(-1);


### PR DESCRIPTION
GreeterApp creates a QQuickView per QScreen and destroys it again in
removeViewForScreen(). With a single display, unplugging the monitor drops the
window count to zero and QGuiApplication's default quitOnLastWindowClosed makes
the greeter exit with status 0.

The daemon takes that for a successful exit and does not start a new greeter,
so the seat is left on a bare console while sddm.service is still active.

Tested with the Qt 5 and Qt 6 greeters on 0.21.0 and develop, the greeter now
survives unplug and replug.

Fixes #2211
