### PR TITLE
Improve handling of PAM conversation messages

### DIFF
--- a/data/themes/elarun/Main.qml
+++ b/data/themes/elarun/Main.qml
@@ -356,6 +356,10 @@ Rectangle {
 
                 model: sessionModel
                 index: sessionModel.lastIndex
+                onIndexChanged: {
+                    if (pamConversationActive)
+                        sddm.setSession(index)
+                }
 
                 font.pixelSize: 14
 

--- a/data/themes/elarun/Main.qml
+++ b/data/themes/elarun/Main.qml
@@ -80,7 +80,7 @@ Rectangle {
         function onInformationMessage(message) {
             prompt_text.text = message
         }
-        function onAuthenticationPrompt(message, echoOn) {
+        function onAuthenticationPrompt(message, promptVisible) {
             prompt_text.text = message.trim().replace(/:\s*$/, "")
             if (pamResponsePending) {
                 var response = pamPendingResponse
@@ -101,7 +101,7 @@ Rectangle {
             pamConversationUser = ""
             pamResponsePending = false
             pamPendingResponse = ""
-            beginPamAuthentication(user_entry.text)
+            pw_entry.enabled = user_entry.text !== ""
         }
     }
 
@@ -175,6 +175,20 @@ Rectangle {
 
                             KeyNavigation.backtab: layoutBox; KeyNavigation.tab: pw_entry
 
+                            onTextChanged: {
+                                if (pamConversationActive && text !== pamConversationUser) {
+                                    sddm.cancelAuthentication()
+                                    pamConversationActive = false
+                                    pamConversationUser = ""
+                                    pamResponsePending = false
+                                    pamPendingResponse = ""
+                                    pw_entry.text = ""
+                                    prompt_text.text = ""
+                                }
+
+                                pw_entry.enabled = text !== ""
+                            }
+
                             Keys.onPressed: function (event) {
                                 if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
                                     beginPamAuthentication(user_entry.text)
@@ -199,7 +213,12 @@ Rectangle {
 
                             KeyNavigation.backtab: user_entry; KeyNavigation.tab: login_button
 
-                            enabled: false
+                            enabled: user_entry.text !== ""
+
+                            onActiveFocusChanged: {
+                                if (activeFocus && user_entry.text !== "" && !pamConversationActive)
+                                    beginPamAuthentication(user_entry.text)
+                            }
 
                             Keys.onPressed: function (event) {
                                 if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
@@ -306,7 +325,6 @@ Rectangle {
         }
     }
 
-    Component.onCompleted: beginPamAuthentication(user_entry.text)
 
     Rectangle {
         id: actionBar
@@ -371,9 +389,10 @@ Rectangle {
     }
 
     Component.onCompleted: {
-        if (user_entry.text === "")
+        if (user_entry.text === "") {
             user_entry.focus = true
-        else
-            pw_entry.focus = true
+        } else {
+            beginPamAuthentication(user_entry.text)
+        }
     }
 }

--- a/data/themes/elarun/Main.qml
+++ b/data/themes/elarun/Main.qml
@@ -34,6 +34,42 @@ Rectangle {
     LayoutMirroring.childrenInherit: true
 
     property int sessionIndex: session.index
+    property bool pamConversationActive: false
+    property string pamConversationUser: ""
+    property bool pamResponsePending: false
+    property string pamPendingResponse: ""
+
+    function beginPamAuthentication(username) {
+        if (!username) {
+            pw_entry.enabled = false
+            prompt_text.text = ""
+            return
+        }
+
+        pamConversationActive = true
+        pamConversationUser = username
+        pw_entry.enabled = false
+        pw_entry.text = ""
+        prompt_text.text = ""
+        pamResponsePending = false
+        pamPendingResponse = ""
+        sddm.beginAuthentication(username, sessionIndex)
+    }
+
+    function submitPamResponse() {
+        if (!pamConversationActive) {
+            beginPamAuthentication(user_entry.text)
+        }
+
+        if (pw_entry.enabled) {
+            pw_entry.enabled = false
+            sddm.respond(pw_entry.text)
+            pw_entry.text = ""
+        } else {
+            pamPendingResponse = pw_entry.text
+            pamResponsePending = true
+        }
+    }
 
     TextConstants { id: textConstants }
 
@@ -42,9 +78,30 @@ Rectangle {
         function onLoginSucceeded() {
         }
         function onInformationMessage(message) {
+            prompt_text.text = message
+        }
+        function onAuthenticationPrompt(message, echoOn) {
+            prompt_text.text = message.trim().replace(/:\s*$/, "")
+            if (pamResponsePending) {
+                var response = pamPendingResponse
+                pamResponsePending = false
+                pamPendingResponse = ""
+                pw_entry.enabled = false
+                pw_entry.text = ""
+                sddm.respond(response)
+            } else {
+                pw_entry.enabled = true
+                pw_entry.text = ""
+                pw_entry.forceActiveFocus()
+            }
         }
         function onLoginFailed() {
             pw_entry.text = ""
+            pamConversationActive = false
+            pamConversationUser = ""
+            pamResponsePending = false
+            pamPendingResponse = ""
+            beginPamAuthentication(user_entry.text)
         }
     }
 
@@ -117,6 +174,13 @@ Rectangle {
                             font.pixelSize: 14
 
                             KeyNavigation.backtab: layoutBox; KeyNavigation.tab: pw_entry
+
+                            Keys.onPressed: function (event) {
+                                if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
+                                    beginPamAuthentication(user_entry.text)
+                                    event.accepted = true
+                                }
+                            }
                         }
                     }
 
@@ -135,13 +199,24 @@ Rectangle {
 
                             KeyNavigation.backtab: user_entry; KeyNavigation.tab: login_button
 
+                            enabled: false
+
                             Keys.onPressed: function (event) {
                                 if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
-                                    sddm.login(user_entry.text, pw_entry.text, sessionIndex)
+                                    submitPamResponse()
                                     event.accepted = true
                                 }
                             }
                         }
+                    }
+
+                    Text {
+                        id: prompt_text
+                        width: 180
+                        color: "#0b678c"
+                        horizontalAlignment: Text.AlignHCenter
+                        font.pixelSize: 12
+                        text: ""
                     }
                 }
 
@@ -153,7 +228,7 @@ Rectangle {
 
                     source: Qt.resolvedUrl("images/login_normal.png")
 
-                    onClicked: sddm.login(user_entry.text, pw_entry.text, sessionIndex)
+                    onClicked: submitPamResponse()
 
 		    KeyNavigation.backtab: pw_entry; KeyNavigation.tab: session
                 }
@@ -230,6 +305,8 @@ Rectangle {
             }
         }
     }
+
+    Component.onCompleted: beginPamAuthentication(user_entry.text)
 
     Rectangle {
         id: actionBar

--- a/data/themes/maldives/Main.qml
+++ b/data/themes/maldives/Main.qml
@@ -268,6 +268,10 @@ Rectangle {
 
                             model: sessionModel
                             index: sessionModel.lastIndex
+                            onIndexChanged: {
+                                if (pamConversationActive)
+                                    sddm.setSession(index)
+                            }
 
                             KeyNavigation.backtab: password; KeyNavigation.tab: layoutBox
                         }

--- a/data/themes/maldives/Main.qml
+++ b/data/themes/maldives/Main.qml
@@ -190,6 +190,7 @@ Rectangle {
                                 pamPendingResponse = ""
                                 password.text = ""
                                 lblPassword.text = ""
+                                errorMessage.text = textConstants.prompt
                             }
 
                             password.enabled = text !== ""

--- a/data/themes/maldives/Main.qml
+++ b/data/themes/maldives/Main.qml
@@ -34,6 +34,42 @@ Rectangle {
     LayoutMirroring.childrenInherit: true
 
     property int sessionIndex: session.index
+    property bool pamConversationActive: false
+    property string pamConversationUser: ""
+    property bool pamResponsePending: false
+    property string pamPendingResponse: ""
+
+    function beginPamAuthentication(username) {
+        if (!username) {
+            password.enabled = false
+            lblPassword.text = ""
+            return
+        }
+
+        pamConversationActive = true
+        pamConversationUser = username
+        password.enabled = false
+        password.text = ""
+        lblPassword.text = ""
+        pamResponsePending = false
+        pamPendingResponse = ""
+        sddm.beginAuthentication(username, sessionIndex)
+    }
+
+    function submitPamResponse() {
+        if (!pamConversationActive) {
+            beginPamAuthentication(name.text)
+        }
+
+        if (password.enabled) {
+            password.enabled = false
+            sddm.respond(password.text)
+            password.text = ""
+        } else {
+            pamPendingResponse = password.text
+            pamResponsePending = true
+        }
+    }
 
     TextConstants { id: textConstants }
 
@@ -44,10 +80,30 @@ Rectangle {
             errorMessage.color = "steelblue"
             errorMessage.text = textConstants.loginSucceeded
         }
+        function onAuthenticationPrompt(message, echoOn) {
+            lblPassword.text = message.trim().replace(/:\s*$/, "")
+            if (pamResponsePending) {
+                var response = pamPendingResponse
+                pamResponsePending = false
+                pamPendingResponse = ""
+                password.enabled = false
+                password.text = ""
+                sddm.respond(response)
+            } else {
+                password.enabled = true
+                password.text = ""
+                password.forceActiveFocus()
+            }
+        }
         function onLoginFailed() {
             password.text = ""
             errorMessage.color = "red"
             errorMessage.text = textConstants.loginFailed
+            pamConversationActive = false
+            pamConversationUser = ""
+            pamResponsePending = false
+            pamPendingResponse = ""
+            beginPamAuthentication(name.text)
         }
         function onInformationMessage(message) {
             errorMessage.color = "red"
@@ -127,7 +183,7 @@ Rectangle {
 
                         Keys.onPressed: function (event) {
                             if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
-                                sddm.login(name.text, password.text, sessionIndex)
+                                beginPamAuthentication(name.text)
                                 event.accepted = true
                             }
                         }
@@ -149,12 +205,13 @@ Rectangle {
                         id: password
                         width: parent.width; height: 30
                         font.pixelSize: 14
+                        enabled: false
 
                         KeyNavigation.backtab: name; KeyNavigation.tab: session
 
                         Keys.onPressed: function (event) {
                             if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
-                                sddm.login(name.text, password.text, sessionIndex)
+                                submitPamResponse()
                                 event.accepted = true
                             }
                         }
@@ -245,7 +302,7 @@ Rectangle {
                         text: textConstants.login
                         width: parent.btnWidth
 
-                        onClicked: sddm.login(name.text, password.text, sessionIndex)
+                        onClicked: submitPamResponse()
 
                         KeyNavigation.backtab: layoutBox; KeyNavigation.tab: shutdownButton
                     }
@@ -280,4 +337,7 @@ Rectangle {
         else
             password.focus = true
     }
+
+    Component.onCompleted: beginPamAuthentication(name.text)
+
 }

--- a/data/themes/maldives/Main.qml
+++ b/data/themes/maldives/Main.qml
@@ -80,7 +80,7 @@ Rectangle {
             errorMessage.color = "steelblue"
             errorMessage.text = textConstants.loginSucceeded
         }
-        function onAuthenticationPrompt(message, echoOn) {
+        function onAuthenticationPrompt(message, promptVisible) {
             lblPassword.text = message.trim().replace(/:\s*$/, "")
             if (pamResponsePending) {
                 var response = pamPendingResponse
@@ -103,7 +103,7 @@ Rectangle {
             pamConversationUser = ""
             pamResponsePending = false
             pamPendingResponse = ""
-            beginPamAuthentication(name.text)
+            password.enabled = name.text !== ""
         }
         function onInformationMessage(message) {
             errorMessage.color = "red"
@@ -181,6 +181,20 @@ Rectangle {
 
                         KeyNavigation.backtab: rebootButton; KeyNavigation.tab: password
 
+                        onTextChanged: {
+                            if (pamConversationActive && text !== pamConversationUser) {
+                                sddm.cancelAuthentication()
+                                pamConversationActive = false
+                                pamConversationUser = ""
+                                pamResponsePending = false
+                                pamPendingResponse = ""
+                                password.text = ""
+                                lblPassword.text = ""
+                            }
+
+                            password.enabled = text !== ""
+                        }
+
                         Keys.onPressed: function (event) {
                             if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
                                 beginPamAuthentication(name.text)
@@ -205,9 +219,14 @@ Rectangle {
                         id: password
                         width: parent.width; height: 30
                         font.pixelSize: 14
-                        enabled: false
+                        enabled: name.text !== ""
 
                         KeyNavigation.backtab: name; KeyNavigation.tab: session
+
+                        onActiveFocusChanged: {
+                            if (activeFocus && name.text !== "" && !pamConversationActive)
+                                beginPamAuthentication(name.text)
+                        }
 
                         Keys.onPressed: function (event) {
                             if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
@@ -332,12 +351,11 @@ Rectangle {
     }
 
     Component.onCompleted: {
-        if (name.text == "")
+        if (name.text == "") {
             name.focus = true
-        else
-            password.focus = true
+        } else {
+            beginPamAuthentication(name.text)
+        }
     }
-
-    Component.onCompleted: beginPamAuthentication(name.text)
 
 }

--- a/data/themes/maldives/Main.qml
+++ b/data/themes/maldives/Main.qml
@@ -106,7 +106,7 @@ Rectangle {
             password.enabled = name.text !== ""
         }
         function onInformationMessage(message) {
-            errorMessage.color = "red"
+            errorMessage.color = "white"
             errorMessage.text = message
         }
     }
@@ -190,6 +190,7 @@ Rectangle {
                                 pamPendingResponse = ""
                                 password.text = ""
                                 lblPassword.text = ""
+                                errorMessage.color = "white"
                                 errorMessage.text = textConstants.prompt
                             }
 

--- a/data/themes/maya/Main.qml
+++ b/data/themes/maya/Main.qml
@@ -514,6 +514,7 @@ Rectangle {
             pamPendingResponse = ""
             maya_password.text = ""
             maya_password_label.text = ""
+            prompt_txt.text = textConstants.prompt
           }
 
           maya_password.enabled = text !== ""

--- a/data/themes/maya/Main.qml
+++ b/data/themes/maya/Main.qml
@@ -66,6 +66,43 @@ Rectangle {
   readonly property int spFontNormal  : 24
   readonly property int spFontSmall   : 16
 
+  property bool pamConversationActive : false
+  property string pamConversationUser : ""
+  property bool pamResponsePending : false
+  property string pamPendingResponse : ""
+
+  function beginPamAuthentication(username) {
+    if (!username) {
+      maya_password.enabled = false
+      maya_password_label.text = ""
+      return
+    }
+
+    pamConversationActive = true
+    pamConversationUser = username
+    maya_password.enabled = false
+    maya_password.text = ""
+    maya_password_label.text = ""
+    pamResponsePending = false
+    pamPendingResponse = ""
+    sddm.beginAuthentication(username, maya_session.index)
+  }
+
+  function submitPamResponse() {
+    if (!pamConversationActive) {
+      beginPamAuthentication(maya_username.text)
+    }
+
+    if (maya_password.enabled) {
+      maya_password.enabled = false
+      sddm.respond(maya_password.text)
+      maya_password.text = ""
+    } else {
+      pamPendingResponse = maya_password.text
+      pamResponsePending = true
+    }
+  }
+
 
   LayoutMirroring.enabled: Qt.locale().textDirection == Qt.RightToLeft
   LayoutMirroring.childrenInherit: true
@@ -84,9 +121,29 @@ Rectangle {
 
       anim_success.start()
     }
+    function onAuthenticationPrompt(message, echoOn) {
+      maya_password_label.text = message.trim().replace(/:\s*$/, "")
+      if (pamResponsePending) {
+        var response = pamPendingResponse
+        pamResponsePending = false
+        pamPendingResponse = ""
+        maya_password.enabled = false
+        maya_password.text = ""
+        sddm.respond(response)
+      } else {
+        maya_password.enabled = true
+        maya_password.text = ""
+        maya_password.forceActiveFocus()
+      }
+    }
     function onLoginFailed() {
       prompt_bg.color = failureText
       prompt_txt.text = textConstants.loginFailed
+      pamConversationActive = false
+      pamConversationUser = ""
+      pamResponsePending = false
+      pamPendingResponse = ""
+      beginPamAuthentication(maya_username.text)
 
       maya_busy.visible = false;
       maya_busy_anim.stop()
@@ -99,8 +156,6 @@ Rectangle {
 
       maya_busy.visible = false;
       maya_busy_anim.stop()
-
-      anim_failure.start()
     }
   }
 
@@ -110,8 +165,7 @@ Rectangle {
   onTryLogin : {
     maya_busy.visible = true;
     maya_busy_anim.start()
-
-    sddm.login(maya_username.text, maya_password.text, maya_session.index);
+    submitPamResponse()
   }
 
 
@@ -460,10 +514,11 @@ Rectangle {
       height  : (spUnit - (padSym * 2))
 
       Text {
+        id      : maya_password_label
         width   : parent.width
         height  : parent.height
 
-        text    : textConstants.password
+        text    : ""
         color   : accentLight
 
         font.family     : opensans_cond_light.name
@@ -482,6 +537,7 @@ Rectangle {
 
       PasswordBox {
         id      : maya_password
+        enabled : false
 
         width   : parent.width
         height  : parent.height
@@ -507,7 +563,7 @@ Rectangle {
 
         Keys.onPressed: function (event) {
           if ((event.key === Qt.Key_Return) || (event.key === Qt.Key_Enter)) {
-            maya_root.tryLogin()
+            beginPamAuthentication(maya_username.text)
 
             event.accepted = true;
           }
@@ -685,4 +741,7 @@ Rectangle {
     else
       maya_password.focus = true
   }
+
+  Component.onCompleted: beginPamAuthentication(maya_username.text)
+
 }

--- a/data/themes/maya/Main.qml
+++ b/data/themes/maya/Main.qml
@@ -151,7 +151,7 @@ Rectangle {
       anim_failure.start()
     }
     function onInformationMessage(message) {
-      prompt_bg.color = failureText
+      prompt_bg.color = "transparent"
       prompt_txt.text = message
 
       maya_busy.visible = false;
@@ -514,6 +514,7 @@ Rectangle {
             pamPendingResponse = ""
             maya_password.text = ""
             maya_password_label.text = ""
+            prompt_bg.color = "transparent"
             prompt_txt.text = textConstants.prompt
           }
 
@@ -758,6 +759,7 @@ Rectangle {
 
       onStopped: {
         maya_password.text  = ""
+        prompt_bg.color     = "transparent"
         prompt_txt.text     = textConstants.prompt
       }
     }

--- a/data/themes/maya/Main.qml
+++ b/data/themes/maya/Main.qml
@@ -336,6 +336,10 @@ Rectangle {
 
         model   : sessionModel
         index   : sessionModel.lastIndex
+        onIndexChanged: {
+          if (pamConversationActive)
+            sddm.setSession(index)
+        }
 
         width   : spUnit * 3
         height  : parent.height

--- a/data/themes/maya/Main.qml
+++ b/data/themes/maya/Main.qml
@@ -121,7 +121,7 @@ Rectangle {
 
       anim_success.start()
     }
-    function onAuthenticationPrompt(message, echoOn) {
+    function onAuthenticationPrompt(message, promptVisible) {
       maya_password_label.text = message.trim().replace(/:\s*$/, "")
       if (pamResponsePending) {
         var response = pamPendingResponse
@@ -143,7 +143,7 @@ Rectangle {
       pamConversationUser = ""
       pamResponsePending = false
       pamPendingResponse = ""
-      beginPamAuthentication(maya_username.text)
+      maya_password.enabled = maya_username.text !== ""
 
       maya_busy.visible = false;
       maya_busy_anim.stop()
@@ -504,6 +504,29 @@ Rectangle {
 
         KeyNavigation.tab     : maya_password
         KeyNavigation.backtab : maya_layout
+
+        onTextChanged: {
+          if (pamConversationActive && text !== pamConversationUser) {
+            sddm.cancelAuthentication()
+            pamConversationActive = false
+            pamConversationUser = ""
+            pamResponsePending = false
+            pamPendingResponse = ""
+            maya_password.text = ""
+            maya_password_label.text = ""
+          }
+
+          maya_password.enabled = text !== ""
+        }
+
+        Keys.onPressed: function (event) {
+          if ((event.key === Qt.Key_Return) || (event.key === Qt.Key_Enter)) {
+            if (maya_username.text !== "")
+              beginPamAuthentication(maya_username.text)
+
+            event.accepted = true;
+          }
+        }
       }
     }
 
@@ -537,7 +560,7 @@ Rectangle {
 
       PasswordBox {
         id      : maya_password
-        enabled : false
+        enabled : maya_username.text !== ""
 
         width   : parent.width
         height  : parent.height
@@ -561,9 +584,14 @@ Rectangle {
         KeyNavigation.tab     : maya_login
         KeyNavigation.backtab : maya_username
 
+        onActiveFocusChanged: {
+          if (activeFocus && maya_username.text !== "" && !pamConversationActive)
+            beginPamAuthentication(maya_username.text)
+        }
+
         Keys.onPressed: function (event) {
           if ((event.key === Qt.Key_Return) || (event.key === Qt.Key_Enter)) {
-            beginPamAuthentication(maya_username.text)
+            maya_root.tryLogin()
 
             event.accepted = true;
           }
@@ -736,12 +764,10 @@ Rectangle {
 
 
   Component.onCompleted: {
-    if (maya_username.text === "")
+    if (maya_username.text === "") {
       maya_username.focus = true
-    else
-      maya_password.focus = true
+    } else {
+      beginPamAuthentication(maya_username.text)
+    }
   }
-
-  Component.onCompleted: beginPamAuthentication(maya_username.text)
-
 }

--- a/src/auth/Auth.cpp
+++ b/src/auth/Auth.cpp
@@ -184,7 +184,7 @@ namespace SDDM {
                         auth->setUser(user);
                         Q_EMIT auth->authentication(user, true);
                         str.reset();
-                        str << AUTHENTICATED << environment << cookie;
+                        str << AUTHENTICATED << environment << cookie << sessionPath << displayServerCmd;
                         str.send();
                     }
                     else {

--- a/src/common/Messages.h
+++ b/src/common/Messages.h
@@ -30,7 +30,10 @@ namespace SDDM {
         Reboot,
         Suspend,
         Hibernate,
-        HybridSleep
+        HybridSleep,
+        AuthenticationResponse,
+        BeginAuthentication,
+        CancelAuthentication
     };
 
     enum class DaemonMessages {
@@ -39,6 +42,7 @@ namespace SDDM {
         LoginSucceeded,
         LoginFailed,
         InformationMessage,
+        AuthenticationPrompt,
     };
 
     enum Capability {

--- a/src/common/Messages.h
+++ b/src/common/Messages.h
@@ -33,6 +33,7 @@ namespace SDDM {
         HybridSleep,
         AuthenticationResponse,
         BeginAuthentication,
+        SetSession,
         CancelAuthentication
     };
 

--- a/src/common/SocketWriter.cpp
+++ b/src/common/SocketWriter.cpp
@@ -49,4 +49,10 @@ namespace SDDM {
 
         return *this;
     }
+
+    SocketWriter &SocketWriter::operator << (bool value) {
+        *output << value;
+
+        return *this;
+    }
 }

--- a/src/common/SocketWriter.h
+++ b/src/common/SocketWriter.h
@@ -36,6 +36,7 @@ namespace SDDM {
         SocketWriter &operator << (const quint32 &u);
         SocketWriter &operator << (const QString &s);
         SocketWriter &operator << (const Session &s);
+        SocketWriter &operator << (bool value);
 
     private:
         QByteArray data;

--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -154,6 +154,9 @@ namespace SDDM {
 
         // connect login signal
         connect(m_socketServer, &SocketServer::login, this, &Display::login);
+        connect(m_socketServer, &SocketServer::beginAuthentication, this, QOverload<QLocalSocket *, const QString &, const Session &>::of(&Display::beginAuthentication));
+        connect(m_socketServer, &SocketServer::cancelAuthentication, this, &Display::cancelAuthentication);
+        connect(m_socketServer, &SocketServer::authenticationResponse, this, &Display::authenticationResponse);
 
         // connect login result signals
         connect(this, &Display::loginFailed, m_socketServer, &SocketServer::loginFailed);
@@ -331,17 +334,106 @@ namespace SDDM {
     void Display::login(QLocalSocket *socket,
                         const QString &user, const QString &password,
                         const Session &session) {
-        m_socket = socket;
+        beginAuthentication(socket, user, password, session, true);
+    }
 
-        //the SDDM user has special privileges that skip password checking so that we can load the greeter
-        //block ever trying to log in as the SDDM user
+    void Display::beginAuthentication(QLocalSocket *socket, const QString &user, const Session &session) {
+        beginAuthentication(socket, user, QString(), session, false);
+    }
+
+    bool Display::beginAuthentication(QLocalSocket *socket, const QString &user,
+                                      const QString &password, const Session &session,
+                                      bool answerInitialRequest) {
+        // The SDDM user has special privileges that skip password checking so
+        // that the greeter can be loaded. Never allow logging in as that user.
         if (user == QLatin1String("sddm")) {
-            emit loginFailed(m_socket);
+            emit loginFailed(socket);
+            return false;
+        }
+
+        // Replacing an active PAM conversation is asynchronous. Remember the
+        // new request and start it only after the helper for the old request
+        // has really exited. This avoids a cancel/start race when users are
+        // switched quickly in the greeter.
+        if (m_auth->isActive()) {
+            m_pendingAuthentication = true;
+            m_pendingSocket = socket;
+            m_pendingUser = user;
+            m_pendingPassword = password;
+            m_pendingSession = session;
+            m_pendingInitialAuthRequest = answerInitialRequest;
+
+            if (!m_cancelingAuthentication) {
+                m_cancelingAuthentication = true;
+                m_socket = nullptr;
+                m_passPhrase.clear();
+                m_initialAuthRequest = false;
+                m_auth->stop();
+            }
+            return true;
+        }
+
+        m_socket = socket;
+        if (!startAuth(user, password, session, answerInitialRequest)) {
+            m_socket = nullptr;
+            return false;
+        }
+        return true;
+    }
+
+    bool Display::startPendingAuthentication() {
+        if (!m_pendingAuthentication)
+            return false;
+
+        const auto socket = m_pendingSocket;
+        const auto user = m_pendingUser;
+        const auto password = m_pendingPassword;
+        const auto session = m_pendingSession;
+        const bool answerInitialRequest = m_pendingInitialAuthRequest;
+
+        m_pendingAuthentication = false;
+        m_pendingSocket = nullptr;
+        m_pendingUser.clear();
+        m_pendingPassword.clear();
+        m_pendingInitialAuthRequest = false;
+
+        return beginAuthentication(socket, user, password, session, answerInitialRequest);
+    }
+
+    void Display::cancelAuthentication(QLocalSocket *socket) {
+        if (socket != m_socket && socket != m_pendingSocket)
+            return;
+
+        m_pendingAuthentication = false;
+        m_pendingSocket = nullptr;
+        m_pendingUser.clear();
+        m_pendingPassword.clear();
+        m_pendingInitialAuthRequest = false;
+
+        if (!m_auth->isActive())
+            return;
+
+        m_cancelingAuthentication = true;
+        m_socket = nullptr;
+        m_passPhrase.clear();
+        m_initialAuthRequest = false;
+        m_auth->stop();
+    }
+
+    void Display::authenticationResponse(QLocalSocket *socket, const QString &response) {
+        if (socket != m_socket || !m_auth->isActive()) {
+            qWarning() << "Ignoring authentication response without a matching active authentication";
             return;
         }
 
-        // authenticate
-        startAuth(user, password, session);
+        const auto prompts = m_auth->request()->prompts();
+        if (prompts.length() != 1) {
+            qWarning() << "Cannot apply authentication response: expected one prompt, got" << prompts.length();
+            return;
+        }
+
+        prompts[0]->setResponse(response.toUtf8());
+        m_auth->request()->done();
     }
 
     QString Display::findGreeterTheme() const {
@@ -385,7 +477,7 @@ namespace SDDM {
         return false;
     }
 
-    bool Display::startAuth(const QString &user, const QString &password, const Session &session) {
+    bool Display::startAuth(const QString &user, const QString &password, const Session &session, bool answerInitialRequest) {
 
         if (m_auth->isActive()) {
             qWarning() << "Existing authentication ongoing, aborting";
@@ -393,6 +485,8 @@ namespace SDDM {
         }
 
         m_passPhrase = password;
+        m_initialAuthRequest = answerInitialRequest;
+        m_cancelingAuthentication = false;
 
         // sanity check
         if (!session.isValid()) {
@@ -539,6 +633,13 @@ namespace SDDM {
     }
 
     void Display::slotHelperFinished(Auth::HelperExitStatus status) {
+        if (m_cancelingAuthentication) {
+            m_cancelingAuthentication = false;
+            if (m_pendingAuthentication)
+                startPendingAuthentication();
+            return;
+        }
+
         // Don't restart greeter and display server unless sddm-helper exited
         // with an internal error or the user session finished successfully,
         // we want to avoid greeter from restarting when an authentication
@@ -549,13 +650,31 @@ namespace SDDM {
     }
 
     void Display::slotRequestChanged() {
-        if (m_auth->request()->prompts().length() == 1) {
-            m_auth->request()->prompts()[0]->setResponse(qPrintable(m_passPhrase));
-            m_auth->request()->done();
-        } else if (m_auth->request()->prompts().length() == 2) {
-            m_auth->request()->prompts()[0]->setResponse(qPrintable(m_auth->user()));
-            m_auth->request()->prompts()[1]->setResponse(qPrintable(m_passPhrase));
-            m_auth->request()->done();
+        const auto prompts = m_auth->request()->prompts();
+
+        // Keep the existing behaviour for the initial request so unchanged
+        // greeter themes continue to work with ordinary password logins.
+        if (m_initialAuthRequest) {
+            m_initialAuthRequest = false;
+
+            if (prompts.length() == 1) {
+                prompts[0]->setResponse(qPrintable(m_passPhrase));
+                m_auth->request()->done();
+            } else if (prompts.length() == 2) {
+                prompts[0]->setResponse(qPrintable(m_auth->user()));
+                prompts[1]->setResponse(qPrintable(m_passPhrase));
+                m_auth->request()->done();
+            }
+            return;
+        }
+
+        // Subsequent requests must be answered by a greeter theme through
+        // sddm.respond().  PAM modules such as pam_google_authenticator use
+        // this for a separate one-time-password prompt.
+        if (prompts.length() == 1 && m_socket) {
+            m_socketServer->authenticationPrompt(m_socket, prompts[0]->message(), prompts[0]->hidden());
+        } else {
+            qWarning() << "Unsupported authentication request with" << prompts.length() << "prompts";
         }
     }
 

--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -155,6 +155,7 @@ namespace SDDM {
         // connect login signal
         connect(m_socketServer, &SocketServer::login, this, &Display::login);
         connect(m_socketServer, &SocketServer::beginAuthentication, this, QOverload<QLocalSocket *, const QString &, const Session &>::of(&Display::beginAuthentication));
+        connect(m_socketServer, &SocketServer::setSession, this, &Display::setAuthenticationSession);
         connect(m_socketServer, &SocketServer::cancelAuthentication, this, &Display::cancelAuthentication);
         connect(m_socketServer, &SocketServer::authenticationResponse, this, &Display::authenticationResponse);
 
@@ -400,6 +401,21 @@ namespace SDDM {
         return beginAuthentication(socket, user, password, session, answerInitialRequest);
     }
 
+    void Display::setAuthenticationSession(QLocalSocket *socket, const Session &session) {
+        if (socket == m_socket && m_auth->isActive()) {
+            if (!session.isValid()) {
+                qWarning() << "Ignoring invalid session change" << session.fileName();
+                return;
+            }
+            m_authenticationSession = session;
+            m_sessionName = session.fileName();
+            return;
+        }
+
+        if (socket == m_pendingSocket && m_pendingAuthentication)
+            m_pendingSession = session;
+    }
+
     void Display::cancelAuthentication(QLocalSocket *socket) {
         if (socket != m_socket && socket != m_pendingSocket)
             return;
@@ -488,7 +504,46 @@ namespace SDDM {
         m_initialAuthRequest = answerInitialRequest;
         m_cancelingAuthentication = false;
 
-        // sanity check
+        // Validate the initial selection. It remains changeable while the PAM
+        // conversation is active and is prepared only after authentication
+        // succeeds.
+        if (!session.isValid()) {
+            qCritical() << "Invalid session" << session.fileName();
+            return false;
+        }
+
+        m_authenticationSession = session;
+        m_sessionName = session.fileName();
+        m_auth->setSession(QString());
+        m_auth->setDisplayServerCommand(QString());
+
+        m_reuseSessionId = QString();
+
+        if (Logind::isAvailable() && mainConfig.Users.ReuseSession.get()) {
+            OrgFreedesktopLogin1ManagerInterface manager(Logind::serviceName(), Logind::managerPath(), QDBusConnection::systemBus());
+            auto reply = manager.ListSessions();
+            reply.waitForFinished();
+
+            for (const SessionInfo &s : reply.value()) {
+                if (s.userName == user) {
+                    OrgFreedesktopLogin1SessionInterface loginSession(Logind::serviceName(), s.sessionPath.path(), QDBusConnection::systemBus());
+                    if ((loginSession.service() == QLatin1String("sddm")
+                        || loginSession.service() == QLatin1String("sddm-autologin"))
+                            && loginSession.state() == QLatin1String("online")) {
+                        m_reuseSessionId = s.sessionId;
+                        break;
+                    }
+                }
+            }
+        }
+
+        m_auth->setUser(user);
+        m_auth->start();
+
+        return true;
+    }
+
+    bool Display::configureUserSession(const Session &session) {
         if (!session.isValid()) {
             qCritical() << "Invalid session" << session.fileName();
             return false;
@@ -502,40 +557,15 @@ namespace SDDM {
             return false;
         }
 
-        m_reuseSessionId = QString();
-
-        if (Logind::isAvailable() && mainConfig.Users.ReuseSession.get()) {
-            OrgFreedesktopLogin1ManagerInterface manager(Logind::serviceName(), Logind::managerPath(), QDBusConnection::systemBus());
-            auto reply = manager.ListSessions();
-            reply.waitForFinished();
-
-            const auto info = reply.value();
-            for(const SessionInfo &s : reply.value()) {
-                if (s.userName == user) {
-                    OrgFreedesktopLogin1SessionInterface session(Logind::serviceName(), s.sessionPath.path(), QDBusConnection::systemBus());
-                    if ((session.service() == QLatin1String("sddm")
-                        || session.service() == QLatin1String("sddm-autologin"))
-                            && session.state() == QLatin1String("online")) {
-                        m_reuseSessionId = s.sessionId;
-                        break;
-                    }
-                }
-            }
-        }
-
-        // save session desktop file name, we'll use it to set the
-        // last session later, in slotAuthenticationFinished()
         m_sessionName = session.fileName();
 
         m_sessionTerminalId = m_terminalId;
         if ((session.type() == Session::WaylandSession && m_displayServerType == X11DisplayServerType) || (m_greeter->isRunning() && m_displayServerType != X11DisplayServerType)) {
             // Create a new VT when we need to have another compositor running
-            if (seat()->canTTY()) {
+            if (seat()->canTTY())
                 m_sessionTerminalId = VirtualTerminal::setUpNewVt();
-            }
         }
 
-        // some information
         qDebug() << "Session" << m_sessionName << "selected, command:" << session.exec() << "for VT" << m_sessionTerminalId;
 
         QProcessEnvironment env;
@@ -556,21 +586,16 @@ namespace SDDM {
         env.insert(QStringLiteral("XDG_SESSION_DESKTOP"), session.desktopNames());
 #endif
 
+        m_auth->setDisplayServerCommand(QString());
         if (session.xdgSessionType() == QLatin1String("x11")) {
-          if (m_displayServerType == X11DisplayServerType)
-            env.insert(QStringLiteral("DISPLAY"), name());
-          else
-            m_auth->setDisplayServerCommand(XorgUserDisplayServer::command(this));
-        } else {
-            m_auth->setDisplayServerCommand(QStringLiteral());
-	}
-        m_auth->setUser(user);
-        if (m_reuseSessionId.isNull()) {
-            m_auth->setSession(session.exec());
+            if (m_displayServerType == X11DisplayServerType)
+                env.insert(QStringLiteral("DISPLAY"), name());
+            else
+                m_auth->setDisplayServerCommand(XorgUserDisplayServer::command(this));
         }
-        m_auth->insertEnvironment(env);
-        m_auth->start();
 
+        m_auth->setSession(session.exec());
+        m_auth->insertEnvironment(env);
         return true;
     }
 
@@ -582,6 +607,13 @@ namespace SDDM {
 
         if (success) {
             qDebug() << "Authentication for user " << user << " successful";
+
+            if (m_reuseSessionId.isNull() && !configureUserSession(m_authenticationSession)) {
+                if (m_socket)
+                    emit loginFailed(m_socket);
+                m_socket = nullptr;
+                return;
+            }
 
             if (!m_reuseSessionId.isNull()) {
                 OrgFreedesktopLogin1ManagerInterface manager(Logind::serviceName(), Logind::managerPath(), QDBusConnection::systemBus());

--- a/src/daemon/Display.h
+++ b/src/daemon/Display.h
@@ -73,6 +73,7 @@ namespace SDDM {
                    const QString &user, const QString &password,
                    const Session &session);
         void beginAuthentication(QLocalSocket *socket, const QString &user, const Session &session);
+        void setAuthenticationSession(QLocalSocket *socket, const Session &session);
         void cancelAuthentication(QLocalSocket *socket);
         void authenticationResponse(QLocalSocket *socket, const QString &response);
         void displayServerStarted();
@@ -94,6 +95,7 @@ namespace SDDM {
                                  const QString &password, const Session &session,
                                  bool answerInitialRequest);
         bool startPendingAuthentication();
+        bool configureUserSession(const Session &session);
 
         void startSocketServerAndGreeter();
         bool handleAutologinFailure();
@@ -114,6 +116,7 @@ namespace SDDM {
         QString m_pendingPassword;
         Session m_pendingSession;
         bool m_pendingInitialAuthRequest { false };
+        Session m_authenticationSession;
         QString m_sessionName;
         QString m_reuseSessionId;
 

--- a/src/daemon/Display.h
+++ b/src/daemon/Display.h
@@ -72,6 +72,9 @@ namespace SDDM {
         void login(QLocalSocket *socket,
                    const QString &user, const QString &password,
                    const Session &session);
+        void beginAuthentication(QLocalSocket *socket, const QString &user, const Session &session);
+        void cancelAuthentication(QLocalSocket *socket);
+        void authenticationResponse(QLocalSocket *socket, const QString &response);
         void displayServerStarted();
 
     signals:
@@ -86,7 +89,11 @@ namespace SDDM {
         bool findSessionEntry(const QStringList &dirPaths, const QString &name) const;
 
         bool startAuth(const QString &user, const QString &password,
-                       const Session &session);
+                       const Session &session, bool answerInitialRequest = true);
+        bool beginAuthentication(QLocalSocket *socket, const QString &user,
+                                 const QString &password, const Session &session,
+                                 bool answerInitialRequest);
+        bool startPendingAuthentication();
 
         void startSocketServerAndGreeter();
         bool handleAutologinFailure();
@@ -99,6 +106,14 @@ namespace SDDM {
         int m_sessionTerminalId = 0;
 
         QString m_passPhrase;
+        bool m_initialAuthRequest { true };
+        bool m_cancelingAuthentication { false };
+        bool m_pendingAuthentication { false };
+        QPointer<QLocalSocket> m_pendingSocket;
+        QString m_pendingUser;
+        QString m_pendingPassword;
+        Session m_pendingSession;
+        bool m_pendingInitialAuthRequest { false };
         QString m_sessionName;
         QString m_reuseSessionId;
 

--- a/src/daemon/SocketServer.cpp
+++ b/src/daemon/SocketServer.cpp
@@ -161,6 +161,14 @@ namespace SDDM {
                     emit beginAuthentication(socket, user, session);
                 }
                 break;
+                case GreeterMessages::SetSession: {
+                    qDebug() << "Message received from greeter: SetSession";
+
+                    Session session;
+                    input >> session;
+                    emit setSession(socket, session);
+                }
+                break;
                 case GreeterMessages::CancelAuthentication: {
                     qDebug() << "Message received from greeter: CancelAuthentication";
                     emit cancelAuthentication(socket);

--- a/src/daemon/SocketServer.cpp
+++ b/src/daemon/SocketServer.cpp
@@ -144,6 +144,28 @@ namespace SDDM {
                     emit login(socket, user, password, session);
                 }
                 break;
+                case GreeterMessages::AuthenticationResponse: {
+                    qDebug() << "Message received from greeter: AuthenticationResponse";
+
+                    QString response;
+                    input >> response;
+                    emit authenticationResponse(socket, response);
+                }
+                break;
+                case GreeterMessages::BeginAuthentication: {
+                    qDebug() << "Message received from greeter: BeginAuthentication";
+
+                    QString user;
+                    Session session;
+                    input >> user >> session;
+                    emit beginAuthentication(socket, user, session);
+                }
+                break;
+                case GreeterMessages::CancelAuthentication: {
+                    qDebug() << "Message received from greeter: CancelAuthentication";
+                    emit cancelAuthentication(socket);
+                }
+                break;
                 case GreeterMessages::PowerOff: {
                     // log message
                     qDebug() << "Message received from greeter: PowerOff";
@@ -190,6 +212,10 @@ namespace SDDM {
             }
         }
 
+    }
+
+    void SocketServer::authenticationPrompt(QLocalSocket *socket, const QString &message, bool promptVisible) {
+        SocketWriter(socket) << quint32(DaemonMessages::AuthenticationPrompt) << message << promptVisible;
     }
 
     void SocketServer::loginFailed(QLocalSocket *socket) {

--- a/src/daemon/SocketServer.h
+++ b/src/daemon/SocketServer.h
@@ -57,6 +57,7 @@ namespace SDDM {
                    const Session &session);
         void authenticationResponse(QLocalSocket *socket, const QString &response);
         void beginAuthentication(QLocalSocket *socket, const QString &user, const Session &session);
+        void setSession(QLocalSocket *socket, const Session &session);
         void cancelAuthentication(QLocalSocket *socket);
         void connected();
 

--- a/src/daemon/SocketServer.h
+++ b/src/daemon/SocketServer.h
@@ -47,6 +47,7 @@ namespace SDDM {
 
     public slots:
         void informationMessage(QLocalSocket *socket, const QString &message);
+        void authenticationPrompt(QLocalSocket *socket, const QString &message, bool promptVisible);
         void loginFailed(QLocalSocket *socket);
         void loginSucceeded(QLocalSocket *socket);
 
@@ -54,6 +55,9 @@ namespace SDDM {
         void login(QLocalSocket *socket,
                    const QString &user, const QString &password,
                    const Session &session);
+        void authenticationResponse(QLocalSocket *socket, const QString &response);
+        void beginAuthentication(QLocalSocket *socket, const QString &user, const Session &session);
+        void cancelAuthentication(QLocalSocket *socket);
         void connected();
 
     private:

--- a/src/greeter/GreeterProxy.cpp
+++ b/src/greeter/GreeterProxy.cpp
@@ -127,6 +127,27 @@ namespace SDDM {
         SocketWriter(d->socket) << quint32(GreeterMessages::Login) << user << password << session;
     }
 
+    void GreeterProxy::beginAuthentication(const QString &user, const int sessionIndex) const {
+        if (!d->sessionModel) {
+            qCritical() << "Session model is not set.";
+            return;
+        }
+
+        const QModelIndex index = d->sessionModel->index(sessionIndex, 0);
+        const Session::Type type = static_cast<Session::Type>(d->sessionModel->data(index, SessionModel::TypeRole).toInt());
+        const QString name = d->sessionModel->data(index, SessionModel::FileRole).toString();
+        const Session session(type, name);
+        SocketWriter(d->socket) << quint32(GreeterMessages::BeginAuthentication) << user << session;
+    }
+
+    void GreeterProxy::cancelAuthentication() const {
+        SocketWriter(d->socket) << quint32(GreeterMessages::CancelAuthentication);
+    }
+
+    void GreeterProxy::respond(const QString &response) const {
+        SocketWriter(d->socket) << quint32(GreeterMessages::AuthenticationResponse) << response;
+    }
+
     void GreeterProxy::connected() {
         // log connection
         qDebug() << "Connected to the daemon.";
@@ -212,6 +233,15 @@ namespace SDDM {
 
                     qDebug() << "Information Message received from daemon: " << message;
                     emit informationMessage(message);
+                }
+                break;
+                case DaemonMessages::AuthenticationPrompt: {
+                    QString prompt;
+                    bool promptVisible;
+                    input >> prompt >> promptVisible;
+
+                    qDebug() << "Authentication prompt received from daemon:" << prompt;
+                    emit authenticationPrompt(prompt, promptVisible);
                 }
                 break;
                 default: {

--- a/src/greeter/GreeterProxy.cpp
+++ b/src/greeter/GreeterProxy.cpp
@@ -140,6 +140,19 @@ namespace SDDM {
         SocketWriter(d->socket) << quint32(GreeterMessages::BeginAuthentication) << user << session;
     }
 
+    void GreeterProxy::setSession(const int sessionIndex) const {
+        if (!d->sessionModel) {
+            qCritical() << "Session model is not set.";
+            return;
+        }
+
+        const QModelIndex index = d->sessionModel->index(sessionIndex, 0);
+        const Session::Type type = static_cast<Session::Type>(d->sessionModel->data(index, SessionModel::TypeRole).toInt());
+        const QString name = d->sessionModel->data(index, SessionModel::FileRole).toString();
+        const Session session(type, name);
+        SocketWriter(d->socket) << quint32(GreeterMessages::SetSession) << session;
+    }
+
     void GreeterProxy::cancelAuthentication() const {
         SocketWriter(d->socket) << quint32(GreeterMessages::CancelAuthentication);
     }

--- a/src/greeter/GreeterProxy.h
+++ b/src/greeter/GreeterProxy.h
@@ -63,6 +63,9 @@ namespace SDDM {
         void hybridSleep();
 
         void login(const QString &user, const QString &password, const int sessionIndex) const;
+        void beginAuthentication(const QString &user, const int sessionIndex) const;
+        void cancelAuthentication() const;
+        void respond(const QString &response) const;
 
     private slots:
         void connected();
@@ -72,6 +75,7 @@ namespace SDDM {
 
     signals:
         void informationMessage(const QString &message);
+        void authenticationPrompt(const QString &message, bool promptVisible);
         void hostNameChanged(const QString &hostName);
         void canPowerOffChanged(bool canPowerOff);
         void canRebootChanged(bool canReboot);

--- a/src/greeter/GreeterProxy.h
+++ b/src/greeter/GreeterProxy.h
@@ -64,6 +64,7 @@ namespace SDDM {
 
         void login(const QString &user, const QString &password, const int sessionIndex) const;
         void beginAuthentication(const QString &user, const int sessionIndex) const;
+        void setSession(const int sessionIndex) const;
         void cancelAuthentication() const;
         void respond(const QString &response) const;
 

--- a/src/greeter/theme/Main.qml
+++ b/src/greeter/theme/Main.qml
@@ -35,6 +35,46 @@ Rectangle {
     LayoutMirroring.childrenInherit: true
 
     property int sessionIndex: session.index
+    property bool pamConversationActive: false
+    property string pamConversationUser: ""
+    property bool pamResponsePending: false
+    property string pamPendingResponse: ""
+
+    function beginPamAuthentication(username) {
+        if (!username)
+            return
+
+        if (pamConversationActive && pamConversationUser === username)
+            return
+
+        if (pamConversationActive)
+            sddm.cancelAuthentication()
+
+        pamConversationActive = true
+        pamConversationUser = username
+        pamResponsePending = false
+        pamPendingResponse = ""
+        txtMessage.text = ""
+        if (listView.currentItem)
+            listView.currentItem.password = ""
+        sddm.beginAuthentication(username, sessionIndex)
+    }
+
+    function submitPamResponse(username, response) {
+        if (!username)
+            return
+
+        if (!pamConversationActive || pamConversationUser !== username) {
+            beginPamAuthentication(username)
+            pamPendingResponse = response
+            pamResponsePending = true
+            return
+        }
+
+        sddm.respond(response)
+        if (listView.currentItem)
+            listView.currentItem.password = ""
+    }
 
     TextConstants { id: textConstants }
 
@@ -45,7 +85,28 @@ Rectangle {
 
         function onLoginFailed() {
             txtMessage.text = textConstants.loginFailed
-            listView.currentItem.password = ""
+            if (listView.currentItem)
+                listView.currentItem.password = ""
+            pamConversationActive = false
+            pamConversationUser = ""
+            pamResponsePending = false
+            pamPendingResponse = ""
+        }
+
+        function onAuthenticationPrompt(message, promptVisible) {
+            txtMessage.text = message
+            if (listView.currentItem) {
+                listView.currentItem.showPassword = true
+                listView.currentItem.password = ""
+                listView.currentItem.forceActiveFocus()
+            }
+
+            if (pamResponsePending) {
+                var response = pamPendingResponse
+                pamResponsePending = false
+                pamPendingResponse = ""
+                sddm.respond(response)
+            }
         }
 
         function onInformationMessage(message) {
@@ -55,11 +116,12 @@ Rectangle {
 
     Background {
         anchors.fill: parent
-        source: "qrc:///theme/background.png"
+        source: Qt.resolvedUrl(config.background)
         fillMode: Image.PreserveAspectCrop
         onStatusChanged: {
-            if (status == Image.Error && source != config.defaultBackground) {
-                source = config.defaultBackground
+            var defaultBackground = Qt.resolvedUrl(config.defaultBackground)
+            if (status == Image.Error && source != defaultBackground) {
+                source = defaultBackground
             }
         }
 
@@ -81,6 +143,7 @@ Rectangle {
 
             PictureBox {
                 anchors.verticalCenter: parent.verticalCenter
+                property string userName: model.name
                 name: (model.realName === "") ? model.name : model.realName
                 icon: model.icon
                 showPassword: model.needsPassword
@@ -88,13 +151,14 @@ Rectangle {
                 focus: (listView.currentIndex === index) ? true : false
                 state: (listView.currentIndex === index) ? "active" : ""
 
-                onLogin: sddm.login(model.name, password, sessionIndex);
+                onLogin: container.submitPamResponse(userName, password);
 
                 MouseArea {
                     anchors.fill: parent
                     onClicked: {
                         listView.currentIndex = index;
                         listView.focus = true;
+                        container.beginPamAuthentication(model.name);
                     }
                 }
             }
@@ -153,6 +217,11 @@ Rectangle {
                         delegate: userDelegate
                         orientation: ListView.Horizontal
                         currentIndex: userModel.lastIndex
+
+                        onCurrentItemChanged: {
+                            if (currentItem)
+                                container.beginPamAuthentication(currentItem.userName)
+                        }
 
                         KeyNavigation.backtab: prevUser; KeyNavigation.tab: nextUser
                     }

--- a/src/greeter/theme/Main.qml
+++ b/src/greeter/theme/Main.qml
@@ -295,6 +295,10 @@ Rectangle {
 
                     model: sessionModel
                     index: sessionModel.lastIndex
+                    onIndexChanged: {
+                        if (pamConversationActive)
+                            sddm.setSession(index)
+                    }
 
                     font.pixelSize: 14
 

--- a/src/helper/HelperApp.cpp
+++ b/src/helper/HelperApp.cpp
@@ -234,8 +234,15 @@ namespace SDDM {
         str.send();
         if (user.isEmpty())
             return env;
+        QString sessionPath;
+        QString displayServerCommand;
         str.receive();
-        str >> m >> env >> m_cookie;
+        str >> m >> env >> m_cookie >> sessionPath >> displayServerCommand;
+        if (m == AUTHENTICATED) {
+            m_session->setPath(sessionPath);
+            m_session->setDisplayServerCommand(displayServerCommand);
+            m_backend->setDisplayServer(!displayServerCommand.isEmpty());
+        }
         if (m != AUTHENTICATED) {
             env = QProcessEnvironment();
             m_cookie = {};


### PR DESCRIPTION
Handle PAM prompts and informational messages separately so that authentication stacks using multiple prompts can clearly indicate which input is currently expected.

This improves support for multi-step PAM authentication and allows PAM_TEXT_INFO messages to be presented to the user without interfering with secret prompts.