### PR TITLE
Greeter: Always try to load last user data

### DIFF
--- a/src/greeter/UserModel.cpp
+++ b/src/greeter/UserModel.cpp
@@ -108,16 +108,14 @@ namespace SDDM {
             }
         }
 
-        // Always try to add the last user if not already found.
-        if (!lastUserFound) {
-            struct passwd *lastUserData;
-            if(!lastUserFound && (lastUserData = getpwnam(qPrintable(lastUser())))) {
-                d->users << UserPtr(new User(lastUserData, iconURI));
-                lastUserFound = true;
-            }
-        }
-
         endpwent();
+
+        // Always try to add the last user if not already found
+        if (!lastUser().isEmpty() && !lastUserFound) {
+            struct passwd *lastUserData;
+            if((lastUserData = getpwnam(qPrintable(lastUser()))))
+                d->users << UserPtr(new User(lastUserData, iconURI));
+        }
 
         // sort users by username
         std::sort(d->users.begin(), d->users.end(), [&](const UserPtr &u1, const UserPtr &u2) { return u1->name < u2->name; });

--- a/src/greeter/UserModel.cpp
+++ b/src/greeter/UserModel.cpp
@@ -103,13 +103,17 @@ namespace SDDM {
                 lastUserFound = true;
 
             if (!needAllUsers && d->users.count() > mainConfig.Theme.DisableAvatarsThreshold.get()) {
-                struct passwd *lastUserData;
-                // If the theme doesn't require that all users are present, try to add the data for lastUser at least
-                if(!lastUserFound && (lastUserData = getpwnam(qPrintable(lastUser()))))
-                    d->users << UserPtr(new User(lastUserData, themeDefaultFace));
-
                 d->containsAllUsers = false;
                 break;
+            }
+        }
+
+        // Always try to add the last user if not already found.
+        if (!lastUserFound) {
+            struct passwd *lastUserData;
+            if(!lastUserFound && (lastUserData = getpwnam(qPrintable(lastUser())))) {
+                d->users << UserPtr(new User(lastUserData, iconURI));
+                lastUserFound = true;
             }
         }
 


### PR DESCRIPTION
When using SSSD the last username is remembered, but the user cannot be found when using a recent version (as enumeration has been disabled by default and a re-compile would be necessary) and so the remember function does not work as expected in such a scenario.

To overcome that limitation, I changed the code to always try to load the remembered user data. Under very specific conditions, this could also happen previously, but the solutions is a bit more generalized.

This PR fixes bug #1418
See also: #826 